### PR TITLE
[codex] Merge RBAC session auth, performance, and docs updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,47 @@
 # --- KiCAD Prism Root Environment Variables ---
 # Use this file as a template for your own .env file at the project root.
+# These variables are consumed by docker-compose and passed into backend/frontend.
 
 # ===========================================
-# Authentication (Google OAuth)
+# Authentication (Google OAuth + RBAC)
 # ===========================================
 # Friendly workspace display name shown on the login page
 WORKSPACE_NAME=KiCAD Prism
 
-# Set to 'false' to disable authentication entirely (Public Gallery Mode)
+# Set to false to disable authentication entirely (guest viewer mode)
 AUTH_ENABLED=true
 
-# Your Google OAuth Client ID from Google Cloud Console
+# Required when AUTH_ENABLED=true and DEV_MODE=false
 GOOGLE_CLIENT_ID=
 
-# Comma-separated list of allowed email domains (e.g., "company.com,org.net")
+# Optional allowlist filters (leave empty to rely only on RBAC role assignments)
+ALLOWED_USERS_STR=
 ALLOWED_DOMAINS_STR=
 
-# Comma-separated list of specific allowed user emails
-ALLOWED_USERS_STR=
+# Bootstrap admins (comma-separated Google account emails)
+BOOTSTRAP_ADMIN_USERS_STR=admin@example.com
+
+# Path override for role store file (optional)
+# Defaults to <KICAD_PROJECTS_ROOT>/.rbac_roles.json
+ROLE_STORE_PATH=
+
+# Required: session signing secret for HttpOnly auth cookie
+SESSION_SECRET=change-me-to-a-long-random-secret
+
+# Session lifetime in hours
+SESSION_TTL_HOURS=12
+
+# Set true only behind HTTPS
+SESSION_COOKIE_SECURE=false
 
 # ===========================================
-# Git & Private Repository Access
+# Git & Repository Access
 # ===========================================
-# Optional: Provide a GitHub Personal Access Token (classic) with 'repo' scope
-# This enables the UI to Import, Sync, and Push to private/organizational repos.
+# Optional: GitHub PAT for private repository import/sync
 GITHUB_TOKEN=
 
 # ===========================================
-# System Settings
+# Runtime / Development
 # ===========================================
-# Set to 'false' for production (disables auth bypass buttons)
+# Keep false for normal auth behavior
 DEV_MODE=false

--- a/README.md
+++ b/README.md
@@ -1,31 +1,30 @@
 # KiCAD Prism
 
-KiCAD Prism is a modern, high-performance web-based platform designed for visualizing, reviewing, and managing KiCAD projects. It bridges the gap between desktop EDA and collaborative web-native engineering by providing real-time design exploration, threaded design reviews, and automated manufacturing workflows.
+KiCAD Prism is a web platform for browsing, reviewing, and operating on KiCad repositories from the browser. It combines a FastAPI backend, a React/Vite frontend, repository import/sync flows, RBAC-based access control, comments export helpers, and manufacturing/documentation workflows in one workspace.
 
 ![KiCAD Prism Home Page](assets/KiCAD-Prism-Home-Page.png)
 
----
+## Core Capabilities
 
-## Key Features
+### Workspace and Repository Management
 
-### Modern Workspace Management
-
-Manage all your KiCAD repositories in a unified dashboard. Import projects directly from GitHub or GitLab via async jobs with real-time status tracking and detailed logs. Analysis is optimized using blobless, no-checkout clones for near-instant repository scanning. Supports both GitHub Tokens and SSH keys for private repository access.
+- Import standalone KiCad repositories or monorepos that contain multiple boards.
+- Sync repositories from their remotes without leaving the UI.
+- Organize projects into folders with RBAC-aware visibility.
+- Search projects by name, display name, description, and parent repo.
 
 <p align="center">
   <img src="assets/KiCAD-Prism-Workspace.png" width="49%" alt="Workspace Overview">
   <img src="assets/KiCAD-Prism-Importing-Repo.png" width="49%" alt="Importing Repositories">
 </p>
 
-*Unified dashboard with repository management and GitHub import flow.*
+### Project Exploration
 
-### The Visualizer Suite
-
-A comprehensive design explorer that renders schematics and PCBs natively in the browser. Powered by [ecad-viewer](https://github.com/Huaqiu-Electronics/ecad-viewer) and [KiCanvas](https://kicanvas.org), KiCAD Prism provides high-fidelity, interactive exploration of your electronics design files.
-
-- **Schematic & PCB**: Native rendering with cross-probing.
-- **3D Visualization**: Real-time 3D model viewing with adjustable Scene Brightness and Directionality.
-- **Interactive BOM**: Integrated [Interactive HTML BOM](https://github.com/quindorian/Sublime-iBOM-Plugin) suite for assembly and review.
+- Native schematic and PCB viewing in the browser.
+- 3D board viewing and Interactive HTML BOM integration.
+- Markdown README and project docs browsing.
+- Design outputs and manufacturing outputs browsing and download.
+- Project history, releases, and visual diff support.
 
 <p align="center">
   <img src="assets/KiCAD-Prism-Visualizer-SCH.png" width="49%" alt="Schematic Viewer">
@@ -37,226 +36,151 @@ A comprehensive design explorer that renders schematics and PCBs natively in the
   <img src="assets/KiCAD-Prism-Visualizer-ibom.png" width="49%" alt="Interactive BOM">
 </p>
 
-*High-fidelity schematic exploration.*
+### Review and Collaboration
 
-### Collaborative Design Reviews
-
-Move away from disjointed feedback. Add contextual comments directly on design elements. Comments can be replied to, resolved, and are visualised as pins in the design overlay.
+- Comments are stored in SQLite for live collaboration.
+- `.comments/comments.json` can be exported for repository-based workflows.
+- Per-project helper URLs are exposed to configure KiCad REST comment sources.
+- Role-based access control separates viewer, designer, and admin permissions.
 
 <p align="center">
   <img src="assets/KiCAD-Prism-Commenting-Mode.png" width="49%" alt="Commenting Mode">
   <img src="assets/KiCAD-Prism-Comment-Dialog.png" width="49%" alt="Comment Dialog">
 </p>
 
-After a comment is added by the user, the comment is stored in a JSON file at `./comments/comments.json` inside the repository and a pin is placed on the schematic at the location where the comment was added. The pin is visible in the schematic viewer and can be clicked to view the comment.  
-In the Comments Panel, the user can view all the comments and replies in a threaded manner. The user can also reply to a comment and the reply will be stored in the JSON file and can be viewed in the schematic viewer. Clicking on an entry in the comments panel will zoom into the schematic/PCB at the location where the comment was added.
+### Workflow Automation
 
-<p align="center">
-  <img src="assets/KiCAD-Prism-Comments-Panel-Reply.png" width="49%" alt="Comments Panel & Replies">
-  <img src="assets/KiCAD-Prism-Comment-JSON.png" width="49%" alt="Comment JSON">
-</p>
-
-Pressing the Push Comments button will push the latest files in the backend to the remote repository with a commit message.
-
-> Native parsing of comments.json and display of comments in KiCAD is currently NOT available
-Please upvote [this](https://gitlab.com/kicad/code/kicad/-/issues/22918) feature request on Gitlab for a comments panel in KiCAD!
-
-*Threaded design reviews with spatial context.*
-
-### Visual Diff & Design Comparison
-
-Track design changes across commits with native support for Schematics, PCBs, and Bill of Materials. Powered by `kicad-cli`, KiCAD Prism generates visual and structural diffs that highlight exactly what was added, removed, or modified.
-
-- **Visual Comparison**: Toggle between schematic sheets or PCB layers with an opacity-controlled overlay to spot subtle layout shifts.
-- **Asymmetric BoM Diff**: Compare component lists across commits with status-based filtering (Added/Removed/Changed) and support for custom project-level fields via `.prism.json`.
-
-<p align="center">
-  <img src="assets/Visual-Diff-GIF.gif" width="49%" alt="Schematic Visual Diff">
-  <img src="assets/Visual-Diff-PCB-GIF.gif" width="49%" alt="PCB Visual Diff">
-</p>
-
-<p align="center">
-  <img src="assets/Visual-Diff-BoM.gif" width="80%" alt="BoM Structural Diff">
-</p>
-
-*Visual and structural diffing of design and manufacturing data.*
-
-### Integrated Documentation & Assets
-
-Explore design and manufacturing outputs through a specialized assets portal. View project specifications and logs with native markdown support and embedded image handling.
-
-![Assets Portal](assets/KiCAD-Prism-Assets-Portal.png)
-![Markdown Support](assets/KiCAD-Prism-Markdown-Support.png)
-![Documentation Browser](assets/KiCAD-Prism-Documentation.png)
-*Native documentation browsing and asset management.*
-
-### Automated Workflows
-
-Trigger `kicad-cli` powered jobs directly from the browser to generate the latest PDFs, Interactive BOMs, and Ray-Traced renders.
-
-**Customizable Workflows**: Users can add or modify whatever workflows they want by defining new scripts or modifying the existing ones in this project. Results are automatically committed and pushed back to the remote repository if configured.
+- Trigger KiCad workflow jobs from the UI.
+- Generate design, manufacturing, and render outputs.
+- Browse generated artifacts from the project detail page.
 
 ![Workflow Management](assets/KiCAD-Prism-Workflows.png)
 
----
+## Architecture
 
-## Tech Stack
+- Frontend: React, TypeScript, Vite, Tailwind, shadcn/ui
+- Backend: FastAPI, GitPython, Pydantic Settings
+- Storage:
+  - imported repositories under `data/projects`
+  - SSH material under `data/ssh`
+  - role assignments in `.rbac_roles.json`
+  - folder metadata in `.folders.json`
+  - comments in SQLite plus optional `.comments/comments.json` export
+- Runtime split:
+  - Docker frontend serves the production bundle on port `8080`
+  - backend API serves on port `8000`
 
-- **Frontend**: React, Vite, Tailwind CSS, ShadCN UI, Lucide Icons.
-- **Backend**: FastAPI (Python 3.10+), GitPython.
-- **Tools**: `kicad-cli` (v9.0+).
-- **Visualization Core**:
-  - [ecad-viewer](https://github.com/Huaqiu-Electronics/ecad-viewer)
-  - [KiCanvas](https://github.com/thevoidinn/KiCanvas)
-  - [Interactive HTML BOM](https://github.com/quindorian/Sublime-iBOM-Plugin)
-  - [Three.js](https://threejs.org/)
+## Quick Start
 
----
-
-## Getting Started
-
-For detailed installation and server setup, see [DEPLOYMENT.md](./DEPLOYMENT.md).  
-For the expected structure of imported KiCAD projects, see [KICAD-PRJ-REPO-STRUCTURE.md](./KICAD-PRJ-REPO-STRUCTURE.md).
-
-### Quick Start with Docker (Recommended)
-
-The easiest way to run KiCAD Prism is with Docker. This works on any machine with Docker installed.
+### Docker
 
 ```bash
-# Clone the repository
 git clone https://github.com/krishna-swaroop/KiCAD-Prism.git
 cd KiCAD-Prism
-
-# Start the application (no authentication)
-AUTH_ENABLED=false docker compose up -d --build
-
-# OR: Start with Google OAuth + RBAC session auth
-GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com SESSION_SECRET=change-me docker compose up -d
-
-# Access the UI at http://localhost
+cp .env.example .env
 ```
 
-#### Persistence & Data
+Guest mode:
 
-By default, the Docker setup creates a `./data` folder in the project root:
-
-- `./data/projects`: This is where your KiCAD projects are stored and managed.
-- Files here will persist across `docker compose down` or container updates.
-
-#### Switching Authentication
-
-Authentication is enabled by default in the Docker image but requires a `GOOGLE_CLIENT_ID`.
-
-- **To Disable**: Set `AUTH_ENABLED=false` in your `.env`.
-- **To Enable**: Set `GOOGLE_CLIENT_ID=...` and ensure `AUTH_ENABLED=true` (the default).
-
-To stop: `docker compose down`
-
-#### Setting Up Google OAuth for Docker
-
-1. Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
-2. Create or select a project
-3. Create an **OAuth 2.0 Client ID** (Web application type)
-4. Add these **Authorized JavaScript Origins**:
-   - `http://localhost`
-   - `http://localhost:80`
-   - `http://127.0.0.1`
-5. Copy the Client ID and pass it to Docker:
-
-```bash
-# Create a .env file for convenience
-echo "GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com" > .env
-echo "AUTH_ENABLED=true" >> .env
-echo "SESSION_SECRET=change-me-to-a-long-random-secret" >> .env
-echo "BOOTSTRAP_ADMIN_USERS_STR=admin@yourcompany.com" >> .env
-
-# Docker Compose automatically reads .env
-docker compose up -d
+```env
+AUTH_ENABLED=false
 ```
 
-### Quick Local Dev Setup
+Google login + RBAC session auth:
+
+```env
+AUTH_ENABLED=true
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+SESSION_SECRET=replace-with-a-long-random-secret
+BOOTSTRAP_ADMIN_USERS_STR=admin@example.com
+SESSION_COOKIE_SECURE=false
+```
+
+Start the stack:
 
 ```bash
-# 1. Backend Setup
+docker compose up --build -d
+```
+
+Open the UI at [http://127.0.0.1:8080](http://127.0.0.1:8080).
+
+Important:
+- `SESSION_SECRET` is required whenever auth is effectively enabled.
+- `SESSION_COOKIE_SECURE=true` should be used only behind HTTPS.
+- Docker Compose reads the root `.env` automatically.
+
+### Local Development
+
+Backend:
+
+```bash
 cd backend
-python3 -m venv venv && source venv/bin/activate
+python3 -m venv venv
+source venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload --port 8000
+```
 
-# 2. Frontend Setup (Separate Terminal)
+Frontend in a second terminal:
+
+```bash
 cd frontend
 npm install
 npm run dev
 ```
 
----
+Frontend dev server runs on [http://127.0.0.1:5173](http://127.0.0.1:5173).
 
-## Authentication & Access Control
+By default, local development usually runs without auth because `DEV_MODE=true` and no Google client ID is configured.
 
-KiCAD Prism supports Google Sign-in with role-based access control (RBAC) and optional allowlists.
+## Authentication Model
 
-| Mode | Behavior |
-|------|----------|
-| **Public Gallery** | No login required, projects are read-only. |
-| **Development** | Login shown with Dev Bypass button for local testing. |
-| **Production** | Full Google OAuth required with domain verification. |
+Current auth behavior is session-based:
+
+- frontend reads `/api/auth/config`
+- Google Sign-In exchanges an ID token with `/api/auth/login`
+- backend issues an `HttpOnly` signed session cookie
+- subsequent API calls resolve the current user and role from that cookie
 
 RBAC roles:
-- `viewer`: read-only project access
-- `designer`: project/folder/workflow/comment mutations
-- `admin`: full access + user role management and SSH settings
+- `viewer`: read-only access
+- `designer`: import, sync, comments, folder/project mutations, workflows
+- `admin`: full access, including settings and role management
 
-See [DEPLOYMENT.md](./DEPLOYMENT.md#authentication-setup) for configuration details.
+Auth is effectively enabled only when all of the following are true:
+- `AUTH_ENABLED=true`
+- `GOOGLE_CLIENT_ID` is set
+- `DEV_MODE=false`
 
----
+## Project Documentation
 
-## Project Structure
+- Deployment and hosting: [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md)
+- Repository layout expectations: [docs/KICAD-PRJ-REPO-STRUCTURE.md](./docs/KICAD-PRJ-REPO-STRUCTURE.md)
+- Path mapping and `.prism.json`: [docs/PATH-MAPPING.md](./docs/PATH-MAPPING.md)
+- Display names and project metadata: [docs/CUSTOM_PROJECT_NAMES.md](./docs/CUSTOM_PROJECT_NAMES.md)
+- Comments export and REST helpers: [docs/COMMENTS-COLLAB-UPDATES.md](./docs/COMMENTS-COLLAB-UPDATES.md)
+- Workspace behavior notes: [docs/WORKSPACE_UX_IMPROVEMENTS.md](./docs/WORKSPACE_UX_IMPROVEMENTS.md)
+- Visualizer vendor sync notes: [docs/ECAD_VIEWER_SYNC_NOTES.md](./docs/ECAD_VIEWER_SYNC_NOTES.md)
+
+## Repository Layout
 
 ```text
 KiCAD-Prism/
 ├── backend/            # FastAPI backend
-│   ├── app/            # API & Service Layer
-│   └── requirements.txt
 ├── frontend/           # React frontend
-│   ├── src/            # Components, Hooks, Views
-│   └── package.json
-└── assets/             # Branding & Showcase media
+├── docs/               # Project documentation
+├── assets/             # Screenshots and media for docs
+└── data/               # Runtime data in local/Docker use
 ```
-
----
-
-## Roadmap
-
-- [x] High-performance Schematic & PCB Viewers
-- [x] Collaborative Threaded Design Review
-- [x] Automated Workflow Generation
-- [x] Visual Git Diff (Native kicad-cli integration)
-- [x] Fix page transition logic completely
-- [x] Refine Workspace UI and handle non-GitHub Imports better
-- [ ] Fix ecad-viewer bugs for small projects
-- [ ] KiCAD Plugin/source code edits to overlay comments on the schematic and PCB editors
-- [ ] User Permissions & Role-Based Access
-- [ ] Real-time Collaboration (WebSockets)
-- [ ] Inventree/PartDB Integration
-
----
 
 ## Acknowledgements
 
-Built with care for the open-source hardware community. Special thanks to the teams behind:
-
-- [ecad-viewer](https://github.com/Huaqiu-Electronics/ecad-viewer) for the core visualization engine.
-- [KiCanvas](https://kicanvas.org) for native schematic rendering.
-- [Interactive HTML BOM](https://github.com/quindorian/Sublime-iBOM-Plugin) for the assembly suite.
-- [Three.js](https://threejs.org/) for the 3D model viewer.
-- [FastAPI](https://fastapi.tiangolo.com/) for the high-performance backend.
-
----
+- [ecad-viewer](https://github.com/Huaqiu-Electronics/ecad-viewer)
+- [KiCanvas](https://kicanvas.org)
+- [Interactive HTML BOM](https://github.com/quindorian/Sublime-iBOM-Plugin)
+- [Three.js](https://threejs.org/)
+- [FastAPI](https://fastapi.tiangolo.com/)
 
 ## License
 
 This project is licensed under the Apache-2.0 License.
-
-## Contributing
-
-Most of the components have been vibe-coded to prove that the project is capable of being developed and is useful for teams working on KiCAD projects. I would love to see actual Typescript devs contribute to this project and make it production ready.

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ cd KiCAD-Prism
 # Start the application (no authentication)
 AUTH_ENABLED=false docker compose up -d --build
 
-# OR: Start with Google OAuth
-GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com docker compose up -d
+# OR: Start with Google OAuth + RBAC session auth
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com SESSION_SECRET=change-me docker compose up -d
 
 # Access the UI at http://localhost
 ```
@@ -167,6 +167,8 @@ To stop: `docker compose down`
 # Create a .env file for convenience
 echo "GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com" > .env
 echo "AUTH_ENABLED=true" >> .env
+echo "SESSION_SECRET=change-me-to-a-long-random-secret" >> .env
+echo "BOOTSTRAP_ADMIN_USERS_STR=admin@yourcompany.com" >> .env
 
 # Docker Compose automatically reads .env
 docker compose up -d
@@ -191,13 +193,18 @@ npm run dev
 
 ## Authentication & Access Control
 
-KiCAD Prism supports Google Sign-in with domain-level restrictions for enterprise security.
+KiCAD Prism supports Google Sign-in with role-based access control (RBAC) and optional allowlists.
 
 | Mode | Behavior |
 |------|----------|
 | **Public Gallery** | No login required, projects are read-only. |
 | **Development** | Login shown with Dev Bypass button for local testing. |
 | **Production** | Full Google OAuth required with domain verification. |
+
+RBAC roles:
+- `viewer`: read-only project access
+- `designer`: project/folder/workflow/comment mutations
+- `admin`: full access + user role management and SSH settings
 
 See [DEPLOYMENT.md](./DEPLOYMENT.md#authentication-setup) for configuration details.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,24 +2,44 @@
 # Copy this file to .env and customize for your environment
 
 # ===========================================
-# Google OAuth Configuration
+# Google OAuth + RBAC Configuration
 # ===========================================
 # Friendly workspace display name shown on the login page
 WORKSPACE_NAME=KiCAD Prism
 
 # Get your Client ID from Google Cloud Console:
 # https://console.cloud.google.com/apis/credentials
-#
-# Leave empty to disable authentication (users go directly to gallery)
 GOOGLE_CLIENT_ID=
 
-# Allowed email domains (comma-separated)
-# Users signing in must have an email from one of these domains
-ALLOWED_DOMAINS_STR=pixxel.co.in,spacepixxel.in
+# Set false to disable authentication entirely
+AUTH_ENABLED=true
+
+# Optional allowlist filters. Leave empty to rely only on RBAC role assignments.
+ALLOWED_USERS_STR=
+ALLOWED_DOMAINS_STR=
+
+# Bootstrap admin emails (comma-separated)
+BOOTSTRAP_ADMIN_USERS_STR=admin@example.com
+
+# Role store file path (optional override; defaults to <projects_root>/.rbac_roles.json)
+ROLE_STORE_PATH=
+
+# Session signing secret (required when AUTH_ENABLED=true and DEV_MODE=false)
+SESSION_SECRET=change-me-to-a-long-random-secret
+
+# Session lifetime in hours
+SESSION_TTL_HOURS=12
+
+# Set to true only when serving over HTTPS
+SESSION_COOKIE_SECURE=false
 
 # ===========================================
 # Development Settings
 # ===========================================
-# Set to True to enable development mode
-# When True AND GOOGLE_CLIENT_ID is empty, authentication is bypassed
-DEV_MODE=True
+# Keep false for normal authentication flow
+DEV_MODE=false
+
+# ===========================================
+# Optional Git Access
+# ===========================================
+GITHUB_TOKEN=

--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 from fastapi import HTTPException
 
-from app.services import project_service
+from app.core.roles import Role
+from app.services import folder_service, project_service
 
 
 VALID_OUTPUT_TYPES = {"design", "manufacturing"}
@@ -11,6 +12,13 @@ VALID_OUTPUT_TYPES = {"design", "manufacturing"}
 def get_project_or_404(project_id: str) -> project_service.Project:
     project = project_service.get_project_by_id(project_id)
     if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+def get_project_for_role_or_404(project_id: str, role: Role) -> project_service.Project:
+    project = get_project_or_404(project_id)
+    if not folder_service.is_folder_visible_to_role(project.folder_id, role):
         raise HTTPException(status_code=404, detail="Project not found")
     return project
 
@@ -32,4 +40,3 @@ def resolve_path_within_root(root: str, relative_path: str, *, invalid_detail: s
         raise HTTPException(status_code=400, detail=invalid_detail) from error
 
     return target_path
-

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -5,11 +5,15 @@ Handles Google OAuth login and domain validation.
 """
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
 from google.oauth2 import id_token
 from google.auth.transport import requests
 from app.core.config import settings
+from app.core.roles import Role
+from app.core.security import AuthenticatedUser, get_current_user, guest_user
+from app.core.session import clear_session_cookie, create_session_token, set_session_cookie
+from app.services import access_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -25,6 +29,7 @@ class UserSession(BaseModel):
     email: str
     name: str
     picture: str = ""
+    role: Role
 
 
 class AuthConfig(BaseModel):
@@ -36,19 +41,35 @@ class AuthConfig(BaseModel):
 
 
 def _guest_user_session() -> UserSession:
-    return UserSession(email="guest@local", name="Guest User", picture="")
+    guest = guest_user()
+    return UserSession(email=guest.email, name=guest.name, picture=guest.picture, role=guest.role)
 
 
 def _validate_allowed_user(email: str) -> None:
-    if not settings.ALLOWED_USERS:
-        return
+    normalized_email = email.strip().casefold()
+    if not normalized_email:
+        raise HTTPException(status_code=401, detail="Invalid token")
 
     allowed_users = {user.strip().casefold() for user in settings.ALLOWED_USERS if user.strip()}
-    if email.casefold() not in allowed_users:
+    if allowed_users and normalized_email not in allowed_users:
         raise HTTPException(
             status_code=403,
             detail="Access denied. Your email is not in the allowed users list.",
         )
+
+    allowed_domains = {domain.strip().casefold() for domain in settings.ALLOWED_DOMAINS if domain.strip()}
+    if allowed_domains:
+        domain = normalized_email.split("@")[-1]
+        if domain not in allowed_domains:
+            raise HTTPException(
+                status_code=403,
+                detail="Access denied. Your email domain is not in the allowed domains list.",
+            )
+
+
+def _require_session_secret() -> None:
+    if settings.AUTH_ENABLED and not settings.SESSION_SECRET:
+        raise HTTPException(status_code=500, detail="SESSION_SECRET is not configured")
 
 
 @router.get("/config", response_model=AuthConfig)
@@ -68,7 +89,7 @@ async def get_auth_config():
 
 
 @router.post("/login", response_model=UserSession)
-async def login(request: TokenRequest):
+async def login(request: TokenRequest, response: Response):
     """
     Authenticate user with Google OAuth token.
     
@@ -78,6 +99,8 @@ async def login(request: TokenRequest):
     # but handle gracefully just in case
     if not settings.AUTH_ENABLED:
         return _guest_user_session()
+
+    _require_session_secret()
     
     try:
         # Verify the token with Google
@@ -92,11 +115,29 @@ async def login(request: TokenRequest):
             raise HTTPException(status_code=401, detail="Invalid token")
 
         _validate_allowed_user(email)
+        role = access_service.resolve_user_role(email)
+        if not role:
+            raise HTTPException(
+                status_code=403,
+                detail="Access denied. No role assignment found for your account.",
+            )
+
+        name = id_info.get("name", email.split("@")[0])
+        picture = id_info.get("picture", "")
+
+        token = create_session_token(
+            email=email,
+            name=name,
+            picture=picture,
+            role=role,
+        )
+        set_session_cookie(response, token)
 
         return UserSession(
             email=email,
-            name=id_info.get("name", email.split("@")[0]),
-            picture=id_info.get("picture", "")
+            name=name,
+            picture=picture,
+            role=role,
         )
 
     except ValueError:
@@ -109,3 +150,19 @@ async def login(request: TokenRequest):
         # Catch-all for unexpected errors
         logger.exception("Authentication error during Google OAuth login")
         raise HTTPException(status_code=500, detail="Authentication service unavailable")
+
+
+@router.get("/me", response_model=UserSession)
+async def get_current_session_user(user: AuthenticatedUser = Depends(get_current_user)):
+    return UserSession(
+        email=user.email,
+        name=user.name,
+        picture=user.picture,
+        role=user.role,
+    )
+
+
+@router.post("/logout")
+async def logout(response: Response):
+    clear_session_cookie(response)
+    return {"success": True}

--- a/backend/app/api/comments.py
+++ b/backend/app/api/comments.py
@@ -8,13 +8,14 @@ comments.json is generated from DB only during push/export workflows.
 import os
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from app.api._helpers import get_project_or_404
+from app.api._helpers import get_project_for_role_or_404
+from app.core.security import AuthenticatedUser, require_designer, require_viewer
 from app.services.comments_store_service import comments_store
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_viewer)])
 
 
 # ============================================================
@@ -94,20 +95,24 @@ def _normalize_content(content: str, *, field: str = "content") -> str:
 # ============================================================
 
 @router.get("/{project_id}/comments")
-async def get_comments(project_id: str):
+async def get_comments(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Get all comments for a project from DB snapshot.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     return comments_store.get_comments_file(project.id, project.path)
 
 
-@router.post("/{project_id}/comments")
-async def create_comment(project_id: str, request: CreateCommentRequest):
+@router.post("/{project_id}/comments", dependencies=[Depends(require_designer)])
+async def create_comment(
+    project_id: str,
+    request: CreateCommentRequest,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Create a new comment on the design.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     context = _normalize_context(request.context)
     content = _normalize_content(request.content)
@@ -122,12 +127,17 @@ async def create_comment(project_id: str, request: CreateCommentRequest):
     )
 
 
-@router.patch("/{project_id}/comments/{comment_id}")
-async def update_comment(project_id: str, comment_id: str, request: UpdateCommentRequest):
+@router.patch("/{project_id}/comments/{comment_id}", dependencies=[Depends(require_designer)])
+async def update_comment(
+    project_id: str,
+    comment_id: str,
+    request: UpdateCommentRequest,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Update a comment's status (e.g., resolve it).
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     if request.status is None:
         raise HTTPException(status_code=400, detail="No update fields provided")
@@ -149,12 +159,17 @@ async def update_comment(project_id: str, comment_id: str, request: UpdateCommen
     return updated_comment
 
 
-@router.post("/{project_id}/comments/{comment_id}/replies")
-async def add_reply(project_id: str, comment_id: str, request: CreateReplyRequest):
+@router.post("/{project_id}/comments/{comment_id}/replies", dependencies=[Depends(require_designer)])
+async def add_reply(
+    project_id: str,
+    comment_id: str,
+    request: CreateReplyRequest,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Add a reply to an existing comment.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     result = comments_store.add_reply(
         project_id=project.id,
@@ -171,12 +186,16 @@ async def add_reply(project_id: str, comment_id: str, request: CreateReplyReques
     return {"comment": comment, "reply": reply}
 
 
-@router.delete("/{project_id}/comments/{comment_id}")
-async def delete_comment(project_id: str, comment_id: str):
+@router.delete("/{project_id}/comments/{comment_id}", dependencies=[Depends(require_designer)])
+async def delete_comment(
+    project_id: str,
+    comment_id: str,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Delete a comment.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     deleted = comments_store.delete_comment(
         project_id=project.id,
@@ -194,13 +213,13 @@ async def delete_comment(project_id: str, comment_id: str):
 # EXPORT ENDPOINT
 # ============================================================
 
-@router.post("/{project_id}/comments/push")
-async def push_comments(project_id: str):
+@router.post("/{project_id}/comments/push", dependencies=[Depends(require_designer)])
+async def push_comments(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Export DB snapshot to comments.json artifact only.
     Git commit/push is intentionally left to the user workflow.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     try:
         comments_path = comments_store.export_comments_json(project.id, project.path)

--- a/backend/app/api/diff.py
+++ b/backend/app/api/diff.py
@@ -2,22 +2,27 @@
 Diff API Routes (Native)
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
-from app.api._helpers import get_project_or_404
+from app.api._helpers import get_project_for_role_or_404
+from app.core.security import AuthenticatedUser, require_designer, require_viewer
 from app.services import diff_service
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_viewer)])
 
 class DiffRequest(BaseModel):
     commit1: str
     commit2: str
 
-@router.post("/{project_id}/diff")
-async def start_diff(project_id: str, request: DiffRequest):
+@router.post("/{project_id}/diff", dependencies=[Depends(require_designer)])
+async def start_diff(
+    project_id: str,
+    request: DiffRequest,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """Start a visual diff job."""
-    get_project_or_404(project_id)
+    get_project_for_role_or_404(project_id, user.role)
     try:
         job_id = diff_service.start_diff_job(project_id, request.commit1, request.commit2)
         return {"job_id": job_id}
@@ -27,32 +32,32 @@ async def start_diff(project_id: str, request: DiffRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/{project_id}/diff/{job_id}/status")
-async def get_status(project_id: str, job_id: str):
-    get_project_or_404(project_id)
+async def get_status(project_id: str, job_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    get_project_for_role_or_404(project_id, user.role)
     status = diff_service.get_job_status(job_id)
     if not status:
         raise HTTPException(status_code=404, detail="Job not found")
     return status
 
 @router.get("/{project_id}/diff/{job_id}/manifest")
-async def get_manifest(project_id: str, job_id: str):
-    get_project_or_404(project_id)
+async def get_manifest(project_id: str, job_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    get_project_for_role_or_404(project_id, user.role)
     manifest = diff_service.get_manifest(job_id)
     if not manifest:
         raise HTTPException(status_code=404, detail="Manifest not found or job not complete")
     return manifest
 
 @router.get("/{project_id}/diff/{job_id}/assets/{path:path}")
-async def get_asset(project_id: str, job_id: str, path: str):
-    get_project_or_404(project_id)
+async def get_asset(project_id: str, job_id: str, path: str, user: AuthenticatedUser = Depends(require_viewer)):
+    get_project_for_role_or_404(project_id, user.role)
     file_path = diff_service.get_asset_path(job_id, path)
     if not file_path:
         raise HTTPException(status_code=404, detail="Asset not found")
     return FileResponse(file_path)
 
-@router.delete("/{project_id}/diff/{job_id}")
-async def delete_job(project_id: str, job_id: str):
+@router.delete("/{project_id}/diff/{job_id}", dependencies=[Depends(require_designer)])
+async def delete_job(project_id: str, job_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """Explicitly clean up a job."""
-    get_project_or_404(project_id)
+    get_project_for_role_or_404(project_id, user.role)
     diff_service.delete_job(job_id)
     return {"status": "deleted"}

--- a/backend/app/api/folders.py
+++ b/backend/app/api/folders.py
@@ -1,11 +1,12 @@
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
+from app.core.security import AuthenticatedUser, require_designer, require_viewer
 from app.services import folder_service, project_service
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_viewer)])
 
 
 class FolderContentsResponse(BaseModel):
@@ -39,20 +40,23 @@ def _normalize_folder_name(name: str) -> str:
 
 
 @router.get("/tree", response_model=List[folder_service.FolderTreeItem])
-async def get_folder_tree():
-    return folder_service.get_folder_tree()
+async def get_folder_tree(user: AuthenticatedUser = Depends(require_viewer)):
+    return folder_service.get_folder_tree(user.role)
 
 
 @router.get("/contents", response_model=FolderContentsResponse)
-async def get_folder_contents(folder_id: Optional[str] = Query(default=None)):
+async def get_folder_contents(
+    folder_id: Optional[str] = Query(default=None),
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     try:
-        payload = folder_service.get_folder_contents(folder_id)
+        payload = folder_service.get_folder_contents(folder_id, user.role)
         return FolderContentsResponse(**payload)
     except ValueError as error:
         raise HTTPException(status_code=404, detail=str(error))
 
 
-@router.post("/", response_model=folder_service.Folder)
+@router.post("/", response_model=folder_service.Folder, dependencies=[Depends(require_designer)])
 async def create_folder(request: CreateFolderRequest):
     try:
         return folder_service.create_folder(
@@ -63,7 +67,7 @@ async def create_folder(request: CreateFolderRequest):
         raise HTTPException(status_code=400, detail=str(error))
 
 
-@router.patch("/{folder_id}", response_model=folder_service.Folder)
+@router.patch("/{folder_id}", response_model=folder_service.Folder, dependencies=[Depends(require_designer)])
 async def update_folder(folder_id: str, request: UpdateFolderRequest):
     field_set = request.model_fields_set
     if "name" not in field_set and "parent_id" not in field_set:
@@ -78,7 +82,7 @@ async def update_folder(folder_id: str, request: UpdateFolderRequest):
         raise HTTPException(status_code=_status_code_for_value_error(error), detail=str(error))
 
 
-@router.delete("/{folder_id}")
+@router.delete("/{folder_id}", dependencies=[Depends(require_designer)])
 async def delete_folder(folder_id: str, cascade: bool = Query(default=True)):
     try:
         deleted = folder_service.delete_folder(folder_id=folder_id, cascade=cascade)
@@ -91,7 +95,7 @@ async def delete_folder(folder_id: str, cascade: bool = Query(default=True)):
     return {"message": "Folder deleted successfully"}
 
 
-@router.post("/projects/{project_id}/move")
+@router.post("/projects/{project_id}/move", dependencies=[Depends(require_designer)])
 async def move_project_to_folder(project_id: str, request: MoveProjectRequest):
     try:
         folder_service.move_project_to_folder(project_id=project_id, folder_id=request.folder_id)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -3,12 +3,13 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
-from app.api._helpers import get_project_or_404, require_output_type, resolve_path_within_root
-from app.services import file_service, path_config_service, project_import_service, project_service
+from app.api._helpers import get_project_for_role_or_404, require_output_type, resolve_path_within_root
+from app.core.security import AuthenticatedUser, require_designer, require_viewer
+from app.services import file_service, folder_service, path_config_service, project_import_service, project_service
 from app.services.comments_url_service import build_comments_source_urls, resolve_comments_base_url
 from app.services.git_service import (
     get_commits_list,
@@ -20,7 +21,7 @@ from app.services.git_service import (
 )
 from app.services.path_config_service import PathConfig
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_viewer)])
 
 ARCHIVE_DIR_NAMES = {"archive", "archived", "old", "backup", "backups", "obsolete"}
 
@@ -87,20 +88,28 @@ def _read_file_from_commit(
 
     return get_file_from_commit_with_prefix(repo_path, commit, file_path, prefix)
 
+
+def _filter_projects_for_user(
+    projects: List[project_service.Project],
+    user: AuthenticatedUser,
+) -> List[project_service.Project]:
+    return folder_service.filter_projects_for_role(projects, user.role)
+
 @router.get("/", response_model=List[project_service.Project])
-async def list_projects():
+async def list_projects(user: AuthenticatedUser = Depends(require_viewer)):
     """Return all registered projects (both Type-1 and Type-2)."""
-    return project_service.get_registered_projects()
+    projects = project_service.get_registered_projects()
+    return _filter_projects_for_user(projects, user)
 
 @router.get("/monorepos", response_model=List[Monorepo])
-async def list_monorepos():
+async def list_monorepos(user: AuthenticatedUser = Depends(require_viewer)):
     """
     List all monorepos with their metadata.
     """
     monorepos = []
 
     if os.path.exists(project_service.MONOREPOS_ROOT):
-        all_projects = project_service.get_registered_projects()
+        all_projects = _filter_projects_for_user(project_service.get_registered_projects(), user)
         projects_by_repo: dict[str, list[project_service.Project]] = {}
         for project in all_projects:
             if project.parent_repo:
@@ -145,7 +154,11 @@ async def list_monorepos():
     return monorepos
 
 @router.get("/monorepos/{repo_name}/structure")
-async def get_monorepo_structure(repo_name: str, subpath: str = ""):
+async def get_monorepo_structure(
+    repo_name: str,
+    subpath: str = "",
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Get folder structure for a monorepo at a given subpath.
     Returns folders and projects at that level.
@@ -161,7 +174,7 @@ async def get_monorepo_structure(repo_name: str, subpath: str = ""):
     folders = []
     projects = []
     
-    all_registered = project_service.get_registered_projects()
+    all_registered = _filter_projects_for_user(project_service.get_registered_projects(), user)
     repo_projects = {p.sub_path: p for p in all_registered if p.parent_repo == repo_name}
     
     for item_path in current_path.iterdir():
@@ -212,6 +225,7 @@ async def get_monorepo_structure(repo_name: str, subpath: str = ""):
 async def search_projects(
     q: str = "",
     limit: int = Query(default=100, ge=1, le=500),
+    user: AuthenticatedUser = Depends(require_viewer),
 ):
     """
     Search across all projects (standalone and monorepo sub-projects).
@@ -221,7 +235,7 @@ async def search_projects(
     if not query:
         return {"results": []}
 
-    all_projects = project_service.get_registered_projects()
+    all_projects = _filter_projects_for_user(project_service.get_registered_projects(), user)
     
     results = []
     for project in all_projects:
@@ -250,7 +264,7 @@ class ImportRequest(BaseModel):
     import_type: str  # "type1" or "type2"
     selected_paths: Optional[List[str]] = None
 
-@router.post("/analyze")
+@router.post("/analyze", dependencies=[Depends(require_designer)])
 async def analyze_repository(request: AnalyzeRequest):
     """
     Analyze a repository to determine import type and discover KiCAD projects.
@@ -263,7 +277,7 @@ async def analyze_repository(request: AnalyzeRequest):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Analysis failed: {str(e)}")
 
-@router.post("/import")
+@router.post("/import", dependencies=[Depends(require_designer)])
 async def import_project(request: ImportRequest):
     """
     Start an async project import job.
@@ -292,13 +306,14 @@ async def get_job_status(job_id: str):
         raise HTTPException(status_code=404, detail="Job not found")
     return status
 
-@router.post("/{project_id}/sync")
-async def sync_project_endpoint(project_id: str):
+@router.post("/{project_id}/sync", dependencies=[Depends(require_designer)])
+async def sync_project_endpoint(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Sync project repository with remote.
     Type-1: pulls the project repo.
     Type-2: pulls the parent repo.
     """
+    _ = get_project_for_role_or_404(project_id, user.role)
     result = project_import_service.sync_project(project_id)
     
     if result["status"] == "error":
@@ -310,8 +325,12 @@ class WorkflowRequest(BaseModel):
     type: str # design, manufacturing, render
     author: Optional[str] = "anonymous"
 
-@router.post("/{project_id}/workflows")
-async def trigger_workflow(project_id: str, request: WorkflowRequest):
+@router.post("/{project_id}/workflows", dependencies=[Depends(require_designer)])
+async def trigger_workflow(
+    project_id: str,
+    request: WorkflowRequest,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Trigger a KiCAD workflow (jobset output).
     """
@@ -320,6 +339,7 @@ async def trigger_workflow(project_id: str, request: WorkflowRequest):
         raise HTTPException(status_code=400, detail="Invalid workflow type")
         
     try:
+        _ = get_project_for_role_or_404(project_id, user.role)
         job_id = project_service.start_workflow_job(project_id, request.type, request.author)
         return {"job_id": job_id}
     except ValueError as e:
@@ -328,16 +348,17 @@ async def trigger_workflow(project_id: str, request: WorkflowRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/{project_id}/thumbnail")
-async def get_project_thumbnail(project_id: str):
+async def get_project_thumbnail(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    _ = get_project_for_role_or_404(project_id, user.role)
     path = project_service.get_project_thumbnail_path(project_id)
     if not path:
         raise HTTPException(status_code=404, detail="Thumbnail not found")
     return FileResponse(path)
 
 @router.get("/{project_id}", response_model=project_service.Project)
-async def get_project_detail(project_id: str):
+async def get_project_detail(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """Get detailed project information."""
-    return get_project_or_404(project_id)
+    return get_project_for_role_or_404(project_id, user.role)
 
 
 @router.get("/{project_id}/comments/source-urls")
@@ -348,11 +369,12 @@ async def get_project_comments_source_urls(
         default=None,
         description="Optional override base URL (e.g. http://localhost:8000).",
     ),
+    user: AuthenticatedUser = Depends(require_viewer),
 ):
     """
     Get helper URLs to configure KiCad comments REST source for this project.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     resolved_base_url = resolve_comments_base_url(request, explicit_base_url=base_url)
     urls = build_comments_source_urls(project.id, resolved_base_url)
@@ -368,20 +390,25 @@ async def get_project_comments_source_urls(
         "relative": urls["relative"],
     }
 
-@router.delete("/{project_id}")
-async def delete_project_endpoint(project_id: str):
+@router.delete("/{project_id}", dependencies=[Depends(require_designer)])
+async def delete_project_endpoint(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Delete a project from the registry.
     For standalone projects, this also deletes the project files.
     For monorepo sub-projects, only removes the registry entry.
     """
+    _ = get_project_for_role_or_404(project_id, user.role)
     success = project_service.delete_project(project_id)
     if not success:
         raise HTTPException(status_code=404, detail="Project not found")
     return {"message": "Project deleted successfully"}
 
 @router.get("/{project_id}/files", response_model=List[file_service.FileItem])
-async def get_project_files(project_id: str, type: str = "design"):
+async def get_project_files(
+    project_id: str,
+    type: str = "design",
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     List files in Design-Outputs or Manufacturing-Outputs.
     
@@ -390,11 +417,17 @@ async def get_project_files(project_id: str, type: str = "design"):
         type: 'design' or 'manufacturing'
     """
     output_type = require_output_type(type)
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     return file_service.get_project_files(project.path, output_type)
 
 @router.get("/{project_id}/download")
-async def download_file(project_id: str, path: str, type: str = "design", inline: bool = False):
+async def download_file(
+    project_id: str,
+    path: str,
+    type: str = "design",
+    inline: bool = False,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Download a specific file from Design-Outputs or Manufacturing-Outputs.
     
@@ -405,7 +438,7 @@ async def download_file(project_id: str, path: str, type: str = "design", inline
         inline: If True, serve as inline content (view in browser)
     """
     output_type = require_output_type(type)
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     output_dir = _resolve_output_dir(project.path, output_type)
 
     file_path = resolve_path_within_root(output_dir, path, invalid_detail="Invalid file path")
@@ -420,13 +453,17 @@ async def download_file(project_id: str, path: str, type: str = "design", inline
     return FileResponse(file_path, filename=file_path.name, content_disposition_type=disposition)
 
 @router.get("/{project_id}/readme")
-async def get_project_readme(project_id: str, commit: str = None):
+async def get_project_readme(
+    project_id: str,
+    commit: str = None,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Get README content from project root.
     If commit is provided, fetch from that commit; otherwise use working directory.
     For Type-2 projects, uses parent repo with relative path prefix.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     # Get readme path from config
     config = path_config_service.get_path_config(project.path)
@@ -456,12 +493,16 @@ async def get_project_readme(project_id: str, commit: str = None):
     }
 
 @router.get("/{project_id}/asset/{asset_path:path}")
-async def get_project_asset(project_id: str, asset_path: str):
+async def get_project_asset(
+    project_id: str,
+    asset_path: str,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Serve assets (images, etc.) from project directory.
     Typically used for README image references.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     file_path = resolve_path_within_root(project.path, asset_path, invalid_detail="Invalid asset path")
 
     if not file_path.exists():
@@ -473,11 +514,11 @@ async def get_project_asset(project_id: str, asset_path: str):
     return FileResponse(file_path)
 
 @router.get("/{project_id}/docs")
-async def get_docs_files(project_id: str):
+async def get_docs_files(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     List all files in the documentation folder.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     resolved = path_config_service.resolve_paths(project.path)
     docs_dir = resolved.documentation_dir
@@ -488,13 +529,18 @@ async def get_docs_files(project_id: str):
     return file_service.get_files_recursive(docs_dir)
 
 @router.get("/{project_id}/docs/content")
-async def get_doc_file_content(project_id: str, path: str, commit: str = None):
+async def get_doc_file_content(
+    project_id: str,
+    path: str,
+    commit: str = None,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Get markdown file content from documentation folder.
     If commit is provided, fetch from that commit; otherwise use working directory.
     For Type-2 projects, uses parent repo with relative path prefix.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     # Get documentation path from config
     config = path_config_service.get_path_config(project.path)
@@ -527,12 +573,12 @@ async def get_doc_file_content(project_id: str, path: str, commit: str = None):
     }
 
 @router.get("/{project_id}/releases")
-async def get_project_releases(project_id: str):
+async def get_project_releases(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Get list of Git releases/tags for a project.
     For Type-2 projects, uses parent repo with subproject file tracking.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     repo_path, relative_path = _repo_context(project)
     if relative_path:
@@ -543,12 +589,16 @@ async def get_project_releases(project_id: str):
     return {"releases": releases}
 
 @router.get("/{project_id}/commits")
-async def get_project_commits(project_id: str, limit: int = Query(default=50, ge=1, le=500)):
+async def get_project_commits(
+    project_id: str,
+    limit: int = Query(default=50, ge=1, le=500),
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Get list of commits for a project.
     For Type-2 projects, shows only commits affecting the subproject.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     repo_path, relative_path = _repo_context(project)
     if relative_path:
@@ -560,8 +610,8 @@ async def get_project_commits(project_id: str, limit: int = Query(default=50, ge
 
 
 @router.get("/{project_id}/schematic")
-async def get_project_schematic(project_id: str):
-    project = get_project_or_404(project_id)
+async def get_project_schematic(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    project = get_project_for_role_or_404(project_id, user.role)
     
     path = project_service.find_schematic_file(project.path)
     if not path:
@@ -569,8 +619,8 @@ async def get_project_schematic(project_id: str):
     return FileResponse(path)
 
 @router.get("/{project_id}/schematic/subsheets")
-async def get_project_subsheets(project_id: str):
-    project = get_project_or_404(project_id)
+async def get_project_subsheets(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    project = get_project_for_role_or_404(project_id, user.role)
     
     main_path = project_service.find_schematic_file(project.path)
     if not main_path:
@@ -582,8 +632,8 @@ async def get_project_subsheets(project_id: str):
     return {"files": subsheet_urls}
 
 @router.get("/{project_id}/pcb")
-async def get_project_pcb(project_id: str):
-    project = get_project_or_404(project_id)
+async def get_project_pcb(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    project = get_project_for_role_or_404(project_id, user.role)
     
     path = project_service.find_pcb_file(project.path)
     if not path:
@@ -591,8 +641,8 @@ async def get_project_pcb(project_id: str):
     return FileResponse(path)
 
 @router.get("/{project_id}/3d-model")
-async def get_project_3d_model(project_id: str):
-    project = get_project_or_404(project_id)
+async def get_project_3d_model(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    project = get_project_for_role_or_404(project_id, user.role)
     
     path = project_service.find_3d_model(project.path)
     if not path:
@@ -600,8 +650,8 @@ async def get_project_3d_model(project_id: str):
     return FileResponse(path)
 
 @router.get("/{project_id}/ibom")
-async def get_project_ibom(project_id: str):
-    project = get_project_or_404(project_id)
+async def get_project_ibom(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    project = get_project_for_role_or_404(project_id, user.role)
     
     path = project_service.find_ibom_file(project.path)
     if not path:
@@ -612,12 +662,12 @@ async def get_project_ibom(project_id: str):
 # Path Configuration Endpoints
 
 @router.get("/{project_id}/config")
-async def get_project_config(project_id: str):
+async def get_project_config(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Get path configuration for a project.
     Returns the current path configuration (from .prism.json or auto-detected).
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     config = path_config_service.get_path_config(project.path)
     resolved = path_config_service.resolve_paths(project.path, config)
@@ -629,13 +679,13 @@ async def get_project_config(project_id: str):
     }
 
 
-@router.post("/{project_id}/detect-paths")
-async def detect_project_paths(project_id: str):
+@router.post("/{project_id}/detect-paths", dependencies=[Depends(require_designer)])
+async def detect_project_paths(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Run auto-detection on project paths.
     Returns detected paths without saving them.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     detected = path_config_service.detect_paths(project.path)
     
@@ -645,13 +695,17 @@ async def detect_project_paths(project_id: str):
     }
 
 
-@router.put("/{project_id}/config")
-async def update_project_config(project_id: str, config: PathConfig):
+@router.put("/{project_id}/config", dependencies=[Depends(require_designer)])
+async def update_project_config(
+    project_id: str,
+    config: PathConfig,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Update path configuration for a project.
     Saves configuration to .prism.json file.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     # Validate the config before saving
     validation = path_config_service.validate_config(project.path, config)
@@ -681,12 +735,12 @@ class ProjectDescriptionRequest(BaseModel):
 
 
 @router.get("/{project_id}/name")
-async def get_project_name(project_id: str):
+async def get_project_name(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Get the display name for a project.
     Returns custom name from .prism.json or fallback name.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     return {
         "display_name": project.display_name,
@@ -694,12 +748,16 @@ async def get_project_name(project_id: str):
     }
 
 
-@router.put("/{project_id}/name")
-async def update_project_name(project_id: str, request: ProjectNameRequest):
+@router.put("/{project_id}/name", dependencies=[Depends(require_designer)])
+async def update_project_name(
+    project_id: str,
+    request: ProjectNameRequest,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Update the display name for a project in .prism.json.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
     
     display_name = request.display_name.strip()
     if not display_name:
@@ -721,23 +779,27 @@ async def update_project_name(project_id: str, request: ProjectNameRequest):
 
 
 @router.get("/{project_id}/description")
-async def get_project_description(project_id: str):
+async def get_project_description(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """
     Get project description from project registry.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     return {
         "description": project.description
     }
 
 
-@router.put("/{project_id}/description")
-async def update_project_description(project_id: str, request: ProjectDescriptionRequest):
+@router.put("/{project_id}/description", dependencies=[Depends(require_designer)])
+async def update_project_description(
+    project_id: str,
+    request: ProjectDescriptionRequest,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Update project description in project registry.
     """
-    project = get_project_or_404(project_id)
+    project = get_project_for_role_or_404(project_id, user.role)
 
     next_description = request.description.strip()
     if not next_description:

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -715,6 +715,7 @@ async def update_project_config(
     
     # Clear cache to ensure fresh resolution
     path_config_service.clear_config_cache(project.path)
+    project_service.invalidate_project_caches()
     
     # Get resolved paths
     resolved = path_config_service.resolve_paths(project.path, config)
@@ -771,6 +772,7 @@ async def update_project_name(
     
     # Save to .prism.json
     path_config_service.save_path_config(project.path, config)
+    project_service.invalidate_project_caches()
     
     return {
         "display_name": display_name,

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -96,6 +96,38 @@ def _filter_projects_for_user(
 ) -> List[project_service.Project]:
     return folder_service.filter_projects_for_role(projects, user.role)
 
+
+def _load_project_readme_content(
+    project: project_service.Project,
+    commit: Optional[str] = None,
+) -> Optional[str]:
+    config = path_config_service.get_path_config(project.path)
+    readme_filename = config.readme or "README.md"
+
+    if commit:
+        try:
+            return _read_file_from_commit(project, commit, readme_filename)
+        except HTTPException as error:
+            if error.status_code == 404:
+                return None
+            raise
+
+    resolved = path_config_service.resolve_paths(project.path, config)
+    readme_path = resolved.readme_path
+    if not readme_path:
+        return None
+
+    try:
+        return _read_utf8_file(
+            readme_path,
+            not_found_detail="README not found",
+            read_error_prefix="Error reading README",
+        )
+    except HTTPException as error:
+        if error.status_code == 404:
+            return None
+        raise
+
 @router.get("/", response_model=List[project_service.Project])
 async def list_projects(user: AuthenticatedUser = Depends(require_viewer)):
     """Return all registered projects (both Type-1 and Type-2)."""
@@ -319,6 +351,8 @@ async def sync_project_endpoint(project_id: str, user: AuthenticatedUser = Depen
     
     if result["status"] == "error":
         raise HTTPException(status_code=400, detail=result["message"])
+
+    file_service.invalidate_file_listing_cache()
     
     return result
 
@@ -360,6 +394,22 @@ async def get_project_thumbnail(project_id: str, user: AuthenticatedUser = Depen
 async def get_project_detail(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """Get detailed project information."""
     return get_project_for_role_or_404(project_id, user.role)
+
+
+@router.get("/{project_id}/overview")
+async def get_project_overview(
+    project_id: str,
+    commit: str = None,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
+    """
+    Return project detail and README content in one payload for the overview page.
+    """
+    project = get_project_for_role_or_404(project_id, user.role)
+    return {
+        "project": project.model_dump(),
+        "readme": _load_project_readme_content(project, commit),
+    }
 
 
 @router.get("/{project_id}/comments/source-urls")
@@ -465,33 +515,10 @@ async def get_project_readme(
     For Type-2 projects, uses parent repo with relative path prefix.
     """
     project = get_project_for_role_or_404(project_id, user.role)
-    
-    # Get readme path from config
-    config = path_config_service.get_path_config(project.path)
-    readme_filename = config.readme or "README.md"
-    
-    # If viewing a specific commit, use Git
-    if commit:
-        try:
-            content = _read_file_from_commit(project, commit, readme_filename)
-            return {"content": content}
-        except HTTPException:
-            raise
-    
-    # Otherwise read from filesystem
-    resolved = path_config_service.resolve_paths(project.path)
-    readme_path = resolved.readme_path
-
-    if not readme_path:
+    content = _load_project_readme_content(project, commit)
+    if content is None:
         raise HTTPException(status_code=404, detail="README not found")
-
-    return {
-        "content": _read_utf8_file(
-            readme_path,
-            not_found_detail="README not found",
-            read_error_prefix="Error reading README",
-        )
-    }
+    return {"content": content}
 
 @router.get("/{project_id}/asset/{asset_path:path}")
 async def get_project_asset(
@@ -747,6 +774,7 @@ async def update_project_config(
     # Clear cache to ensure fresh resolution
     path_config_service.clear_config_cache(project.path)
     project_service.invalidate_project_caches()
+    file_service.invalidate_file_listing_cache()
     
     # Get resolved paths
     resolved = path_config_service.resolve_paths(project.path, config)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -12,6 +12,7 @@ from app.core.security import AuthenticatedUser, require_designer, require_viewe
 from app.services import file_service, folder_service, path_config_service, project_import_service, project_service
 from app.services.comments_url_service import build_comments_source_urls, resolve_comments_base_url
 from app.services.git_service import (
+    get_commit_distance,
     get_commits_list,
     get_commits_list_filtered,
     get_file_from_commit,
@@ -588,6 +589,22 @@ async def get_project_releases(project_id: str, user: AuthenticatedUser = Depend
     
     return {"releases": releases}
 
+@router.get("/{project_id}/commits/distance")
+async def get_project_commit_distance(
+    project_id: str,
+    commit: str,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
+    """
+    Count how many commits behind HEAD the requested commit is.
+    For Type-2 projects, only commits affecting the subproject path are counted.
+    """
+    project = get_project_for_role_or_404(project_id, user.role)
+
+    repo_path, relative_path = _repo_context(project)
+    commits_behind = get_commit_distance(repo_path, commit, relative_path)
+    return {"commits_behind": commits_behind}
+
 @router.get("/{project_id}/commits")
 async def get_project_commits(
     project_id: str,
@@ -671,11 +688,17 @@ async def get_project_config(project_id: str, user: AuthenticatedUser = Depends(
     
     config = path_config_service.get_path_config(project.path)
     resolved = path_config_service.resolve_paths(project.path, config)
+    explicit_config = path_config_service._load_prism_config(project.path)
+    effective_config = config.model_copy(deep=True)
+    if not effective_config.project_name:
+        effective_config.project_name = project.display_name
+    if not effective_config.description:
+        effective_config.description = project.description
     
     return {
-        "config": config.model_dump(),
+        "config": effective_config.model_dump(),
         "resolved": resolved.model_dump(),
-        "source": "explicit" if path_config_service._load_prism_config(project.path) else "auto-detected"
+        "source": "explicit" if explicit_config else "auto-detected"
     }
 
 
@@ -706,6 +729,14 @@ async def update_project_config(
     Saves configuration to .prism.json file.
     """
     project = get_project_for_role_or_404(project_id, user.role)
+
+    if config.project_name is not None:
+        normalized_name = config.project_name.strip()
+        config.project_name = normalized_name or None
+
+    if config.description is not None:
+        normalized_description = config.description.strip()
+        config.description = normalized_description or f"Project {project.name}"
     
     # Validate the config before saving
     validation = path_config_service.validate_config(project.path, config)

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -1,15 +1,21 @@
-from fastapi import APIRouter, HTTPException
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
 import os
 import subprocess
 from pathlib import Path
 from pydantic import BaseModel
 import logging
 
+from app.core.roles import Role, normalize_role
+from app.core.security import AuthenticatedUser, require_admin
+from app.services import access_service
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_admin)])
 
 # In Docker, home is /root. SSH keys are usually in ~/.ssh
 # We use resolve() to get the absolute path to avoid any ambiguity
@@ -23,6 +29,16 @@ class SSHKeyResponse(BaseModel):
 
 class GenerateSSHKeyRequest(BaseModel):
     email: str = "kicad-prism@example.com"
+
+
+class RoleAssignmentResponse(BaseModel):
+    email: str
+    role: Role
+    source: str
+
+
+class UpsertRoleRequest(BaseModel):
+    role: str
 
 @router.get("/ssh-key", response_model=SSHKeyResponse)
 async def get_ssh_key():
@@ -104,3 +120,39 @@ async def generate_ssh_key(request: GenerateSSHKeyRequest):
     except Exception as e:
         logger.error(f"An unexpected error occurred during key generation: {str(e)}")
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
+
+
+@router.get("/access/users", response_model=List[RoleAssignmentResponse])
+async def list_access_users():
+    return [RoleAssignmentResponse(**item) for item in access_service.list_role_assignments()]
+
+
+@router.put("/access/users/{email}", response_model=RoleAssignmentResponse)
+async def upsert_access_user(
+    email: str,
+    request: UpsertRoleRequest,
+    user: AuthenticatedUser = Depends(require_admin),
+):
+    normalized_role = normalize_role(request.role)
+    if normalized_role is None:
+        raise HTTPException(status_code=400, detail="Invalid role. Must be admin, designer, or viewer.")
+
+    try:
+        assignment = access_service.upsert_user_role(email=email, role=normalized_role, updated_by=user.email)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error))
+
+    return RoleAssignmentResponse(**assignment)
+
+
+@router.delete("/access/users/{email}")
+async def delete_access_user(email: str, user: AuthenticatedUser = Depends(require_admin)):
+    try:
+        deleted = access_service.delete_user_role(email=email, updated_by=user.email)
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error))
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail="User role assignment not found")
+
+    return {"deleted": email.strip().lower()}

--- a/backend/app/api/workspace.py
+++ b/backend/app/api/workspace.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.core.security import AuthenticatedUser, require_viewer
+from app.services import folder_service, project_service
+
+router = APIRouter(dependencies=[Depends(require_viewer)])
+
+
+class WorkspaceBootstrapResponse(BaseModel):
+    projects: List[project_service.Project]
+    folders: List[folder_service.FolderTreeItem]
+
+
+@router.get("/bootstrap", response_model=WorkspaceBootstrapResponse)
+async def get_workspace_bootstrap(user: AuthenticatedUser = Depends(require_viewer)):
+    projects = folder_service.filter_projects_for_role(project_service.get_registered_projects(), user.role)
+    folders = folder_service.get_folder_tree(user.role)
+    return WorkspaceBootstrapResponse(projects=projects, folders=folders)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -45,6 +45,44 @@ class Settings(BaseSettings):
         default="",
         description="Comma-separated list of allowed user emails"
     )
+
+    # Comma-separated list of allowed email domains (legacy compatibility).
+    ALLOWED_DOMAINS_STR: str = Field(
+        default="",
+        description="Comma-separated list of allowed email domains"
+    )
+
+    # Comma-separated list of bootstrap admin user emails.
+    BOOTSTRAP_ADMIN_USERS_STR: str = Field(
+        default="",
+        description="Comma-separated list of admin user emails provisioned from env"
+    )
+
+    # Path to persistent role assignment JSON file.
+    ROLE_STORE_PATH: str = Field(
+        default="",
+        description="Path to persistent RBAC role store JSON"
+    )
+
+    # Session signing secret for HttpOnly cookie authentication.
+    SESSION_SECRET: str = Field(
+        default="",
+        description="HMAC secret used to sign session cookies"
+    )
+
+    # Session TTL in hours.
+    SESSION_TTL_HOURS: int = Field(
+        default=12,
+        ge=1,
+        le=168,
+        description="Session expiration (hours)"
+    )
+
+    # Cookie secure flag (set true behind HTTPS).
+    SESSION_COOKIE_SECURE: bool = Field(
+        default=False,
+        description="Whether session cookie should be marked Secure"
+    )
     
     # ===========================================
     # Development Settings
@@ -78,6 +116,29 @@ class Settings(BaseSettings):
     def ALLOWED_USERS(self) -> List[str]:
         """Parse allowed emails from comma-separated string."""
         return [u.strip().lower() for u in self.ALLOWED_USERS_STR.split(",") if u.strip()]
+
+    @property
+    def ALLOWED_DOMAINS(self) -> List[str]:
+        """Parse allowed domains from comma-separated string."""
+        return [d.strip().lower() for d in self.ALLOWED_DOMAINS_STR.split(",") if d.strip()]
+
+    @property
+    def BOOTSTRAP_ADMIN_USERS(self) -> List[str]:
+        """Parse bootstrap admin emails from comma-separated string."""
+        return [u.strip().lower() for u in self.BOOTSTRAP_ADMIN_USERS_STR.split(",") if u.strip()]
+
+    @property
+    def KICAD_PROJECTS_ROOT(self) -> str:
+        return os.environ.get(
+            "KICAD_PROJECTS_ROOT",
+            os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../data/projects")),
+        )
+
+    @property
+    def RESOLVED_ROLE_STORE_PATH(self) -> str:
+        if self.ROLE_STORE_PATH.strip():
+            return os.path.abspath(os.path.expanduser(self.ROLE_STORE_PATH.strip()))
+        return os.path.join(self.KICAD_PROJECTS_ROOT, ".rbac_roles.json")
     
     @property
     def AUTH_ENABLED(self) -> bool:

--- a/backend/app/core/roles.py
+++ b/backend/app/core/roles.py
@@ -1,0 +1,22 @@
+from typing import Literal, Optional
+
+Role = Literal["admin", "designer", "viewer"]
+
+ROLE_ORDER: dict[Role, int] = {
+    "viewer": 1,
+    "designer": 2,
+    "admin": 3,
+}
+
+
+def normalize_role(value: Optional[str]) -> Optional[Role]:
+    if value is None:
+        return None
+    lowered = value.strip().lower()
+    if lowered not in ROLE_ORDER:
+        return None
+    return lowered  # type: ignore[return-value]
+
+
+def role_meets_minimum(role: Role, minimum: Role) -> bool:
+    return ROLE_ORDER[role] >= ROLE_ORDER[minimum]

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,62 @@
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from app.core.config import settings
+from app.core.roles import Role, normalize_role, role_meets_minimum
+from app.core.session import SESSION_COOKIE_NAME, decode_session_token
+from app.services import access_service
+
+
+class AuthenticatedUser(BaseModel):
+    email: str
+    name: str
+    picture: str = ""
+    role: Role
+
+
+def guest_user() -> AuthenticatedUser:
+    return AuthenticatedUser(email="guest@local", name="Guest User", picture="", role="viewer")
+
+
+def _resolve_allowed_user_role(email: str) -> Role | None:
+    role = access_service.resolve_user_role(email)
+    if role is None:
+        return None
+    return normalize_role(role)
+
+
+async def get_current_user(request: Request) -> AuthenticatedUser:
+    if not settings.AUTH_ENABLED:
+        return guest_user()
+
+    token = request.cookies.get(SESSION_COOKIE_NAME)
+    payload = decode_session_token(token or "")
+    if not payload:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    role = _resolve_allowed_user_role(payload["email"])
+    if not role:
+        raise HTTPException(status_code=403, detail="Access denied. No role assignment found for your account.")
+
+    return AuthenticatedUser(
+        email=payload["email"],
+        name=payload["name"],
+        picture=payload["picture"],
+        role=role,
+    )
+
+
+async def require_viewer(user: AuthenticatedUser = Depends(get_current_user)) -> AuthenticatedUser:
+    return user
+
+
+async def require_designer(user: AuthenticatedUser = Depends(get_current_user)) -> AuthenticatedUser:
+    if not role_meets_minimum(user.role, "designer"):
+        raise HTTPException(status_code=403, detail="Designer role required")
+    return user
+
+
+async def require_admin(user: AuthenticatedUser = Depends(get_current_user)) -> AuthenticatedUser:
+    if not role_meets_minimum(user.role, "admin"):
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return user

--- a/backend/app/core/session.py
+++ b/backend/app/core/session.py
@@ -1,0 +1,118 @@
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, TypedDict
+
+from fastapi import Response
+
+from app.core.config import settings
+from app.core.roles import Role
+
+SESSION_COOKIE_NAME = "kicad_prism_session"
+SESSION_COOKIE_SAMESITE = "lax"
+
+
+class SessionPayload(TypedDict):
+    email: str
+    name: str
+    picture: str
+    role: Role
+    iat: int
+    exp: int
+
+
+def _b64_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64_decode(value: str) -> bytes:
+    pad = "=" * ((4 - len(value) % 4) % 4)
+    return base64.urlsafe_b64decode((value + pad).encode("ascii"))
+
+
+def _sign(message: str) -> str:
+    secret = settings.SESSION_SECRET.encode("utf-8")
+    digest = hmac.new(secret, message.encode("utf-8"), hashlib.sha256).digest()
+    return _b64_encode(digest)
+
+
+def _serialize_payload(payload: SessionPayload) -> str:
+    return _b64_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+
+
+def _deserialize_payload(encoded_payload: str) -> SessionPayload:
+    raw = _b64_decode(encoded_payload)
+    data: dict[str, Any] = json.loads(raw.decode("utf-8"))
+    return SessionPayload(
+        email=str(data["email"]).strip().lower(),
+        name=str(data.get("name") or ""),
+        picture=str(data.get("picture") or ""),
+        role=str(data["role"]),  # type: ignore[typeddict-item]
+        iat=int(data["iat"]),
+        exp=int(data["exp"]),
+    )
+
+
+def create_session_token(email: str, name: str, picture: str, role: Role) -> str:
+    now = int(time.time())
+    payload: SessionPayload = SessionPayload(
+        email=email.strip().lower(),
+        name=name,
+        picture=picture,
+        role=role,
+        iat=now,
+        exp=now + (settings.SESSION_TTL_HOURS * 3600),
+    )
+    encoded_payload = _serialize_payload(payload)
+    signature = _sign(encoded_payload)
+    return f"v1.{encoded_payload}.{signature}"
+
+
+def decode_session_token(token: str) -> SessionPayload | None:
+    if not token:
+        return None
+    if not settings.SESSION_SECRET:
+        return None
+
+    parts = token.split(".")
+    if len(parts) != 3 or parts[0] != "v1":
+        return None
+
+    _, encoded_payload, signature = parts
+    expected_signature = _sign(encoded_payload)
+    if not hmac.compare_digest(signature, expected_signature):
+        return None
+
+    try:
+        payload = _deserialize_payload(encoded_payload)
+    except (ValueError, json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+    if payload["exp"] <= int(time.time()):
+        return None
+    return payload
+
+
+def set_session_cookie(response: Response, token: str) -> None:
+    max_age = settings.SESSION_TTL_HOURS * 3600
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=token,
+        httponly=True,
+        secure=settings.SESSION_COOKIE_SECURE,
+        samesite=SESSION_COOKIE_SAMESITE,
+        max_age=max_age,
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=SESSION_COOKIE_NAME,
+        httponly=True,
+        secure=settings.SESSION_COOKIE_SECURE,
+        samesite=SESSION_COOKIE_SAMESITE,
+        path="/",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from app.api.comments import router as comments_router
 from app.api.diff import router as diff_router
 from app.api.folders import router as folders_router
 from app.api.settings import router as settings_router
+from app.api.workspace import router as workspace_router
 from app.services.git_service import router as git_router
 from app.services.comments_store_service import initialize_comments_store
 from app.core.config import settings
@@ -122,3 +123,4 @@ app.include_router(comments_router, prefix="/api/projects", tags=["comments"])
 app.include_router(diff_router, prefix="/api/projects", tags=["diff"])
 app.include_router(settings_router, prefix="/api/settings", tags=["settings"])
 app.include_router(folders_router, prefix="/api/folders", tags=["folders"])
+app.include_router(workspace_router, prefix="/api/workspace", tags=["workspace"])

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -1,0 +1,148 @@
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.config import settings
+from app.core.roles import Role, normalize_role
+
+ROLE_STORE_VERSION = "1"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_email(email: str) -> str:
+    normalized = (email or "").strip().lower()
+    if not normalized or "@" not in normalized:
+        raise ValueError("Invalid email")
+    return normalized
+
+
+def _bootstrap_admin_set() -> set[str]:
+    return {email.strip().lower() for email in settings.BOOTSTRAP_ADMIN_USERS if email.strip()}
+
+
+def _default_store() -> dict[str, Any]:
+    return {
+        "version": ROLE_STORE_VERSION,
+        "updated_at": _now_iso(),
+        "updated_by": "system",
+        "users": {},
+    }
+
+
+def _role_store_path() -> str:
+    return settings.RESOLVED_ROLE_STORE_PATH
+
+
+def _ensure_role_store_directory() -> None:
+    os.makedirs(os.path.dirname(_role_store_path()), exist_ok=True)
+
+
+def _load_role_store() -> dict[str, Any]:
+    path = _role_store_path()
+    if not os.path.exists(path):
+        return _default_store()
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict):
+            return _default_store()
+        users = payload.get("users")
+        if not isinstance(users, dict):
+            payload["users"] = {}
+        return payload
+    except (OSError, json.JSONDecodeError):
+        return _default_store()
+
+
+def _save_role_store(payload: dict[str, Any]) -> None:
+    _ensure_role_store_directory()
+    path = _role_store_path()
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+    os.replace(tmp_path, path)
+
+
+def _entry_to_role(entry: Any) -> Role | None:
+    if isinstance(entry, str):
+        return normalize_role(entry)
+    if isinstance(entry, dict):
+        return normalize_role(entry.get("role"))
+    return None
+
+
+def resolve_user_role(email: str) -> Role | None:
+    normalized_email = _normalize_email(email)
+    if normalized_email in _bootstrap_admin_set():
+        return "admin"
+
+    payload = _load_role_store()
+    users = payload.get("users") or {}
+    return _entry_to_role(users.get(normalized_email))
+
+
+def list_role_assignments() -> list[dict[str, str]]:
+    payload = _load_role_store()
+    users = payload.get("users") or {}
+    bootstrap_admins = _bootstrap_admin_set()
+
+    assignments: list[dict[str, str]] = []
+    for email, value in users.items():
+        if email in bootstrap_admins:
+            assignments.append({"email": str(email), "role": "admin", "source": "bootstrap"})
+            continue
+        role = _entry_to_role(value)
+        if not role:
+            continue
+        assignments.append({"email": str(email), "role": role, "source": "store"})
+
+    bootstrap_only = bootstrap_admins - {entry["email"] for entry in assignments}
+    for email in sorted(bootstrap_only):
+        assignments.append({"email": email, "role": "admin", "source": "bootstrap"})
+
+    assignments.sort(key=lambda item: item["email"])
+    return assignments
+
+
+def upsert_user_role(email: str, role: Role, updated_by: str) -> dict[str, str]:
+    normalized_email = _normalize_email(email)
+    if normalized_email in _bootstrap_admin_set():
+        if role != "admin":
+            raise ValueError("Cannot override bootstrap admin role assignment")
+        return {"email": normalized_email, "role": "admin", "source": "bootstrap"}
+
+    payload = _load_role_store()
+    users = payload.setdefault("users", {})
+    users[normalized_email] = {
+        "role": role,
+        "updated_at": _now_iso(),
+        "updated_by": _normalize_email(updated_by),
+    }
+    payload["version"] = ROLE_STORE_VERSION
+    payload["updated_at"] = _now_iso()
+    payload["updated_by"] = _normalize_email(updated_by)
+    _save_role_store(payload)
+
+    return {"email": normalized_email, "role": role, "source": "store"}
+
+
+def delete_user_role(email: str, updated_by: str) -> bool:
+    normalized_email = _normalize_email(email)
+    if normalized_email in _bootstrap_admin_set():
+        raise ValueError("Cannot delete bootstrap admin role assignment")
+
+    payload = _load_role_store()
+    users = payload.setdefault("users", {})
+    if normalized_email not in users:
+        return False
+
+    users.pop(normalized_email, None)
+    payload["updated_at"] = _now_iso()
+    payload["updated_by"] = _normalize_email(updated_by)
+    _save_role_store(payload)
+    return True

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -1,4 +1,5 @@
 import os
+import time
 from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime
@@ -12,7 +13,18 @@ class FileItem(BaseModel):
     type: str  # file extension or 'folder'
     is_dir: bool
 
-def get_files_recursive(directory: str, base_path: str = "") -> List[FileItem]:
+FILE_LISTING_CACHE_TTL = 2.0
+_file_listing_cache: dict[str, dict[str, object]] = {}
+
+
+def invalidate_file_listing_cache(directory: Optional[str] = None) -> None:
+    if directory is None:
+        _file_listing_cache.clear()
+        return
+    _file_listing_cache.pop(os.path.abspath(directory), None)
+
+
+def _scan_files_recursive(directory: str, base_path: str = "") -> List[FileItem]:
     """
     Recursively list all files in a directory.
     
@@ -43,7 +55,7 @@ def get_files_recursive(directory: str, base_path: str = "") -> List[FileItem]:
                     is_dir=True
                 ))
                 # Recursively add subdirectory contents
-                items.extend(get_files_recursive(entry.path, rel_path))
+                items.extend(_scan_files_recursive(entry.path, rel_path))
             else:
                 # Get file extension
                 ext = os.path.splitext(entry.name)[1].lstrip('.')
@@ -58,6 +70,34 @@ def get_files_recursive(directory: str, base_path: str = "") -> List[FileItem]:
     except PermissionError:
         pass
         
+    return items
+
+
+def get_files_recursive(directory: str) -> List[FileItem]:
+    directory_path = os.path.abspath(directory)
+    if not os.path.exists(directory_path):
+        return []
+
+    try:
+        directory_mtime = os.path.getmtime(directory_path)
+    except OSError:
+        return []
+
+    now = time.time()
+    cached = _file_listing_cache.get(directory_path)
+    if (
+        cached
+        and cached.get("mtime") == directory_mtime
+        and (now - float(cached.get("cached_at", 0))) < FILE_LISTING_CACHE_TTL
+    ):
+        return cached["items"]  # type: ignore[return-value]
+
+    items = _scan_files_recursive(directory_path)
+    _file_listing_cache[directory_path] = {
+        "items": items,
+        "mtime": directory_mtime,
+        "cached_at": now,
+    }
     return items
 
 def get_project_files(project_path: str, output_type: str) -> List[FileItem]:

--- a/backend/app/services/folder_service.py
+++ b/backend/app/services/folder_service.py
@@ -14,8 +14,9 @@ import shutil
 import uuid
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from app.core.roles import Role, normalize_role
 from app.services import project_service
 
 
@@ -25,6 +26,8 @@ class Folder(BaseModel):
     parent_id: Optional[str] = None
     created_at: str
     updated_at: str
+    visibility_mode: Optional[str] = None
+    allowed_roles: List[str] = Field(default_factory=list)
 
 
 class FolderTreeItem(BaseModel):
@@ -35,6 +38,8 @@ class FolderTreeItem(BaseModel):
     has_children: bool = False
     direct_project_count: int = 0
     total_project_count: int = 0
+    visibility_mode: Optional[str] = None
+    allowed_roles: List[str] = Field(default_factory=list)
 
 
 FOLDERS_FILE = os.path.join(project_service.PROJECTS_ROOT, ".folders.json")
@@ -106,6 +111,27 @@ def _normalize_name(name: str) -> str:
     return normalized
 
 
+def _normalize_allowed_roles(roles: List[str] | None) -> List[str]:
+    if not roles:
+        return []
+    normalized: List[str] = []
+    for value in roles:
+        role = normalize_role(value)
+        if role and role not in normalized:
+            normalized.append(role)
+    return normalized
+
+
+def _is_folder_visible_to_role(folder: Folder, user_role: Optional[Role]) -> bool:
+    if user_role is None:
+        return True
+    if folder.visibility_mode != "roles":
+        return True
+    if not folder.allowed_roles:
+        return True
+    return user_role in folder.allowed_roles
+
+
 def _load_folders() -> Dict[str, Folder]:
     _ensure_canonical_folders_file()
 
@@ -113,7 +139,13 @@ def _load_folders() -> Dict[str, Folder]:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 raw = json.load(f)
-            folders = {folder_id: Folder(**payload) for folder_id, payload in raw.items()}
+            folders: Dict[str, Folder] = {}
+            for folder_id, payload in raw.items():
+                folder = Folder(**payload)
+                folder.allowed_roles = _normalize_allowed_roles(folder.allowed_roles)
+                if folder.visibility_mode not in {None, "roles"}:
+                    folder.visibility_mode = None
+                folders[folder_id] = folder
 
             # If loaded from a legacy location, persist into canonical path once.
             if path != FOLDERS_FILE and not os.path.exists(FOLDERS_FILE):
@@ -162,7 +194,24 @@ def _project_ids_by_folder(folders: Dict[str, Folder]) -> Dict[str, List[str]]:
     return by_folder
 
 
-def get_folder_tree() -> List[FolderTreeItem]:
+def is_folder_visible_to_role(folder_id: Optional[str], user_role: Optional[Role]) -> bool:
+    if folder_id is None:
+        return True
+    folders = _load_folders()
+    folder = folders.get(folder_id)
+    if not folder:
+        return False
+    return _is_folder_visible_to_role(folder, user_role)
+
+
+def filter_projects_for_role(
+    projects: List[project_service.Project],
+    user_role: Optional[Role],
+) -> List[project_service.Project]:
+    return [project for project in projects if is_folder_visible_to_role(project.folder_id, user_role)]
+
+
+def get_folder_tree(user_role: Optional[Role] = None) -> List[FolderTreeItem]:
     folders = _load_folders()
     if not folders:
         return []
@@ -181,6 +230,9 @@ def get_folder_tree() -> List[FolderTreeItem]:
         count = len(direct_project_ids.get(folder_id, []))
         active_stack.add(folder_id)
         for child_id in children.get(folder_id, []):
+            child = folders.get(child_id)
+            if not child or not _is_folder_visible_to_role(child, user_role):
+                continue
             count += total_count(child_id, active_stack)
         active_stack.remove(folder_id)
         total_cache[folder_id] = count
@@ -193,17 +245,25 @@ def get_folder_tree() -> List[FolderTreeItem]:
         for folder_id in children.get(parent_id, []):
             if folder_id in active_stack:
                 continue
-            active_stack.add(folder_id)
             folder = folders[folder_id]
+            if not _is_folder_visible_to_role(folder, user_role):
+                continue
+            active_stack.add(folder_id)
             tree_items.append(
                 FolderTreeItem(
                     id=folder.id,
                     name=folder.name,
                     parent_id=folder.parent_id,
                     depth=depth,
-                    has_children=folder_id in children,
+                    has_children=any(
+                        (child := folders.get(child_id)) is not None
+                        and _is_folder_visible_to_role(child, user_role)
+                        for child_id in children.get(folder_id, [])
+                    ),
                     direct_project_count=len(direct_project_ids.get(folder_id, [])),
                     total_project_count=total_count(folder_id),
+                    visibility_mode=folder.visibility_mode,
+                    allowed_roles=folder.allowed_roles,
                 )
             )
             walk(folder_id, depth + 1, active_stack)
@@ -239,6 +299,8 @@ def create_folder(name: str, parent_id: Optional[str] = None) -> Folder:
         parent_id=parent_id,
         created_at=now,
         updated_at=now,
+        visibility_mode=None,
+        allowed_roles=[],
     )
     folders[folder.id] = folder
     _save_folders(folders)
@@ -307,17 +369,27 @@ def move_project_to_folder(project_id: str, folder_id: Optional[str]) -> None:
         raise ValueError("Project not found")
 
 
-def get_folder_contents(folder_id: Optional[str]) -> dict:
+def get_folder_contents(folder_id: Optional[str], user_role: Optional[Role] = None) -> dict:
     folders = _load_folders()
-    if folder_id is not None and folder_id not in folders:
-        raise ValueError("Folder not found")
+    if folder_id is not None:
+        folder = folders.get(folder_id)
+        if folder is None or not _is_folder_visible_to_role(folder, user_role):
+            raise ValueError("Folder not found")
 
     children = sorted(
-        [folder for folder in folders.values() if folder.parent_id == folder_id],
+        [
+            folder
+            for folder in folders.values()
+            if folder.parent_id == folder_id and _is_folder_visible_to_role(folder, user_role)
+        ],
         key=lambda folder: folder.name.lower(),
     )
     projects = sorted(
-        [project for project in project_service.get_registered_projects() if project.folder_id == folder_id],
+        [
+            project
+            for project in project_service.get_registered_projects()
+            if project.folder_id == folder_id and is_folder_visible_to_role(project.folder_id, user_role)
+        ],
         key=lambda project: (project.display_name or project.name).lower(),
     )
 

--- a/backend/app/services/folder_service.py
+++ b/backend/app/services/folder_service.py
@@ -188,7 +188,7 @@ def _descendant_ids(root_folder_id: str, children: Dict[Optional[str], List[str]
 
 def _project_ids_by_folder(folders: Dict[str, Folder]) -> Dict[str, List[str]]:
     by_folder: Dict[str, List[str]] = {folder_id: [] for folder_id in folders.keys()}
-    for project in project_service.get_registered_projects():
+    for project in project_service.get_registered_project_records():
         if project.folder_id and project.folder_id in by_folder:
             by_folder[project.folder_id].append(project.id)
     return by_folder
@@ -208,7 +208,20 @@ def filter_projects_for_role(
     projects: List[project_service.Project],
     user_role: Optional[Role],
 ) -> List[project_service.Project]:
-    return [project for project in projects if is_folder_visible_to_role(project.folder_id, user_role)]
+    if user_role is None:
+        return projects
+
+    folders = _load_folders()
+
+    def project_visible(project: project_service.Project) -> bool:
+        if project.folder_id is None:
+            return True
+        folder = folders.get(project.folder_id)
+        if not folder:
+            return False
+        return _is_folder_visible_to_role(folder, user_role)
+
+    return [project for project in projects if project_visible(project)]
 
 
 def get_folder_tree(user_role: Optional[Role] = None) -> List[FolderTreeItem]:
@@ -351,7 +364,7 @@ def delete_folder(folder_id: str, cascade: bool = True) -> bool:
         raise ValueError("Folder has subfolders. Use cascade delete or move subfolders first.")
 
     # Move all projects under deleted folders back to root.
-    for project in project_service.get_registered_projects():
+    for project in project_service.get_registered_project_records():
         if project.folder_id in delete_ids:
             project_service.update_project_folder_id(project.id, None)
 
@@ -388,7 +401,14 @@ def get_folder_contents(folder_id: Optional[str], user_role: Optional[Role] = No
         [
             project
             for project in project_service.get_registered_projects()
-            if project.folder_id == folder_id and is_folder_visible_to_role(project.folder_id, user_role)
+            if project.folder_id == folder_id
+            and (
+                folder_id is None
+                or (
+                    (folder := folders.get(project.folder_id)) is not None
+                    and _is_folder_visible_to_role(folder, user_role)
+                )
+            )
         ],
         key=lambda project: (project.display_name or project.name).lower(),
     )

--- a/backend/app/services/folder_service.py
+++ b/backend/app/services/folder_service.py
@@ -11,6 +11,7 @@ import datetime
 import json
 import os
 import shutil
+import time
 import uuid
 from typing import Dict, List, Optional
 
@@ -44,6 +45,11 @@ class FolderTreeItem(BaseModel):
 
 FOLDERS_FILE = os.path.join(project_service.PROJECTS_ROOT, ".folders.json")
 os.makedirs(os.path.dirname(FOLDERS_FILE), exist_ok=True)
+
+FOLDERS_CACHE_TTL = 5.0
+_folders_cache: Dict[str, Folder] = {}
+_folders_cache_time: float = 0
+_folders_cache_mtime: Optional[float] = None
 
 
 def _legacy_folders_files() -> List[str]:
@@ -133,7 +139,21 @@ def _is_folder_visible_to_role(folder: Folder, user_role: Optional[Role]) -> boo
 
 
 def _load_folders() -> Dict[str, Folder]:
+    global _folders_cache, _folders_cache_time, _folders_cache_mtime
     _ensure_canonical_folders_file()
+
+    current_time = time.time()
+    try:
+        current_mtime = os.path.getmtime(FOLDERS_FILE)
+    except OSError:
+        current_mtime = None
+
+    if (
+        _folders_cache
+        and (current_time - _folders_cache_time) < FOLDERS_CACHE_TTL
+        and _folders_cache_mtime == current_mtime
+    ):
+        return _folders_cache
 
     for path in _existing_folders_file_candidates():
         try:
@@ -151,16 +171,33 @@ def _load_folders() -> Dict[str, Folder]:
             if path != FOLDERS_FILE and not os.path.exists(FOLDERS_FILE):
                 _save_folders(folders)
 
+            _folders_cache = folders
+            _folders_cache_time = current_time
+            try:
+                _folders_cache_mtime = os.path.getmtime(FOLDERS_FILE)
+            except OSError:
+                _folders_cache_mtime = current_mtime
             return folders
         except (json.JSONDecodeError, IOError):
             continue
 
+    _folders_cache = {}
+    _folders_cache_time = current_time
+    _folders_cache_mtime = current_mtime
     return {}
+
+
+def invalidate_folder_cache() -> None:
+    global _folders_cache, _folders_cache_time, _folders_cache_mtime
+    _folders_cache = {}
+    _folders_cache_time = 0
+    _folders_cache_mtime = None
 
 
 def _save_folders(folders: Dict[str, Folder]) -> None:
     with open(FOLDERS_FILE, "w", encoding="utf-8") as f:
         json.dump({k: v.dict() for k, v in folders.items()}, f, indent=2)
+    invalidate_folder_cache()
 
 
 def _children_map(folders: Dict[str, Folder]) -> Dict[Optional[str], List[str]]:

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -31,24 +31,12 @@ def get_commits_list_filtered(repo_path: str, relative_path: str = None, limit: 
     try:
         repo = Repo(repo_path)
         commits = []
-        
-        for commit in repo.iter_commits(max_count=limit * 3):  # Fetch more to account for filtering
-            # If relative_path provided, filter to commits that touched files under that path
-            if relative_path:
-                # Use diff to get changed files - more reliable than stats
-                changed_files = []
-                if commit.parents:
-                    # Compare with parent to get changed files
-                    diff = commit.parents[0].diff(commit)
-                    changed_files = [d.a_path or d.b_path for d in diff if d.a_path or d.b_path]
-                else:
-                    # Initial commit - list all files in tree
-                    changed_files = [item.path for item in commit.tree.traverse() if item.type == 'blob']
-                
-                # Check if any file starts with the relative_path
-                if not any(f.startswith(relative_path) for f in changed_files):
-                    continue
-            
+
+        iter_kwargs = {"max_count": limit}
+        if relative_path:
+            iter_kwargs["paths"] = relative_path
+
+        for commit in repo.iter_commits(**iter_kwargs):
             commits.append({
                 "hash": commit.hexsha[:7],
                 "full_hash": commit.hexsha,

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1,6 +1,7 @@
 import os
 from fastapi import APIRouter, Depends, HTTPException
 from git import Repo
+from git.exc import BadName, GitCommandError
 from typing import List, Dict, Any
 from pydantic import BaseModel
 import datetime
@@ -20,38 +21,77 @@ class CommitInfo(BaseModel):
     date: str
 
 
+def _open_repo(repo_path: str) -> Repo:
+    if not os.path.exists(repo_path):
+        raise HTTPException(status_code=404, detail=f"Repository not found at {repo_path}")
+
+    try:
+        return Repo(repo_path)
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
+
+
+def _serialize_commit(commit) -> Dict[str, str]:
+    return {
+        "hash": commit.hexsha[:7],
+        "full_hash": commit.hexsha,
+        "author": commit.author.name,
+        "email": commit.author.email,
+        "date": datetime.datetime.fromtimestamp(commit.committed_date).isoformat(),
+        "message": commit.message.strip(),
+    }
+
+
+def _get_commits(repo_path: str, limit: int, relative_path: str = None):
+    repo = _open_repo(repo_path)
+    iter_kwargs = {"max_count": limit}
+    if relative_path:
+        iter_kwargs["paths"] = relative_path
+
+    try:
+        return [_serialize_commit(commit) for commit in repo.iter_commits(**iter_kwargs)]
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
+
+
 def get_commits_list_filtered(repo_path: str, relative_path: str = None, limit: int = 50):
     """
     Get list of commits from repository, optionally filtered to a subdirectory.
     For Type-2 projects, relative_path scopes commits to the subproject.
     """
-    if not os.path.exists(repo_path):
-        raise HTTPException(status_code=404, detail=f"Repository not found at {repo_path}")
-    
+    return _get_commits(repo_path, limit, relative_path)
+
+
+def _count_tree_entries(commit, relative_path: str) -> int | None:
     try:
-        repo = Repo(repo_path)
-        commits = []
+        target = commit.tree / relative_path
+        if target.type == "tree":
+            return len(list(target.traverse()))
+    except Exception:
+        return None
+    return None
 
-        iter_kwargs = {"max_count": limit}
-        if relative_path:
-            iter_kwargs["paths"] = relative_path
 
-        for commit in repo.iter_commits(**iter_kwargs):
-            commits.append({
-                "hash": commit.hexsha[:7],
-                "full_hash": commit.hexsha,
-                "author": commit.author.name,
-                "email": commit.author.email,
+def _get_releases(repo_path: str, relative_path: str = None):
+    repo = _open_repo(repo_path)
+    releases = []
+    try:
+        for tag in repo.tags:
+            commit = tag.commit
+            release = {
+                "tag": tag.name,
+                "commit_hash": commit.hexsha[:7],
                 "date": datetime.datetime.fromtimestamp(commit.committed_date).isoformat(),
-                "message": commit.message.strip()
-            })
-            
-            if len(commits) >= limit:
-                break
-                
-        return commits
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Git error: {str(e)}")
+                "message": commit.message.strip(),
+            }
+            if relative_path:
+                release["subproject_files_changed"] = _count_tree_entries(commit, relative_path)
+            releases.append(release)
+
+        releases.sort(key=lambda item: item["date"], reverse=True)
+        return releases
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
 
 
 def get_releases_filtered(repo_path: str, relative_path: str = None):
@@ -59,38 +99,7 @@ def get_releases_filtered(repo_path: str, relative_path: str = None):
     Get list of Git tags/releases from repository.
     For Type-2 projects, shows file count under relative_path for each tag.
     """
-    if not os.path.exists(repo_path):
-        raise HTTPException(status_code=404, detail=f"Repository not found at {repo_path}")
-    
-    try:
-        repo = Repo(repo_path)
-        releases = []
-        for tag in repo.tags:
-            commit = tag.commit
-            
-            # Count files under relative_path if provided
-            file_count = None
-            if relative_path:
-                try:
-                    tree = commit.tree
-                    target = tree / relative_path
-                    if target.type == 'tree':
-                        file_count = len(list(target.traverse()))
-                except:
-                    pass
-            
-            releases.append({
-                "tag": tag.name,
-                "commit_hash": commit.hexsha[:7],
-                "date": datetime.datetime.fromtimestamp(commit.committed_date).isoformat(),
-                "message": commit.message.strip(),
-                "subproject_files_changed": file_count
-            })
-        # Sort by date descending (newest first)
-        releases.sort(key=lambda x: x['date'], reverse=True)
-        return releases
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Git error: {str(e)}")
+    return _get_releases(repo_path, relative_path)
 
 
 def get_file_from_commit_with_prefix(repo_path: str, commit_hash: str, file_path: str, relative_prefix: str = None) -> str:
@@ -151,11 +160,8 @@ async def list_commits(repo_path: str = DEFAULT_REPO_PATH, limit: int = 50):
     """
     List commits for a given repository.
     """
-    if not os.path.exists(repo_path):
-        raise HTTPException(status_code=404, detail=f"Repository not found at {repo_path}")
-    
     try:
-        repo = Repo(repo_path)
+        repo = _open_repo(repo_path)
         commits = []
         for commit in repo.iter_commits(max_count=limit):
             commits.append(CommitInfo(
@@ -165,65 +171,55 @@ async def list_commits(repo_path: str = DEFAULT_REPO_PATH, limit: int = 50):
                 date=datetime.datetime.fromtimestamp(commit.committed_date).isoformat()
             ))
         return commits
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Git error: {str(e)}")
+    except HTTPException:
+        raise
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
 
 def get_releases(repo_path: str):
     """
     Get list of Git tags/releases from repository.
     """
-    if not os.path.exists(repo_path):
-        raise HTTPException(status_code=404, detail=f"Repository not found at {repo_path}")
-    
-    try:
-        repo = Repo(repo_path)
-        releases = []
-        for tag in repo.tags:
-            releases.append({
-                "tag": tag.name,
-                "commit_hash": tag.commit.hexsha[:7],
-                "date": datetime.datetime.fromtimestamp(tag.commit.committed_date).isoformat(),
-                "message": tag.commit.message.strip()
-            })
-        # Sort by date descending (newest first)
-        releases.sort(key=lambda x: x['date'], reverse=True)
-        return releases
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Git error: {str(e)}")
+    return _get_releases(repo_path)
 
 def get_commits_list(repo_path: str, limit: int = 50):
     """
     Get list of commits from repository.
     """
-    if not os.path.exists(repo_path):
-        raise HTTPException(status_code=404, detail=f"Repository not found at {repo_path}")
-    
+    return _get_commits(repo_path, limit)
+
+
+def get_commit_distance(repo_path: str, commit_hash: str, relative_path: str = None) -> int:
+    """
+    Count commits between the requested commit and HEAD.
+    When relative_path is provided, only count commits that affect that path.
+    """
     try:
-        repo = Repo(repo_path)
-        commits = []
-        for commit in repo.iter_commits(max_count=limit):
-            commits.append({
-                "hash": commit.hexsha[:7],
-                "full_hash": commit.hexsha,
-                "author": commit.author.name,
-                "email": commit.author.email,
-                "date": datetime.datetime.fromtimestamp(commit.committed_date).isoformat(),
-                "message": commit.message.strip()
-            })
-        return commits
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Git error: {str(e)}")
+        repo = _open_repo(repo_path)
+        repo.commit(commit_hash)
+
+        rev_list_args = ["--count", f"{commit_hash}..HEAD"]
+        if relative_path:
+            rev_list_args.extend(["--", relative_path])
+
+        return int(repo.git.rev_list(*rev_list_args).strip() or "0")
+    except BadName as error:
+        raise HTTPException(status_code=404, detail=f"Commit not found: {commit_hash}") from error
+    except GitCommandError as error:
+        message = str(error).lower()
+        if "bad revision" in message or "unknown revision" in message:
+            raise HTTPException(status_code=404, detail=f"Commit not found: {commit_hash}") from error
+        raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
 
 @router.get("/content")
 async def get_file_content(commit_sha: str, file_path: str, repo_path: str = DEFAULT_REPO_PATH):
     """
     Get file content from a specific commit.
     """
-    if not os.path.exists(repo_path):
-         raise HTTPException(status_code=404, detail=f"Repository not found at {repo_path}")
-
     try:
-        repo = Repo(repo_path)
+        repo = _open_repo(repo_path)
         commit = repo.commit(commit_sha)
         
         try:

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1,11 +1,13 @@
 import os
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from git import Repo
 from typing import List, Dict, Any
 from pydantic import BaseModel
 import datetime
 
-router = APIRouter()
+from app.core.security import require_viewer
+
+router = APIRouter(dependencies=[Depends(require_viewer)])
 
 # Configuration
 # Default to sibling directory for development

--- a/backend/app/services/path_config_service.py
+++ b/backend/app/services/path_config_service.py
@@ -331,6 +331,19 @@ def _detect_jobset_path(project_path: Path) -> Optional[str]:
     return None
 
 
+PATH_DETECTORS = {
+    "schematic": _detect_schematic_path,
+    "pcb": _detect_pcb_path,
+    "subsheets": _detect_subsheets_path,
+    "designOutputs": _detect_design_outputs_path,
+    "manufacturingOutputs": _detect_manufacturing_outputs_path,
+    "documentation": _detect_documentation_path,
+    "thumbnail": _detect_thumbnail_path,
+    "readme": _detect_readme_path,
+    "jobset": _detect_jobset_path,
+}
+
+
 def detect_paths(project_path: str) -> PathConfig:
     """
     Auto-detect path configuration for a project.
@@ -377,31 +390,21 @@ def get_path_config(project_path: str, use_cache: bool = True) -> PathConfig:
         if cached_entry.get("prism_mtime") == prism_mtime:
             return PathConfig(**cached_entry["config"])
 
-    # 1. Auto-detect base config
-    detected = detect_paths(project_path)
+    project_dir = Path(project_path)
 
-    # 2. Fill in defaults where detection failed
-    for key, default_value in DEFAULT_PATHS.items():
-        current_value = getattr(detected, key)
-        if current_value is None:
-            # Don't default subsheets - None means "root directory"
-            if key != "subsheets":
-                setattr(detected, key, default_value)
+    # Start from explicit config so complete `.prism.json` files skip auto-detection.
+    explicit_config = _normalize_config_values(_load_prism_config(project_path) or {})
+    merged_dict: Dict[str, Any] = dict(explicit_config)
 
-    detected_dict = detected.dict()
+    for key in PATH_FIELDS:
+        if merged_dict.get(key) is None:
+            detected_value = PATH_DETECTORS[key](project_dir)
+            if detected_value is not None:
+                merged_dict[key] = detected_value
+            elif key != "subsheets":
+                merged_dict[key] = DEFAULT_PATHS[key]
 
-    # 3. Overlay explicit .prism.json config field-by-field
-    # Empty path fields are treated as unset and keep auto-detected/default values.
-    explicit_config = _load_prism_config(project_path) or {}
-    explicit_config = _normalize_config_values(explicit_config)
-    for key, value in explicit_config.items():
-        if key in PATH_FIELDS:
-            if value is not None:
-                detected_dict[key] = value
-        else:
-            detected_dict[key] = value
-
-    merged = PathConfig(**detected_dict)
+    merged = PathConfig(**merged_dict)
     _config_cache[cache_key] = {
         "config": merged.dict(),
         "prism_mtime": prism_mtime,

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,10 +1,16 @@
 import os
-import datetime
+import json
+import time
+import uuid
 import shutil
+import threading
+import datetime
+import subprocess
+from typing import Dict, List, Optional
+
 from git import Repo, RemoteProgress
-from typing import List, Optional, Dict
 from pydantic import BaseModel
-from fastapi.responses import FileResponse
+
 from app.services import path_config_service
 
 class Project(BaseModel):
@@ -22,6 +28,20 @@ class Project(BaseModel):
     parent_repo_path: Optional[str] = None  # Path to parent repo for Type-2
     folder_id: Optional[str] = None  # Optional folder assignment for workspace organization
 
+
+class RegisteredProjectRecord(BaseModel):
+    id: str
+    name: str
+    path: str
+    description: str
+    last_modified: str
+    sub_path: Optional[str] = None
+    parent_repo: Optional[str] = None
+    repo_url: Optional[str] = None
+    import_type: Optional[str] = None
+    parent_repo_path: Optional[str] = None
+    folder_id: Optional[str] = None
+
 # PROJECTS_ROOT is where imported projects are stored.
 # In Docker, this should be a persistent volume mount.
 PROJECTS_ROOT = os.environ.get("KICAD_PROJECTS_ROOT", os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../data/projects")))
@@ -37,7 +57,12 @@ os.makedirs(PROJECTS_ROOT, exist_ok=True)
 os.makedirs(MONOREPOS_ROOT, exist_ok=True)
 os.makedirs(os.path.join(PROJECTS_ROOT, "type1"), exist_ok=True)
 
-import json
+PROJECTS_CACHE_TTL = 5.0  # seconds
+
+_project_records_cache: List[RegisteredProjectRecord] = []
+_project_records_cache_time: float = 0
+_projects_cache: List[Project] = []
+_projects_cache_time: float = 0
 
 def _load_project_registry() -> Dict[str, dict]:
     """Load the project registry from JSON file."""
@@ -54,8 +79,18 @@ def _save_project_registry(registry: Dict[str, dict]) -> None:
     try:
         with open(PROJECT_REGISTRY_FILE, 'w') as f:
             json.dump(registry, f, indent=2)
+        invalidate_project_caches()
     except IOError as e:
         print(f"Warning: Failed to save project registry: {e}")
+
+
+def invalidate_project_caches() -> None:
+    global _project_records_cache, _project_records_cache_time
+    global _projects_cache, _projects_cache_time
+    _project_records_cache = []
+    _project_records_cache_time = 0
+    _projects_cache = []
+    _projects_cache_time = 0
 
 def register_project(project_id: str, name: str, path: str, repo_url: str,
                      sub_path: Optional[str] = None, parent_repo: Optional[str] = None,
@@ -130,10 +165,75 @@ def _normalize_path(path: str) -> str:
     # Return original path if no conversion worked
     return path
 
-# Cache for registered projects
-_projects_cache: List[Project] = []
-_projects_cache_time: float = 0
-PROJECTS_CACHE_TTL = 5.0 # seconds
+def _record_last_modified(path: str, fallback: str) -> str:
+    try:
+        mtime = os.path.getmtime(path)
+        return datetime.datetime.fromtimestamp(mtime).strftime('%Y-%m-%d')
+    except OSError:
+        return fallback
+
+
+def _record_to_project(record: RegisteredProjectRecord) -> Project:
+    custom_display_name = path_config_service.get_project_display_name(record.path)
+    custom_description = path_config_service.get_project_description(record.path)
+
+    return Project(
+        id=record.id,
+        name=record.name,
+        display_name=custom_display_name,
+        description=custom_description or record.description,
+        path=record.path,
+        last_modified=record.last_modified,
+        thumbnail_url=f"/api/projects/{record.id}/thumbnail",
+        sub_path=record.sub_path,
+        parent_repo=record.parent_repo,
+        repo_url=record.repo_url,
+        import_type=record.import_type,
+        parent_repo_path=record.parent_repo_path,
+        folder_id=record.folder_id,
+    )
+
+
+def get_registered_project_records() -> List[RegisteredProjectRecord]:
+    """
+    Return normalized registry-backed project records without hydrating `.prism.json`.
+    """
+    global _project_records_cache, _project_records_cache_time
+
+    current_time = time.time()
+    if _project_records_cache and (current_time - _project_records_cache_time) < PROJECTS_CACHE_TTL:
+        return _project_records_cache
+
+    registry = _load_project_registry()
+    records: List[RegisteredProjectRecord] = []
+    for project_id, data in registry.items():
+        normalized_path = _normalize_path(data["path"])
+        if not os.path.exists(normalized_path):
+            continue
+
+        records.append(
+            RegisteredProjectRecord(
+                id=project_id,
+                name=data["name"],
+                path=normalized_path,
+                description=data.get("description", f"Project {data['name']}"),
+                last_modified=_record_last_modified(normalized_path, data.get("last_modified", "Unknown")),
+                sub_path=data.get("sub_path"),
+                parent_repo=data.get("parent_repo"),
+                repo_url=data.get("repo_url"),
+                import_type=data.get("import_type"),
+                parent_repo_path=(
+                    _normalize_path(data.get("parent_repo_path"))
+                    if data.get("import_type") == "type2_subproject" and data.get("parent_repo_path")
+                    else None
+                ),
+                folder_id=data.get("folder_id"),
+            )
+        )
+
+    _project_records_cache = records
+    _project_records_cache_time = current_time
+    return records
 
 def get_registered_projects() -> List[Project]:
     """
@@ -146,42 +246,7 @@ def get_registered_projects() -> List[Project]:
     if _projects_cache and (current_time - _projects_cache_time) < PROJECTS_CACHE_TTL:
         return _projects_cache
         
-    registry = _load_project_registry()
-    projects = []
-    for project_id, data in registry.items():
-        # Normalize path for current environment
-        normalized_path = _normalize_path(data["path"])
-        
-        # Verify the project path still exists
-        if not os.path.exists(normalized_path):
-            continue
-        
-        # Update last modified time
-        try:
-            mtime = os.path.getmtime(normalized_path)
-            last_modified = datetime.datetime.fromtimestamp(mtime).strftime('%Y-%m-%d')
-        except:
-            last_modified = data.get("last_modified", "Unknown")
-        
-        # Get custom display name from .prism.json
-        custom_display_name = path_config_service.get_project_display_name(normalized_path)
-        custom_description = path_config_service.get_project_description(normalized_path)
-        
-        projects.append(Project(
-            id=project_id,
-            name=data["name"],
-            display_name=custom_display_name,
-            description=custom_description or data.get("description", f"Project {data['name']}"),
-            path=normalized_path,
-            last_modified=last_modified,
-            thumbnail_url=f"/api/projects/{project_id}/thumbnail",
-            sub_path=data.get("sub_path"),
-            parent_repo=data.get("parent_repo"),
-            repo_url=data.get("repo_url"),
-            import_type=data.get("import_type"),
-            parent_repo_path=_normalize_path(data.get("parent_repo_path")) if data.get("import_type") == "type2_subproject" else None,
-            folder_id=data.get("folder_id")
-        ))
+    projects = [_record_to_project(record) for record in get_registered_project_records()]
     
     _projects_cache = projects
     _projects_cache_time = current_time
@@ -200,45 +265,11 @@ def get_project_by_id(project_id: str) -> Optional[Project]:
         if project:
             return project
 
-    registry = _load_project_registry()
-    if project_id not in registry:
+    record = next((item for item in get_registered_project_records() if item.id == project_id), None)
+    if not record:
         return None
-        
-    data = registry[project_id]
-    normalized_path = _normalize_path(data["path"])
-    
-    if not os.path.exists(normalized_path):
-        return None
-        
-    try:
-        mtime = os.path.getmtime(normalized_path)
-        last_modified = datetime.datetime.fromtimestamp(mtime).strftime('%Y-%m-%d')
-    except:
-        last_modified = data.get("last_modified", "Unknown")
-        
-    custom_display_name = path_config_service.get_project_display_name(normalized_path)
-    custom_description = path_config_service.get_project_description(normalized_path)
-    
-    return Project(
-        id=project_id,
-        name=data["name"],
-        display_name=custom_display_name,
-        description=custom_description or data.get("description", f"Project {data['name']}"),
-        path=normalized_path,
-        last_modified=last_modified,
-        thumbnail_url=f"/api/projects/{project_id}/thumbnail",
-        sub_path=data.get("sub_path"),
-        parent_repo=data.get("parent_repo"),
-        repo_url=data.get("repo_url"),
-        import_type=data.get("import_type"),
-        parent_repo_path=_normalize_path(data.get("parent_repo_path")) if data.get("import_type") == "type2_subproject" else None,
-        folder_id=data.get("folder_id")
-    )
 
-import threading
-import uuid
-import time
-import subprocess
+    return _record_to_project(record)
 
 # Global job store: {job_id: {status: str, message: str, percent: float, project_id: str, error: str, logs: list[str], type: str}}
 jobs = {}
@@ -587,8 +618,7 @@ def start_workflow_job(project_id: str, workflow_type: str, author: str = "anony
     return job_id
 
 def get_project_thumbnail_path(project_id: str) -> Optional[str]:
-    projects = get_registered_projects()
-    project = next((p for p in projects if p.id == project_id), None)
+    project = get_project_by_id(project_id)
     if not project:
         print(f"[DEBUG] Project {project_id} not found")
         return None
@@ -707,11 +737,6 @@ def delete_project(project_id: str) -> bool:
         except Exception as e:
             print(f"Warning: Failed to delete project directory {project_path}: {e}")
     
-    # Clear projects cache so deleted entries are not returned.
-    global _projects_cache, _projects_cache_time
-    _projects_cache = []
-    _projects_cache_time = 0
-
     return True
 
 
@@ -727,10 +752,6 @@ def update_project_folder_id(project_id: str, folder_id: Optional[str]) -> bool:
     registry[project_id]["folder_id"] = folder_id
     _save_project_registry(registry)
 
-    # Clear projects cache so subsequent reads include updated folder_id.
-    global _projects_cache, _projects_cache_time
-    _projects_cache = []
-    _projects_cache_time = 0
     return True
 
 
@@ -754,9 +775,6 @@ def update_project_description(project_id: str, description: str) -> bool:
         registry[project_id]["description"] = description
         _save_project_registry(registry)
 
-    global _projects_cache, _projects_cache_time
-    _projects_cache = []
-    _projects_cache_time = 0
     return True
 
 def get_subsheets(project_path: str, main_schematic: str) -> List[str]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,13 @@ services:
       - WORKSPACE_NAME=${WORKSPACE_NAME:-KiCAD Prism}
       # Google OAuth Configuration (required for authentication)
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
-      - ALLOWED_DOMAINS=${ALLOWED_DOMAINS:-}
+      - ALLOWED_USERS_STR=${ALLOWED_USERS_STR:-}
+      - ALLOWED_DOMAINS_STR=${ALLOWED_DOMAINS_STR:-}
+      - BOOTSTRAP_ADMIN_USERS_STR=${BOOTSTRAP_ADMIN_USERS_STR:-}
+      - ROLE_STORE_PATH=${ROLE_STORE_PATH:-}
+      - SESSION_SECRET=${SESSION_SECRET:-}
+      - SESSION_TTL_HOURS=${SESSION_TTL_HOURS:-12}
+      - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-false}
       # Set to false to disable authentication entirely
       - AUTH_ENABLED=${AUTH_ENABLED:-true}
       # Development mode (set to false for production/bundling)

--- a/docs/COMMENTS-COLLAB-UPDATES.md
+++ b/docs/COMMENTS-COLLAB-UPDATES.md
@@ -1,154 +1,79 @@
-# Comments Collaboration Updates
+# Comments Collaboration Model
 
-This document summarizes recent improvements to KiCAD-Prism comment handling for both REST and local artifact workflows.
+This document describes the current comments architecture in KiCAD Prism.
 
-## Overview
+## Current Behavior
 
-The comments system now uses a database-first model for live collaboration, and generates `.comments/comments.json` as an export artifact when requested.
+Comments are database-backed for live application use.
 
-- Source of truth for comments/replies: SQLite
-- Artifact for KiCad/local Git workflow: `.comments/comments.json`
-- REST URL helpers are available per project and now include reply URL templates
+- source of truth: SQLite comment store
+- export artifact: `.comments/comments.json` inside the project repository
+- REST helper URLs are generated per project so KiCad or external tooling can target the correct API endpoints
 
-## Backend Changes
+The export action generates the JSON artifact. Git commit and push operations remain a separate user workflow.
 
-### 1) Database-backed comment store
+## Backend Model
 
-Implemented `CommentsStoreService` in:
+### Storage
 
-- `backend/app/services/comments_store_service.py`
-
-Key behavior:
-
-- Stores comments and replies in SQLite with per-project isolation (`project_id`)
-- Imports existing `.comments/comments.json` once per project (bootstrap)
-- Supports CRUD operations for comments and replies
-- Exports DB snapshot to `.comments/comments.json` atomically
-
-### 2) Comments API refactor
-
-Updated:
-
-- `backend/app/api/comments.py`
+`CommentsStoreService` keeps comments and replies in SQLite with per-project isolation.
 
 Key behavior:
+- bootstraps from an existing `.comments/comments.json` once when needed
+- supports comment create, update, reply, and delete operations
+- exports JSON atomically back into the repository
 
-- `GET /api/projects/{project_id}/comments` reads DB snapshot
-- `POST /api/projects/{project_id}/comments` creates comment in DB
-- `PATCH /api/projects/{project_id}/comments/{comment_id}` updates status
-- `POST /api/projects/{project_id}/comments/{comment_id}/replies` adds reply
-- `DELETE /api/projects/{project_id}/comments/{comment_id}` deletes comment
-- `POST /api/projects/{project_id}/comments/push` now only exports JSON artifact
+### API Surface
 
-Important: export endpoint no longer commits or pushes to Git. Users handle Git operations themselves.
+Comments endpoints live under `/api/projects/{project_id}`:
 
-### 3) URL helper service
+- `GET /comments`
+- `POST /comments`
+- `PATCH /comments/{comment_id}`
+- `POST /comments/{comment_id}/replies`
+- `DELETE /comments/{comment_id}`
+- `POST /comments/push`
 
-Implemented:
+`POST /comments/push` now means export the current DB-backed state to `.comments/comments.json`. It does not perform a Git push.
 
-- `backend/app/services/comments_url_service.py`
+### Helper URLs
 
-Updated:
+`GET /api/projects/{project_id}/comments/source-urls` returns helper URLs for external integration:
 
-- `backend/app/api/projects.py`
+- `list_url`
+- `patch_url_template`
+- `reply_url_template`
+- `delete_url_template`
 
-Key behavior:
+Base URL resolution priority:
+1. explicit `base_url` query parameter
+2. `COMMENTS_API_BASE_URL`
+3. request host and forwarded headers
 
-- `GET /api/projects/{project_id}/comments/source-urls` returns:
-  - `list_url`
-  - `patch_url_template`
-  - `reply_url_template`
-  - `delete_url_template`
-- Supports URL base resolution priority:
-  1. `base_url` query param
-  2. `COMMENTS_API_BASE_URL` env setting
-  3. incoming request host/protocol (including forwarded headers)
+## Frontend Behavior
 
-### 4) Startup initialization
+Current UI behavior includes:
+- import dialog shows comment-source helper URLs after import
+- visualizer exposes the same URLs through a persistent popover
+- users can copy list, patch, reply, and delete templates directly
+- export action is labeled `Generate JSON`
 
-Updated:
+## Hosting Notes
 
-- `backend/app/main.py`
+### LAN or remote access
 
-The comments DB is initialized at backend startup.
+If users or tools connect from another machine, helper URLs must resolve to a reachable backend host.
 
-### 5) Configuration
+Use either:
+- `COMMENTS_API_BASE_URL=http://reachable-host:8000`
+- or access the backend using the same host/IP that external clients will use, so request-derived URLs are correct
 
-Updated:
+### Repository workflow
 
-- `backend/app/core/config.py`
+After generating `.comments/comments.json`, use normal Git commands to stage, commit, and push the artifact if you want it versioned in the repository.
 
-Added/updated config:
+## Recommended Usage
 
-- `COMMENTS_API_BASE_URL` (optional)
-  - If set, helper URLs use this base (recommended for fixed LAN setups)
-  - If empty, backend derives base URL from request host/IP
-
-## Frontend Changes
-
-### 1) Import dialog URL helpers
-
-Updated:
-
-- `frontend/src/components/import-dialog.tsx`
-
-Now displays all four REST fields after import:
-
-- List URL
-- Patch URL Template
-- Reply URL Template
-- Delete URL Template
-
-### 2) Visualizer REST helper UX
-
-Updated:
-
-- `frontend/src/components/visualizer.tsx`
-
-Changes:
-
-- Replaced fragile hover tooltip with persistent popover UI
-- Added copy buttons for each URL field
-- Included reply URL template display
-
-### 3) Comment rendering and mode fixes
-
-Updated:
-
-- `frontend/src/components/visualizer.tsx`
-- `frontend/src/components/comment-overlay.tsx`
-- `frontend/src/components/comment-form.tsx`
-
-Fixes:
-
-- Correct SCH/PCB overlay filtering by active tab context
-- Prevent comment context drift when switching tabs
-- Keep comment-mode behavior consistent across tab changes
-- Ensure add-comment dialog appears above overlays (z-index layering fix)
-
-### 4) Export action naming
-
-Updated:
-
-- `frontend/src/components/visualizer.tsx`
-
-`Push Comments` action is now labeled `Generate JSON` and triggers artifact export only.
-
-## Operational Notes
-
-### LAN hosting behavior
-
-For users on other machines in the same network:
-
-- Set `COMMENTS_API_BASE_URL` to a reachable host (example: `http://192.168.1.42:8000`), or
-- Leave it empty and access backend via LAN IP so request-derived URL helpers are correct
-
-### Git workflow
-
-After pressing `Generate JSON`, use normal Git commands to stage/commit/push `.comments/comments.json` as needed.
-
-## Validation
-
-- Frontend build passes (`npm run build`)
-- Backend touched modules compile (`py_compile`)
-- Existing lint config issue remains unrelated (`eslint.config.js` recommended preset error)
+- use the web UI and SQLite store for normal collaboration
+- generate `.comments/comments.json` when you need a repository artifact for downstream tools or KiCad-side workflows
+- keep backend URL generation explicit with `COMMENTS_API_BASE_URL` when deploying behind LAN IPs, reverse proxies, or non-default hosts

--- a/docs/CUSTOM_PROJECT_NAMES.md
+++ b/docs/CUSTOM_PROJECT_NAMES.md
@@ -1,170 +1,105 @@
-# Custom Project Names Feature
+# Custom Project Names and Metadata
 
-## Overview
+KiCAD Prism supports project-level display metadata through `.prism.json` and related API endpoints.
 
-This feature allows users to set custom display names for their KiCAD projects that override the default folder names throughout the KiCAD-Prism interface.
+## What Is Configurable
 
-## How It Works
+Current project metadata fields include:
+- `project_name`: display name shown in the UI
+- `description`: project description shown in workspace and detail views
 
-### Backend Implementation
+These fields live alongside path mappings in `.prism.json`.
 
-1. **Extended `.prism.json` Schema**
-   - Added optional `project_name` field at the top level
-   - Maintains backward compatibility with existing files
+Example:
 
-2. **Path Config Service Updates**
-   - `PathConfig` model now includes `project_name: Optional[str]`
-   - `get_project_display_name()` function retrieves custom names
-   - `save_path_config()` handles both paths and project names
-
-3. **API Endpoints**
-   - `GET /api/projects/{id}/name` - Get current project name
-   - `PUT /api/projects/{id}/name` - Update project name
-   - Enhanced project listing to include `display_name` field
-
-4. **Project Service Integration**
-   - `get_registered_projects()` now includes custom names
-   - Monorepo structure API supports custom names
-   - Maintains fallback to folder names
-
-### Frontend Implementation
-
-1. **TypeScript Interfaces**
-   - `Project` interface includes `display_name?: string`
-   - `MonorepoProject` interface includes `display_name?: string`
-   - `PathConfig` interface includes `projectName?: string`
-
-2. **Component Updates**
-   - **Workspace**: Uses custom names in project cards and search
-   - **Project Cards**: Display custom names with fallback
-   - **Project Detail Page**: Shows custom name in title
-   - **Path Config Dialog**: Added project name editing field
-
-3. **API Integration**
-   - `project-name-api.ts` service for name management
-   - `project-name-editor.tsx` component for editing (standalone)
-   - Integrated name editing into existing Path Config Dialog
-
-## Usage
-
-### Setting Custom Names
-
-1. **Via Path Config Dialog** (Recommended)
-   - Open any project
-   - Click "Paths" button to open Project Settings
-   - Enter custom name in "Project Name" field
-   - Click "Save Configuration"
-
-2. **Via `.prism.json` File** (Manual)
-   ```json
-   {
-     "project_name": "My Custom Project Name",
-     "paths": {
-       "schematic": "*.kicad_sch",
-       "pcb": "*.kicad_pcb",
-       "designOutputs": "Design-Outputs",
-       "manufacturingOutputs": "Manufacturing-Outputs",
-       "documentation": "docs",
-       "thumbnail": "assets/thumbnail",
-       "readme": "README.md",
-       "jobset": "Outputs.kicad_jobset"
-     }
-   }
-   ```
-
-### Name Resolution Priority
-
-1. **Custom name** from `.prism.json` `project_name` field
-2. **KiCAD filename** for Type-2 imports (`.kicad_pro` filename)
-3. **Folder name** as fallback (existing behavior)
-4. **Repository name** for Type-1 imports
-
-## Features
-
-### Implemented Features
-
-- **Custom Project Names**: Set display names via `.prism.json`
-- **UI Integration**: Edit names through Path Config Dialog
-- **Search Support**: Custom names are searchable
-- **Monorepo Support**: Works with subprojects
-- **Backward Compatibility**: Existing projects unchanged
-- **Fallback System**: Graceful degradation to folder names
-- **Real-time Updates**: Changes reflect immediately
-
-### API Endpoints
-
-#### Get Project Name
-```http
-GET /api/projects/{project_id}/name
-```
-
-Response:
 ```json
 {
-  "display_name": "Custom Name",
-  "fallback_name": "folder-name"
+  "project_name": "Power Distribution Board",
+  "description": "48 V input board for lab power routing.",
+  "paths": {
+    "schematic": "board.kicad_sch",
+    "pcb": "board.kicad_pcb",
+    "designOutputs": "Design-Outputs",
+    "manufacturingOutputs": "Manufacturing-Outputs",
+    "documentation": "docs",
+    "thumbnail": "assets/thumbnail",
+    "readme": "README.md",
+    "jobset": "Outputs.kicad_jobset"
+  }
 }
 ```
 
-#### Update Project Name
+## Resolution Rules
+
+Display name resolution uses this order:
+1. `.prism.json` `project_name`
+2. imported project display name from registry
+3. project folder or repo-derived fallback name
+
+Description resolution uses this order:
+1. `.prism.json` `description`
+2. registry description
+3. backend fallback such as `Project <name>`
+
+## Primary API
+
+The main settings flow is the config endpoint:
+
+### Get effective config
+
 ```http
-PUT /api/projects/{project_id}/name
+GET /api/projects/{project_id}/config
+```
+
+Returns:
+- `config`: effective configuration, including `project_name` and `description`
+- `resolved`: resolved absolute paths
+- `source`: `explicit` or `auto-detected`
+
+### Update config
+
+```http
+PUT /api/projects/{project_id}/config
 Content-Type: application/json
 
 {
-  "display_name": "New Custom Name"
+  "project_name": "Power Distribution Board",
+  "description": "48 V input board for lab power routing.",
+  "schematic": "board.kicad_sch",
+  "pcb": "board.kicad_pcb"
 }
 ```
 
-Response:
-```json
-{
-  "display_name": "New Custom Name",
-  "message": "Project name updated successfully"
-}
+This is the preferred path for project settings because it updates metadata and path mapping together.
+
+## Compatibility Endpoints
+
+Separate name endpoints still exist for compatibility:
+
+```http
+GET /api/projects/{project_id}/name
+PUT /api/projects/{project_id}/name
 ```
 
+They remain useful for narrow integrations, but the main UI now prefers the config endpoint.
 
-## Migration Notes
+## UI Behavior
 
-### For Existing Projects
-- No action required - projects continue to work with folder names
-- Custom names are completely optional
+Current frontend behavior:
+- workspace cards and search use `display_name` when present
+- project detail header uses the resolved display name from project detail/overview payloads
+- project settings dialog edits `project_name`, `description`, and paths together
 
-### For New Projects
-- Consider adding `project_name` to `.prism.json` during project setup
-- Use descriptive names for better project identification
+## Why Explicit Metadata Helps
 
-## Troubleshooting
+Using `.prism.json` metadata has two practical benefits:
+- clearer labels for monorepo subprojects and imported repos
+- less ambiguity when several folders have similar technical filenames
 
-### Common Issues
+It also avoids relying on inferred names from repository structure alone.
 
-1. **Custom name not showing**
-   - Check `.prism.json` syntax
-   - Verify `project_name` field is at top level
-   - Refresh project page
+## Recommendations
 
-2. **Name not persisting**
-   - Ensure Path Config Dialog saves successfully
-   - Check file permissions on project directory
-   - Verify backend API responses
-
-3. **Search not working**
-   - Clear browser cache
-   - Check frontend build includes latest changes
-   - Verify API returns display names
-
-## Future Enhancements
-
-### Potential Improvements
-- [ ] Bulk rename projects
-- [ ] Project name templates
-- [ ] Name validation rules
-- [ ] Import/export project names
-- [ ] Name history/undo functionality
-
----
-
-**Version**: 1.0  
-**Last Updated**: 2025-02-09  
-**Compatible**: KiCAD-Prism v0.0.0+
+- set `project_name` for any project whose folder name is not presentation-friendly
+- keep `description` short and task-oriented so workspace search remains useful
+- treat `.prism.json` as the canonical place for project-specific display metadata

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,190 +1,273 @@
 # Deployment Guide
 
-This guide provides instructions for setting up KiCAD Prism. The **easiest and recommended** way is using Docker.
+This document covers the current KiCAD Prism deployment model for Docker hosting and local development.
 
----
+## Runtime Overview
 
-## 1. Quick Start: Docker Deployment (Recommended)
+KiCAD Prism runs as two services:
 
-Docker packages both the frontend and the backend (with `kicad-cli` v9 pre-installed) into a portable environment. This works on Windows, macOS (including Apple Silicon), and Linux.
+- `backend`: FastAPI API server on port `8000`
+- `frontend`: production Vite bundle served by Nginx on port `8080`
+
+In Docker, the frontend proxies `/api/*` requests to the backend over the Compose network.
+
+Default local endpoints:
+- UI: [http://127.0.0.1:8080](http://127.0.0.1:8080)
+- API: [http://127.0.0.1:8000](http://127.0.0.1:8000)
+
+## Docker Hosting
 
 ### Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
+- Docker Engine or Docker Desktop
+- Docker Compose support
+- enough disk space for imported repositories and generated outputs
 
-### Installation
+### 1. Clone the repository
 
 ```bash
-# 1. Clone the repository
 git clone https://github.com/krishna-swaroop/KiCAD-Prism.git
 cd KiCAD-Prism
-
-# 2. Start the platform
-docker compose up -d --build
 ```
 
-> `docker compose up -d` will automatically build the images the first time. Using the `--build` flag ensures that any local changes to the `Dockerfile` or source code are re-built into the images.
+### 2. Create the root `.env`
 
-Access the UI at: **`http://localhost`**
-
-### Volume Mapping & Persistence
-
-By default, Docker creates a `data` directory in the repository root to store persistent data:
-
-- **`./data/projects`**: This is where your KiCAD repositories are stored.
-- **Data Survival**: Your projects remain available even if you stop or update the containers.
-- **Manual Import**: You can clone existing KiCAD project repositories into `./data/projects` on your host machine, and they will appear in the dashboard.
-
----
-
-## 2. Environment Configuration
-
-For Docker deployments, you **must** create a `.env` file in the **root directory** of the project (where `docker-compose.yml` is located).
-
-### Example .env File
-
-Place this at the root of the `KiCAD-Prism/` directory:
+Docker Compose reads the repository root `.env` automatically.
 
 ```bash
-# --- .env (Project Root) ---
+cp .env.example .env
+```
 
-# [AUTH] Force authentication toggle
-# Set to 'false' for public gallery mode
+Baseline authenticated configuration:
+
+```env
+WORKSPACE_NAME=KiCAD Prism
 AUTH_ENABLED=true
-
-# [AUTH] Google OAuth Configuration
-GOOGLE_CLIENT_ID=your-id.apps.googleusercontent.com
-
-# [AUTH] Access Control
-ALLOWED_DOMAINS_STR=yourcompany.com
-ALLOWED_USERS_STR=admin@yourcompany.com
-
-# [CONFIG] Development Mode
-# Set to 'false' for production (enforces login)
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+SESSION_SECRET=replace-with-a-long-random-secret
+SESSION_TTL_HOURS=12
+SESSION_COOKIE_SECURE=false
+ALLOWED_USERS_STR=
+ALLOWED_DOMAINS_STR=
+BOOTSTRAP_ADMIN_USERS_STR=admin@example.com
+GITHUB_TOKEN=
 DEV_MODE=false
-
-# [GIT] Private Repository Access (Optional)
-# Enter your GitHub Personal Access Token (classic) to enable 
-# sync and import for private repositories. Note: This is an 
-# optional override; SSH keys are the recommended way for 
-# private repository access.
-GITHUB_TOKEN=ghp_your_secret_token_here
 ```
 
-### Accessing Private/Organizational Repos
+Generate a session secret with:
 
-If you need KiCAD Prism to interact with private repositories:
-
-1. Generate a **Personal Access Token (classic)** on GitHub with the `repo` scope.
-2. If using an Organizational repo, ensure you click **"Configure SSO"** next to the token and authorize your organization.
-3. Add the token to your `.env` as shown above.
-4. Restart your containers: `docker compose up -d`.
-
-The backend will automatically configure Git to use this token for all `https://github.com` operations.
-
----
-
-## 3. Multi-Provider Git Support (GitLab, Bitbucket, etc.)
-
-KiCAD Prism is provider-agnostic. While it has dedicated support for GitHub Tokens, it also supports **SSH Keys**, which is the recommended way to interact with GitLab, Bitbucket, or self-hosted Git instances.
-
-### Using the SSH Setup Wizard (Recommended)
-
-1. Open the KiCAD Prism UI and go to the **Workspace**.
-2. Click the **Settings (Gear icon)** in the top right.
-3. Under the **Git & SSH** tab, if no key is present, click **Generate New SSH Key**.
-4. Copy the generated **Public Key**.
-5. Add this key to your Git provider (e.g., GitHub Settings -> SSH and GPG keys -> New SSH Key).
-6. You can now import projects using SSH URLs (e.g., `git@github.com:user/repo.git`).
-
-### Manual Docker Configuration for SSH
-
-To ensure your SSH keys persist across container restarts, you must mount a volume for the `.ssh` directory in your `docker-compose.yml`:
-
-```yaml
-services:
-  backend:
-    volumes:
-      - ./data/ssh:/root/.ssh:rw
+```bash
+python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
 ```
 
-> [IMPORTANT]
-> The setup wizard requires the volume to be mapped with read-write (`:rw`) permissions so it can generate and store the keys.
+Important:
+- `SESSION_SECRET` is required whenever auth is effectively enabled.
+- `SESSION_COOKIE_SECURE=true` should be used only behind HTTPS.
+- `DEV_MODE` should stay `false` in Docker hosting.
 
----
+### 3. Start the stack
 
-## 4. Local Development (Manual Setup)
+```bash
+docker compose up --build -d
+```
 
-If you want to contribute to the code or run without Docker, follow these steps.
+Open the UI at [http://127.0.0.1:8080](http://127.0.0.1:8080).
 
-### Prerequisites
+### 4. Stop the stack
 
-1. **Python 3.10+**
-2. **Node.js v18+ & NPM**
-3. **KiCAD 9.0** (with `kicad-cli` in your PATH)
+```bash
+docker compose down
+```
 
-### Backend Setup
+## Docker Volumes and Persistence
+
+Current Compose mounts:
+
+- `./data/projects` -> `/app/projects`
+- `./data/ssh` -> `/root/.ssh`
+
+Persisted data includes:
+- imported repositories
+- `.project_registry.json`
+- `.rbac_roles.json`
+- `.folders.json`
+- exported comments JSON inside repos when generated
+- SSH keys and `known_hosts`
+
+## Authentication Modes
+
+### Guest Mode
+
+```env
+AUTH_ENABLED=false
+GOOGLE_CLIENT_ID=
+SESSION_SECRET=
+DEV_MODE=false
+```
+
+Behavior:
+- login wall is disabled
+- backend serves a guest viewer session
+- write operations still require privileged roles, so this mode is best for public read-only use
+
+### Google Login + Session Auth
+
+```env
+AUTH_ENABLED=true
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+SESSION_SECRET=your-random-secret
+DEV_MODE=false
+```
+
+Behavior:
+- frontend shows the Google sign-in screen
+- backend verifies the Google ID token
+- backend issues an `HttpOnly` signed session cookie
+- RBAC role resolution uses stored assignments plus bootstrap admins
+
+### Local Dev Bypass
+
+```env
+AUTH_ENABLED=true
+GOOGLE_CLIENT_ID=
+SESSION_SECRET=
+DEV_MODE=true
+```
+
+Behavior:
+- auth is effectively disabled because the backend only enables auth when `AUTH_ENABLED=true`, `GOOGLE_CLIENT_ID` is set, and `DEV_MODE=false`
+- this is convenient for local backend/frontend development
+
+## Google OAuth Setup
+
+Create a Google OAuth client of type "Web application" and add the frontend origins you actually use.
+
+Typical origins:
+- local frontend dev: `http://127.0.0.1:5173`
+- local Docker frontend: `http://127.0.0.1:8080`
+- production: `https://your-domain.example`
+
+Use the client ID value in `GOOGLE_CLIENT_ID`.
+
+If your production deployment is HTTPS, also set:
+
+```env
+SESSION_COOKIE_SECURE=true
+```
+
+## Private Repository Access
+
+KiCAD Prism supports two normal approaches.
+
+### SSH
+
+Recommended for long-lived hosted deployments.
+
+- SSH material persists under `./data/ssh`
+- backend startup ensures `~/.ssh` exists and scans common Git hosts into `known_hosts`
+- add the generated or mounted public key to your Git host account
+
+### GitHub Personal Access Token
+
+If you use HTTPS cloning for private GitHub repositories, set:
+
+```env
+GITHUB_TOKEN=your_token_here
+```
+
+The backend configures Git URL rewriting at startup so GitHub HTTPS operations can use the token.
+
+## Local Development Hosting
+
+### Backend
 
 ```bash
 cd backend
-python -m venv venv
-source venv/bin/activate  # Windows: venv\Scripts\activate
+python3 -m venv venv
+source venv/bin/activate
 pip install -r requirements.txt
-
-# Create backend .env
-cp .env.example .env
-
-# Run server
 uvicorn app.main:app --reload --port 8000
 ```
 
-### Frontend Setup
+Notes:
+- backend settings also support a backend-local `.env`
+- if nothing is configured, local dev defaults generally keep auth off because `DEV_MODE=true`
+
+### Frontend
 
 ```bash
 cd frontend
 npm install
-
-# Create frontend .env
-cp .env.example .env
-
-# Run dev server
 npm run dev
 ```
 
-> **Note**: For local development, `.env` files must be placed inside the `backend/` and `frontend/` directories respectively.
+Frontend dev URL:
+- [http://127.0.0.1:5173](http://127.0.0.1:5173)
 
----
+## Operational Notes
 
-## 5. Authentication Setup (Google OAuth)
+### Rebuild after env or frontend changes
 
-KiCAD Prism supports optional Google Sign-in with domain restrictions.
+```bash
+docker compose up --build -d
+```
 
-### Configuring Google Cloud
+### Inspect logs
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com/)
-2. Create an **OAuth 2.0 Client ID** (Web application type)
-3. Add these Authorized JavaScript Origins:
-   - Development: `http://localhost:5173`
-   - Production/Docker: `http://localhost`
-4. Copy the **Client ID** to your `.env` file.
+```bash
+docker compose logs --tail=100 frontend
+docker compose logs --tail=100 backend
+```
 
-### Configuration Modes
+### Session behavior
 
-| Mode | Behavior | Configuration |
-|------|----------|---------------|
-| **Public Gallery** | No login required | `AUTH_ENABLED=false` |
-| **Development** | Login with "Dev Bypass" | `DEV_MODE=true` |
-| **Production** | Strict Google Login | `DEV_MODE=false` |
+- changing `SESSION_SECRET` invalidates all existing sessions
+- secure cookies require HTTPS and will not work correctly on plain HTTP if `SESSION_COOKIE_SECURE=true`
 
----
+## Troubleshooting
 
-## 6. Troubleshooting
+### Blank page with frontend bundle errors
 
-| Issue | Solution |
-| :--- | :--- |
-| **Docker pull fails** | Check your internet connection and ensure you are using the correct image tag (e.g., `kicad/kicad:9.0.0-arm64` for Mac M1/M2). |
-| **Visual Diff Empty** | Check `docker logs kicad-prism-backend` to ensure `kicad-cli` is running correctly. |
-| **Persistence Issues** | Ensure the `./data/projects` folder has write permissions for the Docker user. |
-| **Auth Rejection** | Verify that `GOOGLE_CLIENT_ID` matches in both backend and frontend configs. |
-| **Sync Fails** | Ensure the server/container has network access to the remote Git repository. |
+If the browser shows a blank page, open DevTools and check the first JavaScript error.
+
+A previously observed production issue came from unsafe manual chunk splitting. If a bundle regression returns, rebuild and verify that:
+- `/assets/index-*.js` loads successfully
+- `/api/auth/config` returns `200`
+- the first console error is captured before reloading again
+
+### `SESSION_SECRET is not configured`
+
+Cause:
+- auth is enabled but `SESSION_SECRET` is empty
+
+Fix:
+- set `SESSION_SECRET` in the root `.env`
+- rebuild/restart the stack
+
+### Google sign-in not appearing
+
+Check:
+- `AUTH_ENABLED=true`
+- `GOOGLE_CLIENT_ID` is set
+- `DEV_MODE=false`
+- browser origin is listed in the Google OAuth configuration
+
+### Login works but API requests fail after deploy
+
+Check:
+- `SESSION_COOKIE_SECURE` matches your transport mode
+- HTTPS termination is configured correctly if using secure cookies
+- browser is not blocking cookies for the deployed origin
+
+### Imported repositories disappear after restart
+
+Check that `./data/projects` is mounted and writable on the host.
+
+## Related Docs
+
+- [../README.md](../README.md)
+- [./KICAD-PRJ-REPO-STRUCTURE.md](./KICAD-PRJ-REPO-STRUCTURE.md)
+- [./PATH-MAPPING.md](./PATH-MAPPING.md)

--- a/docs/ECAD_VIEWER_SYNC_NOTES.md
+++ b/docs/ECAD_VIEWER_SYNC_NOTES.md
@@ -1,9 +1,26 @@
 # ecad-viewer Sync Notes
 
-- Date: 2026-02-27
-- Synced upstream ref: `origin/main`
-- Upstream commit used for this Prism refactor: `a85abd4`
-- Vendored artifacts updated:
-  - `frontend/public/ecad-viewer.js`
-  - `frontend/public/glyph-full.js`
-  - `frontend/public/3d-viewer.js`
+This document tracks the current upstream sync reference for the vendored visualizer assets.
+
+## Current Reference
+
+- sync date: 2026-02-27
+- upstream ref used for the Prism vendor refresh: `origin/main`
+- upstream commit used for the current refactor baseline: `a85abd4`
+
+## Vendored Artifacts
+
+The current sync updated:
+- `frontend/public/ecad-viewer.js`
+- `frontend/public/glyph-full.js`
+- `frontend/public/3d-viewer.js`
+
+## Scope Notes
+
+Visualizer code is intentionally treated as a higher-risk surface than the rest of the app.
+
+That means:
+- general frontend cleanup should avoid changing vendored visualizer assets unless the task is explicitly a visualizer/vendor sync
+- performance or bundle work outside the visualizer should isolate viewer-specific chunks rather than rewriting the viewer surface itself
+
+If you need to update visualizer behavior, treat it as a dedicated task with explicit validation.

--- a/docs/KICAD-PRJ-REPO-STRUCTURE.md
+++ b/docs/KICAD-PRJ-REPO-STRUCTURE.md
@@ -1,77 +1,89 @@
 # KiCAD Project Repository Structure
 
-To ensure full compatibility with the KiCAD-Prism platform (including visualizers and automated workflows), board project repositories should follow this standardized folder layout.
+KiCAD Prism works with flexible repository layouts, but projects are easiest to operate when a few conventions are followed.
 
-## Root Directory
+This document describes the recommended layout, not a hard requirement. If your repo differs, use `.prism.json` path mapping as described in [PATH-MAPPING.md](./PATH-MAPPING.md).
 
-| File/Folder | Purpose |
-|--------------|----------|
-| `BoardName.kicad_pro` | Main KiCAD project file |
-| `BoardName.kicad_sch` | Root schematic file |
-| `BoardName.kicad_pcb` | PCB layout file |
-| `Outputs.kicad_jobset` | **Required** for KiCAD Prism Workflows View |
-| `README.md` | Board overview and specifications |
-| `Subsheets/` | Directory for all hierarchical schematic subsheets |
-| `assets/` | Images and renders for documentation |
-| `docs/` | Board datasheets, ICDs, and test guides |
-| `simulation/` | Simulation files and results |
+## Recommended Root Contents
 
----
+| File or Folder | Purpose |
+| --- | --- |
+| `BoardName.kicad_pro` | Main KiCad project file |
+| `BoardName.kicad_sch` | Root schematic |
+| `BoardName.kicad_pcb` | PCB layout |
+| `Outputs.kicad_jobset` | Workflow definition used by KiCAD Prism jobs |
+| `README.md` | Project overview shown in the Overview tab |
+| `Subsheets/` | Optional schematic subsheets |
+| `docs/` | Optional markdown documentation tree |
+| `assets/` | Images, thumbnails, renders |
+| `Design-Outputs/` | Generated design artifacts |
+| `Manufacturing-Outputs/` | Generated fabrication artifacts |
 
-## Repository Structure Visualization
+## Recommended Example Layout
 
 ```text
 Board-Project-Repo/
-├── BoardName.kicad_pro       # Main project file
-├── BoardName.kicad_sch       # Root schematic
-├── BoardName.kicad_pcb       # PCB layout
-├── Outputs.kicad_jobset        # Workflow configuration
-├── README.md                   # Documentation hub
-├── Subsheets/                  # All secondary schematic files
-│   └── sheet_name.kicad_sch
-├── assets/                     # Visual assets (renders, images)
-│   ├── images.png
-│   ├── renders/Top-View.png
-│   ├── renders/Bottom-View.png
-│   └── thumbnail/BoardName-Blender-Render.png # Used as Project thumbnail in KiCAD Prism
-├── docs/                       # Project documentation (ICDs, Bring-up logs)
-├── simulation/                 # Simulation files (SPICE, etc.)
-├── Design-Outputs/             # Auto-generated reference outputs (Workflows)
+├── BoardName.kicad_pro
+├── BoardName.kicad_sch
+├── BoardName.kicad_pcb
+├── Outputs.kicad_jobset
+├── README.md
+├── Subsheets/
+│   └── power-sheet.kicad_sch
+├── assets/
+│   ├── images/
+│   ├── renders/
+│   └── thumbnail/
+├── docs/
+│   ├── bringup.md
+│   └── manufacturing-notes.md
+├── Design-Outputs/
 │   ├── BoardName.pdf
-│   ├── 3DModel/BoardName.glb
-│   ├── 3DModel/BoardName.step
 │   ├── BoardName_iBoM.html
-│   ├── BoardName.pdf
-│   ├── BoardName.csv
-│   └── BoardName.net
-│   
-└── Manufacturing-Outputs/      # Auto-generated fabrication outputs (Workflows)
+│   └── 3DModel/
+└── Manufacturing-Outputs/
     ├── Gerbers/
-    └── BOM/
+    ├── BOM/
+    └── XY-Data/
 ```
 
-## Sub-Directories
+## How KiCAD Prism Uses These Paths
 
-### `Subsheets/`
+- Overview tab reads `README.md` or another configured readme path
+- Documentation tab reads the configured docs directory recursively
+- Assets and downloads surfaces read configured design/manufacturing output directories
+- workflow jobs look for the configured jobset file
+- thumbnails are resolved from the configured thumbnail directory
 
-Contains all hierarchical schematic pages (`.kicad_sch`) except for the root schematic. This keeps the root directory clean and allows KiCAD Prism to find subsheets automatically.
+## Flexible Layout Support
 
-### `Design-Outputs/`
+KiCAD Prism does not require this exact shape.
 
-This folder is automatically managed by the **Workflows** feature in KiCAD Prism. It typically contains:
+If your repository uses different names, define them in `.prism.json`, for example:
 
-- `BoardName.pdf`: Full schematic PDF.
-- `BoardName_iBoM.html`: Interactive BOM.
-- `3DModel/BoardName.step`: PCB 3D model.
+```json
+{
+  "paths": {
+    "schematic": "hardware/main.kicad_sch",
+    "pcb": "hardware/main.kicad_pcb",
+    "documentation": "wiki",
+    "designOutputs": "out/design",
+    "manufacturingOutputs": "out/mfg",
+    "thumbnail": "media/thumbs",
+    "readme": "docs/overview.md",
+    "jobset": "ci/Outputs.kicad_jobset"
+  }
+}
+```
 
-### `Manufacturing-Outputs/`
+## Recommendations for Smooth Operation
 
-This folder is also managed by the **Workflows** feature and contains fabrication-ready files:
+- keep one clear root schematic and one clear PCB path per project
+- store generated outputs in stable directories so users know where to find artifacts
+- keep documentation in markdown if you want it rendered directly in the UI
+- put thumbnail images in a dedicated subdirectory so selection is predictable
+- use `.prism.json` instead of relying on auto-detection when a repo is non-standard
 
-- `Gerbers/`: Gerber and drill files.
-- `BOM/`: Precise manufacturing BOMs.
-- `XY-Data/`: Pick-and-place files.
+## Monorepos
 
-### `docs/`
-
-This folder is managed by the **Documentation** feature in KiCAD Prism. Typically contains markdown files detailing various aspects of the board.
+For monorepo imports, each discovered subproject should still have a coherent local structure. Explicit `.prism.json` files for subprojects are especially useful because they remove ambiguity and reduce path auto-detection work.

--- a/docs/PATH-MAPPING.md
+++ b/docs/PATH-MAPPING.md
@@ -1,250 +1,129 @@
-# KiCAD Prism Path Mapping System
+# Path Mapping and `.prism.json`
 
-## Overview
+KiCAD Prism supports both convention-based repository layouts and explicit path configuration.
 
-KiCAD Prism now supports **flexible folder structures** for your KiCAD projects. You no longer need to follow a strict directory layout - the platform can auto-detect your project structure or you can explicitly configure paths via a `.prism.json` file.
+## Why `.prism.json` Exists
 
-## How It Works
+Without explicit config, the backend has to inspect the repository and infer where files live. That works for common layouts, but it is slower and less predictable on unusual repos or monorepos.
 
-Path resolution follows this priority order:
+A complete `.prism.json` gives you:
+- deterministic file resolution
+- less path auto-detection work
+- clearer project metadata
+- fewer surprises when importing or syncing repositories
 
-1. **Explicit `.prism.json`** - If present in project root, use configured paths
-2. **Auto-detection** - Scan repository and infer structure based on common patterns
-3. **Fallback defaults** - Use legacy hardcoded paths (Design-Outputs/, docs/, etc.)
+## Resolution Order
 
-## Configuration File
+Current path resolution follows this order:
+1. explicit `.prism.json`
+2. auto-detection for missing fields
+3. fallback legacy defaults where applicable
 
-Create a `.prism.json` file in your project root to explicitly define paths:
+A key current behavior is that explicit fields are honored first, and only missing fields are auto-detected.
+
+## Supported Fields
+
+Top-level metadata:
+- `project_name`
+- `description`
+- `workflows`
+
+Path fields:
+- `schematic`
+- `pcb`
+- `subsheets`
+- `designOutputs`
+- `manufacturingOutputs`
+- `documentation`
+- `thumbnail`
+- `readme`
+- `jobset`
+
+## Example
 
 ```json
 {
+  "project_name": "Flight Controller Rev B",
+  "description": "Main avionics control board.",
   "paths": {
-    "schematic": "*.kicad_sch",
-    "pcb": "*.kicad_pcb",
-    "subsheets": "Subsheets",
+    "schematic": "hardware/fc.kicad_sch",
+    "pcb": "hardware/fc.kicad_pcb",
+    "subsheets": "hardware/subsheets",
     "designOutputs": "outputs/design",
     "manufacturingOutputs": "outputs/manufacturing",
-    "documentation": "documentation",
+    "documentation": "docs",
     "thumbnail": "assets/thumbnail",
     "readme": "README.md",
-    "jobset": "project.kicad_jobset"
+    "jobset": "Outputs.kicad_jobset"
   }
 }
 ```
 
-### Path Options
-
-| Option | Description | Example |
-|--------|-------------|---------|
-| `schematic` | Main schematic file (glob pattern supported) | `*.kicad_sch` |
-| `pcb` | PCB layout file (glob pattern supported) | `*.kicad_pcb` |
-| `subsheets` | Directory containing hierarchical schematic sheets | `Subsheets` |
-| `designOutputs` | Directory for design outputs (PDFs, 3D models, etc.) | `Design-Outputs` |
-| `manufacturingOutputs` | Directory for manufacturing files (Gerbers, BOMs) | `Manufacturing-Outputs` |
-| `documentation` | Directory for project documentation | `docs` |
-| `thumbnail` | Directory containing project thumbnail images | `assets/thumbnail` |
-| `readme` | README file name | `README.md` |
-| `jobset` | KiCAD jobset file for workflows | `Outputs.kicad_jobset` |
-
-## Auto-Detection
-
-If no `.prism.json` exists, KiCAD Prism will automatically detect your project structure by:
-
-- **Schematic/PCB**: Finds `.kicad_sch` and `.kicad_pcb` files in root
-- **Subsheets**: Looks for directories named `*sheet*`, `*schematic*`, `pages/`, etc. containing `.kicad_sch` files
-- **Design Outputs**: Searches for `*output*`, `*export*`, `*build*`, `*dist*` directories with PDFs/3D models
-- **Manufacturing Outputs**: Searches for `*gerber*`, `*fab*`, `*mfg*`, `*manufacturing*` directories
-- **Documentation**: Searches for `*doc*`, `*wiki*`, `*guide*`, `*manual*` directories with markdown files
-- **Thumbnail**: Searches for `*assets*`, `*images*`, `*renders*`, `*thumbnail*` directories with images
-
 ## API Endpoints
 
-### Get Current Configuration
+### Get effective config
 
 ```http
 GET /api/projects/{project_id}/config
 ```
 
-Returns the current path configuration and resolved absolute paths.
+Returns:
+- `config`: effective path and metadata config
+- `resolved`: resolved absolute paths
+- `source`: `explicit` or `auto-detected`
 
-### Detect Paths (Preview)
+### Preview auto-detection
 
 ```http
 POST /api/projects/{project_id}/detect-paths
 ```
 
-Runs auto-detection and returns detected paths without saving them. Useful for previewing what would be detected.
+Returns a detected config plus validation without writing `.prism.json`.
 
-### Update Configuration
+### Save config
 
 ```http
 PUT /api/projects/{project_id}/config
 Content-Type: application/json
 
 {
-  "paths": {
-    "schematic": "*.kicad_sch",
-    "pcb": "*.kicad_pcb",
-    "documentation": "docs"
-  }
+  "project_name": "Flight Controller Rev B",
+  "description": "Main avionics control board.",
+  "schematic": "hardware/fc.kicad_sch",
+  "pcb": "hardware/fc.kicad_pcb",
+  "documentation": "docs"
 }
 ```
 
-Saves the configuration to `.prism.json` in the project root.
+Saving config writes `.prism.json` in the project root.
 
-## Examples
+## Auto-Detection Heuristics
 
-### Example 1: Flat Structure
+If you do not provide a `.prism.json`, KiCAD Prism looks for common patterns such as:
+- root `.kicad_sch` and `.kicad_pcb` files
+- common docs folders like `docs`, `documentation`, `wiki`
+- common output folders like `Design-Outputs`, `Manufacturing-Outputs`, `outputs`, `exports`
+- common thumbnail/image directories under `assets`, `images`, or `renders`
+- README-like files such as `README*` or `OVERVIEW*`
 
-```
-my-project/
-├── main.kicad_pro
-├── main.kicad_sch
-├── main.kicad_pcb
-├── sheet1.kicad_sch
-├── sheet2.kicad_sch
-├── README.md
-└── outputs/
-    ├── schematic.pdf
-    ├── pcb.step
-    └── gerbers/
-        ├── board.gbr
-        └── drill.drl
-```
+## Recommendations
 
-`.prism.json`:
-```json
-{
-  "paths": {
-    "schematic": "main.kicad_sch",
-    "pcb": "main.kicad_pcb",
-    "designOutputs": "outputs",
-    "manufacturingOutputs": "outputs/gerbers"
-  }
-}
-```
+- use explicit config for monorepos or non-standard layouts
+- set `readme` and `documentation` explicitly if your documentation is not under `README.md` and `docs/`
+- keep output directories stable across workflow runs
+- store project metadata and path mapping together in `.prism.json`
 
-### Example 2: KiCAD Default Structure
+## Validation and Troubleshooting
 
-```
-my-project/
-├── my-project.kicad_pro
-├── my-project.kicad_sch
-├── my-project.kicad_pcb
-├── my-project.kicad_jobset
-├── README.md
-├── subsheets/
-│   ├── power.kicad_sch
-│   └── mcu.kicad_sch
-├── manufacturing/
-│   ├── gerbers/
-│   └── bom/
-└── exports/
-    ├── schematic.pdf
-    └── step/
-```
+If a file is not showing up where expected:
+1. call `GET /api/projects/{project_id}/config`
+2. inspect `resolved` paths
+3. run `POST /api/projects/{project_id}/detect-paths` to compare inferred values
+4. save an explicit `.prism.json` if the repo layout is unusual
 
-`.prism.json`:
-```json
-{
-  "paths": {
-    "schematic": "my-project.kicad_sch",
-    "pcb": "my-project.kicad_pcb",
-    "subsheets": "subsheets",
-    "designOutputs": "exports",
-    "manufacturingOutputs": "manufacturing",
-    "jobset": "my-project.kicad_jobset"
-  }
-}
-```
+For schematic and PCB fields, glob-like values are supported where the backend expects them, but explicit file paths are usually the least ambiguous option.
 
-### Example 3: Documentation-Heavy Project
+## Related Docs
 
-```
-my-project/
-├── board.kicad_pro
-├── board.kicad_sch
-├── board.kicad_pcb
-├── README.md
-├── wiki/
-│   ├── getting-started.md
-│   ├── hardware-guide.md
-│   └── troubleshooting.md
-└── releases/
-    └── v1.0/
-        ├── production_files/
-        └── design_files/
-```
-
-`.prism.json`:
-```json
-{
-  "paths": {
-    "schematic": "board.kicad_sch",
-    "pcb": "board.kicad_pcb",
-    "documentation": "wiki",
-    "designOutputs": "releases/v1.0/design_files",
-    "manufacturingOutputs": "releases/v1.0/production_files"
-  }
-}
-```
-
-## Migration from Legacy Structure
-
-If you have existing projects using the legacy KiCAD-Prism structure, they will continue to work without any changes. The auto-detection recognizes the standard folder names:
-
-- `Design-Outputs/` → `designOutputs`
-- `Manufacturing-Outputs/` → `manufacturingOutputs`
-- `docs/` → `documentation`
-- `Subsheets/` → `subsheets`
-- `assets/thumbnail/` → `thumbnail`
-
-To migrate to explicit configuration, simply run the auto-detection endpoint and save the results:
-
-```bash
-# Preview what would be detected
-curl -X POST /api/projects/{id}/detect-paths
-
-# Save the detected configuration
-curl -X PUT /api/projects/{id}/config \
-  -H "Content-Type: application/json" \
-  -d '{"schematic": "*.kicad_sch", "pcb": "*.kicad_pcb", ...}'
-```
-
-## Troubleshooting
-
-### Files Not Found
-
-If KiCAD Prism reports files not found:
-
-1. Check the auto-detected paths via `GET /api/projects/{id}/config`
-2. Run `POST /api/projects/{id}/detect-paths` to see what was detected
-3. Create a `.prism.json` file with explicit paths if auto-detection failed
-
-### Path Validation
-
-When updating configuration, the API validates paths against the actual filesystem:
-
-- **Valid paths** are resolved to absolute paths
-- **Missing paths** return warnings (for glob patterns)
-- **Invalid paths** return errors (for explicit paths that don't exist)
-
-### Glob Patterns
-
-For `schematic` and `pcb` fields, you can use glob patterns:
-
-- `*.kicad_sch` - Match any .kicad_sch file in root
-- `project*.kicad_sch` - Match files starting with "project"
-- `**/*.kicad_sch` - Match recursively (first match is used)
-
-## Backward Compatibility
-
-This system is fully backward compatible:
-
-- Existing projects without `.prism.json` continue to work
-- Default paths match the legacy structure
-- No migration required unless you want explicit control
-
----
-
-For more information, see the [KiCAD-Prism Repository Structure](./KICAD-PRJ-REPO-STRUCTURE.md) document.
+- [./KICAD-PRJ-REPO-STRUCTURE.md](./KICAD-PRJ-REPO-STRUCTURE.md)
+- [./CUSTOM_PROJECT_NAMES.md](./CUSTOM_PROJECT_NAMES.md)

--- a/docs/WORKSPACE_UX_IMPROVEMENTS.md
+++ b/docs/WORKSPACE_UX_IMPROVEMENTS.md
@@ -1,157 +1,80 @@
-# Workspace UX Improvements
+# Workspace Behavior Notes
 
-This document describes the UX improvements made to the KiCAD-Prism workspace component.
+This document summarizes the current workspace behavior in KiCAD Prism rather than a historical changelog.
 
-## Overview
+## Current Workspace Data Flow
 
-Four key improvements were implemented to enhance the user experience:
+The workspace now boots from a single internal endpoint:
 
-1. Monorepo Structure Caching
-2. Fuzzy Search
-3. Search Result Highlighting
-4. Improved Delete Error Handling
-
----
-
-## 1. Monorepo Structure Caching
-
-**Problem:** Every folder navigation in a monorepo triggered a new API call, even for previously visited folders.
-
-**Solution:** Added an in-memory cache using a `Map<string, MonorepoStructure>` to store fetched folder structures.
-
-**Implementation:**
-
-```typescript
-const [structureCache, setStructureCache] = useState<Map<string, MonorepoStructure>>(new Map());
-
-// In useEffect:
-const cacheKey = `${selectedMonorepo}:${subpath}`;
-if (structureCache.has(cacheKey)) {
-  setMonorepoStructure(structureCache.get(cacheKey)!);
-  return;
-}
-// Otherwise fetch and add to cache
+```http
+GET /api/workspace/bootstrap
 ```
 
-**Cache Invalidation:**
+Response shape:
 
-- Cache is cleared when a project is deleted
-- Cache is scoped to the component lifecycle (clears on unmount)
-
----
-
-## 2. Fuzzy Search with Fuse.js
-
-**Problem:** The original search used exact substring matching, which failed for typos or partial matches.
-
-**Solution:** Replaced server-side search with client-side Fuse.js fuzzy search.
-
-**Dependencies Added:**
-
-```bash
-npm install fuse.js
-```
-
-**Configuration:**
-
-```typescript
-const fuse = useMemo(() => {
-  return new Fuse(projects, {
-    keys: [
-      { name: "name", weight: 2 },
-      { name: "display_name", weight: 2 },
-      { name: "description", weight: 1 },
-      { name: "parent_repo", weight: 0.5 }
-    ],
-    threshold: 0.4,  // Lower = stricter matching
-    includeScore: true,
-    ignoreLocation: true,
-  });
-}, [projects]);
-```
-
-**Benefits:**
-
-- Typo tolerance (e.g., "usb-pg" matches "USB-PD")
-- Weighted search (name matches rank higher)
-- Faster response (150ms debounce vs 300ms for server-side)
-
----
-
-## 3. Search Result Highlighting
-
-**Problem:** Users couldn't see why a result matched their query.
-
-**Solution:** Added a `highlightMatch()` function that wraps matched text in a `<mark>` element.
-
-**Implementation:**
-
-```typescript
-function highlightMatch(text: string, query: string): React.ReactNode {
-  if (!query.trim()) return text;
-  
-  const lowerText = text.toLowerCase();
-  const lowerQuery = query.toLowerCase();
-  const index = lowerText.indexOf(lowerQuery);
-  
-  if (index === -1) return text;
-  
-  return (
-    <>
-      {text.slice(0, index)}
-      <mark className="bg-yellow-200 dark:bg-yellow-800 px-0.5 rounded">
-        {text.slice(index, index + query.length)}
-      </mark>
-      {text.slice(index + query.length)}
-    </>
-  );
+```json
+{
+  "projects": [...],
+  "folders": [...]
 }
 ```
 
-**Styling:**
+This replaces the previous need for separate initial requests for project and folder trees in the main workspace load path.
 
-- Light mode: `bg-yellow-200`
-- Dark mode: `bg-yellow-800`
-- Rounded corners with subtle padding
+## Search Behavior
 
----
+Workspace search is client-side and optimized for responsiveness.
 
-## 4. Toast Notifications for Delete
+Current behavior:
+- search input is deferred so typing does not block rendering
+- project matching uses fuzzy search across key project fields
+- results include display names and descriptions where available
 
-**Problem:** Delete errors showed generic `alert()` messages without actual error details.
+This keeps the workspace responsive without changing project data or server-side semantics.
 
-**Solution:** Replaced `alert()` with sonner toast notifications that display backend error messages.
+## Folder and Visibility Model
 
-**Dependencies Added:**
+Workspace folders are role-aware.
 
-```bash
-npm install sonner
-```
+Current behavior:
+- folder trees are filtered by the current user role
+- project visibility respects RBAC assignments
+- folder counts and visibility are computed without forcing full project hydration where unnecessary
 
-**Setup in App.tsx:**
+## Project and Dialog Loading
 
-```tsx
-import { Toaster } from 'sonner';
+The non-visualizer application shell is route-split.
 
-// In component:
-<BrowserRouter>
-  <Toaster richColors position="top-right" />
-  <Routes>...</Routes>
-</BrowserRouter>
-```
+Current behavior:
+- login, workspace, and project detail routes are lazy-loaded
+- settings and import dialogs are deferred until opened
+- auth and markdown runtimes are deferred out of the initial shell
 
-**Usage in workspace.tsx:**
+This reduces startup cost without changing user-facing features.
 
-```typescript
-import { toast } from "sonner";
+## Import Flow Notes
 
-// On success:
-toast.success(`Deleted "${projectName}" successfully`);
+Import and analysis use async jobs.
 
-// On error:
-const errorData = await res.json().catch(() => ({}));
-const errorMessage = errorData.detail || errorData.message || 'Unknown error';
-toast.error(`Failed to delete project: ${errorMessage}`);
-```
+Current behavior:
+- repository analysis and import return a job id
+- frontend polls job status during the active flow
+- polling is stopped cleanly when dialogs close or unmount
+- imported projects can expose comments helper URLs immediately after import
 
----
+## Why This Matters
+
+The workspace is the highest-frequency surface in the product. These behaviors are aimed at:
+- keeping initial load small
+- reducing duplicate API work
+- avoiding unnecessary background polling
+- preserving UI responsiveness on larger project sets
+
+## Related Endpoints
+
+- `GET /api/workspace/bootstrap`
+- `GET /api/folders/tree`
+- `GET /api/folders/contents`
+- `POST /api/projects/analyze`
+- `POST /api/projects/import`
+- `GET /api/projects/jobs/{job_id}`

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,48 @@
-# React + TypeScript + Vite + shadcn/ui
+# KiCAD Prism Frontend
 
-This is a template for a new Vite project with React, TypeScript, and shadcn/ui.
+This package contains the React/Vite frontend for KiCAD Prism.
+
+## Responsibilities
+
+- login and session bootstrap
+- workspace and folder UI
+- project detail surfaces: overview, history, visualizers, assets, docs, workflows
+- comments helpers and import UX
+- route-level chunking for the non-visualizer application shell
+
+## Local Development
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Default dev URL:
+
+```text
+http://127.0.0.1:5173
+```
+
+The frontend expects the backend API to be available at `http://127.0.0.1:8000` via the Vite proxy configuration.
+
+## Scripts
+
+- `npm run dev`: start the Vite dev server
+- `npm run build`: type-check and build the production bundle
+- `npm run lint`: run ESLint
+- `npm run preview`: serve the built bundle locally
+
+## Build Notes
+
+- The app uses lazy route loading for the main non-visualizer surfaces.
+- Auth and markdown runtimes are deferred out of the initial shell.
+- Visualizer-related bundles remain isolated because that surface has different stability constraints.
+
+## Directory Guide
+
+- `src/App.tsx`: route shell, auth bootstrap, global providers
+- `src/components/`: shared UI components and feature surfaces
+- `src/pages/`: route-level pages
+- `src/hooks/`: data and search hooks
+- `public/`: static viewer assets and vendored visualizer artifacts

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy, useDeferredValue, useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import type { User, AuthConfig } from './types/auth';
-import { GoogleOAuthProvider } from '@react-oauth/google';
 import { Button } from '@/components/ui/button';
 import { Toaster } from 'sonner';
 import { Input } from '@/components/ui/input';
@@ -146,16 +145,15 @@ function App() {
         }
 
         return (
-            <GoogleOAuthProvider clientId={authConfig.google_client_id}>
-                <Suspense fallback={<RouteFallback />}>
-                    <LoginPage
-                        onLoginSuccess={setUser}
-                        devMode={authConfig.dev_mode}
-                        workspaceName={authConfig.workspace_name}
-                        initialError={authError}
-                    />
-                </Suspense>
-            </GoogleOAuthProvider>
+            <Suspense fallback={<RouteFallback />}>
+                <LoginPage
+                    onLoginSuccess={setUser}
+                    googleClientId={authConfig.google_client_id}
+                    devMode={authConfig.dev_mode}
+                    workspaceName={authConfig.workspace_name}
+                    initialError={authError}
+                />
+            </Suspense>
         );
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,28 +9,16 @@ import { ProjectDetailPage } from './pages/ProjectDetailPage';
 import { Toaster } from 'sonner';
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
-import { fetchJson } from '@/lib/api';
+import { ApiHttpError, fetchApi, fetchJson } from '@/lib/api';
 import prismLogoMark from './assets/branding/kicad-prism/kicad-prism-icon.svg';
 
 
 
 function App() {
-    const [user, setUser] = useState<User | null>(() => {
-        // Restore user from localStorage on initial load
-        if (typeof window !== 'undefined') {
-            const saved = localStorage.getItem('auth_user');
-            if (saved) {
-                try {
-                    return JSON.parse(saved);
-                } catch {
-                    return null;
-                }
-            }
-        }
-        return null;
-    });
+    const [user, setUser] = useState<User | null>(null);
     const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
     const [loading, setLoading] = useState(true);
+    const [authError, setAuthError] = useState<string | null>(null);
     const [workspaceSearchQuery, setWorkspaceSearchQuery] = useState("");
 
     // Fetch auth configuration on mount
@@ -49,12 +37,36 @@ function App() {
                 }
 
                 setAuthConfig(config);
+                setAuthError(null);
 
                 // If auth is disabled, auto-login as guest
                 if (!config.auth_enabled) {
-                    const guestUser = { name: 'Guest', email: 'guest@local' };
+                    const guestUser: User = { name: 'Guest', email: 'guest@local', role: 'viewer' };
                     setUser(guestUser);
-                    localStorage.setItem('auth_user', JSON.stringify(guestUser));
+                    return;
+                }
+
+                try {
+                    const currentUser = await fetchJson<User>(
+                        '/api/auth/me',
+                        { signal: controller.signal },
+                        'Failed to fetch current user'
+                    );
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+                    setUser(currentUser);
+                    setAuthError(null);
+                } catch (err) {
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+                    if (err instanceof ApiHttpError && (err.status === 401 || err.status === 403)) {
+                        setUser(null);
+                        setAuthError(err.status === 403 ? err.message : null);
+                    } else {
+                        setUser(null);
+                    }
                 }
             } catch (err) {
                 if (controller.signal.aborted) {
@@ -62,9 +74,8 @@ function App() {
                 }
                 console.error('Failed to fetch auth config:', err);
                 // On error, default to no auth (allow access)
-                const guestUser = { name: 'Guest', email: 'guest@local' };
+                const guestUser: User = { name: 'Guest', email: 'guest@local', role: 'viewer' };
                 setUser(guestUser);
-                localStorage.setItem('auth_user', JSON.stringify(guestUser));
             } finally {
                 if (!controller.signal.aborted) {
                     setLoading(false);
@@ -76,18 +87,28 @@ function App() {
         return () => controller.abort();
     }, []);
 
-    // Persist user to localStorage when it changes
     useEffect(() => {
-        if (user) {
-            localStorage.setItem('auth_user', JSON.stringify(user));
-        } else {
-            localStorage.removeItem('auth_user');
-        }
-    }, [user]);
+        const handleAuthError = (event: Event) => {
+            const customEvent = event as CustomEvent<{ status?: number; url?: string }>;
+            const status = customEvent.detail?.status;
+            const url = customEvent.detail?.url ?? "";
+            if (status === 401) {
+                setUser(null);
+                return;
+            }
+            if (status === 403 && url.includes('/api/auth/me')) {
+                setUser(null);
+            }
+        };
+        window.addEventListener('kicad-prism-auth-error', handleAuthError);
+        return () => window.removeEventListener('kicad-prism-auth-error', handleAuthError);
+    }, []);
 
     const handleLogout = () => {
-        setUser(null);
-        localStorage.removeItem('auth_user');
+        void fetchApi('/api/auth/logout', { method: 'POST' }).finally(() => {
+            setUser(null);
+            setAuthError(null);
+        });
     };
 
     // Show loading state while fetching auth config
@@ -116,6 +137,7 @@ function App() {
                     onLoginSuccess={setUser}
                     devMode={authConfig.dev_mode}
                     workspaceName={authConfig.workspace_name}
+                    initialError={authError}
                 />
             </GoogleOAuthProvider>
         );
@@ -150,7 +172,9 @@ function App() {
                                 <div className="flex items-center gap-4">
                                     {user && user.email !== 'guest@local' && (
                                         <>
-                                            <span className="text-sm text-muted-foreground">Welcome, {user.name}</span>
+                                            <span className="text-sm text-muted-foreground">
+                                                Welcome, {user.name} ({user.role})
+                                            </span>
                                             <Button variant="ghost" size="sm" onClick={handleLogout}>Logout</Button>
                                         </>
                                     )}
@@ -164,6 +188,7 @@ function App() {
                         <main className="h-[calc(100vh-4rem)]">
                             <Workspace
                                 searchQuery={workspaceSearchQuery}
+                                user={user}
                             />
                         </main>
                     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useDeferredValue, useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { User, AuthConfig } from './types/auth';
 import { LoginPage } from './components/login-page';
@@ -20,6 +20,7 @@ function App() {
     const [loading, setLoading] = useState(true);
     const [authError, setAuthError] = useState<string | null>(null);
     const [workspaceSearchQuery, setWorkspaceSearchQuery] = useState("");
+    const deferredWorkspaceSearchQuery = useDeferredValue(workspaceSearchQuery);
 
     // Fetch auth configuration on mount
     useEffect(() => {
@@ -187,7 +188,7 @@ function App() {
 
                         <main className="h-[calc(100vh-4rem)]">
                             <Workspace
-                                searchQuery={workspaceSearchQuery}
+                                searchQuery={deferredWorkspaceSearchQuery}
                                 user={user}
                             />
                         </main>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,31 @@
-import { useDeferredValue, useEffect, useState } from 'react';
+import { Suspense, lazy, useDeferredValue, useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { User, AuthConfig } from './types/auth';
-import { LoginPage } from './components/login-page';
+import type { User, AuthConfig } from './types/auth';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import { Button } from '@/components/ui/button';
-import { Workspace } from './components/workspace';
-import { ProjectDetailPage } from './pages/ProjectDetailPage';
 import { Toaster } from 'sonner';
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
 import { ApiHttpError, fetchApi, fetchJson } from '@/lib/api';
 import prismLogoMark from './assets/branding/kicad-prism/kicad-prism-icon.svg';
 
+const LoginPage = lazy(() =>
+    import('./components/login-page').then((module) => ({ default: module.LoginPage }))
+);
+const Workspace = lazy(() =>
+    import('./components/workspace').then((module) => ({ default: module.Workspace }))
+);
+const ProjectDetailPage = lazy(() =>
+    import('./pages/ProjectDetailPage').then((module) => ({ default: module.ProjectDetailPage }))
+);
 
+function RouteFallback() {
+    return (
+        <div className="flex items-center justify-center h-full min-h-[16rem] bg-background">
+            <div className="text-muted-foreground">Loading...</div>
+        </div>
+    );
+}
 
 function App() {
     const [user, setUser] = useState<User | null>(null);
@@ -134,12 +147,14 @@ function App() {
 
         return (
             <GoogleOAuthProvider clientId={authConfig.google_client_id}>
-                <LoginPage
-                    onLoginSuccess={setUser}
-                    devMode={authConfig.dev_mode}
-                    workspaceName={authConfig.workspace_name}
-                    initialError={authError}
-                />
+                <Suspense fallback={<RouteFallback />}>
+                    <LoginPage
+                        onLoginSuccess={setUser}
+                        devMode={authConfig.dev_mode}
+                        workspaceName={authConfig.workspace_name}
+                        initialError={authError}
+                    />
+                </Suspense>
             </GoogleOAuthProvider>
         );
     }
@@ -187,14 +202,23 @@ function App() {
                         </header>
 
                         <main className="h-[calc(100vh-4rem)]">
-                            <Workspace
-                                searchQuery={deferredWorkspaceSearchQuery}
-                                user={user}
-                            />
+                            <Suspense fallback={<RouteFallback />}>
+                                <Workspace
+                                    searchQuery={deferredWorkspaceSearchQuery}
+                                    user={user}
+                                />
+                            </Suspense>
                         </main>
                     </div>
                 } />
-                <Route path="/project/:projectId" element={<ProjectDetailPage user={user} />} />
+                <Route
+                    path="/project/:projectId"
+                    element={
+                        <Suspense fallback={<RouteFallback />}>
+                            <ProjectDetailPage user={user} />
+                        </Suspense>
+                    }
+                />
                 <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
         </BrowserRouter>

--- a/frontend/src/components/assets-portal.tsx
+++ b/frontend/src/components/assets-portal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Download, File, FileText, Package, Image as ImageIcon, Folder, ChevronRight, ChevronDown, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -168,8 +168,10 @@ export function AssetsPortal({ projectId }: AssetsPortalProps) {
         window.open(url, '_blank');
     };
 
-    const designTree = buildFileTree(designFiles);
-    const mfgTree = buildFileTree(mfgFiles);
+    const designTree = useMemo(() => buildFileTree(designFiles), [designFiles]);
+    const mfgTree = useMemo(() => buildFileTree(mfgFiles), [mfgFiles]);
+    const designTotalSize = useMemo(() => calculateTotalSize(designFiles), [designFiles]);
+    const mfgTotalSize = useMemo(() => calculateTotalSize(mfgFiles), [mfgFiles]);
 
     if (loading) {
         return (
@@ -191,7 +193,7 @@ export function AssetsPortal({ projectId }: AssetsPortalProps) {
                 <div className="flex items-center justify-between">
                     <h3 className="text-lg font-semibold">Design Outputs</h3>
                     <span className="text-xs text-muted-foreground">
-                        {formatBytes(calculateTotalSize(designFiles))} total
+                        {formatBytes(designTotalSize)} total
                     </span>
                 </div>
                 <div className="border rounded-lg p-4 max-h-[600px] overflow-y-auto">
@@ -219,7 +221,7 @@ export function AssetsPortal({ projectId }: AssetsPortalProps) {
                 <div className="flex items-center justify-between">
                     <h3 className="text-lg font-semibold">Manufacturing Outputs</h3>
                     <span className="text-xs text-muted-foreground">
-                        {formatBytes(calculateTotalSize(mfgFiles))} total
+                        {formatBytes(mfgTotalSize)} total
                     </span>
                 </div>
                 <div className="border rounded-lg p-4 max-h-[600px] overflow-y-auto">

--- a/frontend/src/components/comment-panel.tsx
+++ b/frontend/src/components/comment-panel.tsx
@@ -12,6 +12,7 @@ interface CommentPanelProps {
     onReply: (commentId: string, content: string) => Promise<void>;
     onDelete: (commentId: string) => Promise<void>;
     onCommentClick: (comment: Comment) => void;
+    canModify: boolean;
 }
 
 export function CommentPanel({
@@ -20,7 +21,8 @@ export function CommentPanel({
     onResolve,
     onReply,
     onDelete,
-    onCommentClick
+    onCommentClick,
+    canModify
 }: CommentPanelProps) {
     const [filter, setFilter] = useState<'ALL' | 'OPEN' | 'RESOLVED'>('ALL');
 
@@ -87,6 +89,7 @@ export function CommentPanel({
                                                 onReply={onReply}
                                                 onDelete={onDelete}
                                                 onClick={() => onCommentClick(comment)}
+                                                canModify={canModify}
                                             />
                                         ))}
                                     </div>
@@ -107,6 +110,7 @@ export function CommentPanel({
                                                 onReply={onReply}
                                                 onDelete={onDelete}
                                                 onClick={() => onCommentClick(comment)}
+                                                canModify={canModify}
                                             />
                                         ))}
                                     </div>
@@ -140,9 +144,10 @@ interface CommentCardProps {
     onReply: (id: string, content: string) => Promise<void>;
     onDelete: (id: string) => Promise<void>;
     onClick: () => void;
+    canModify: boolean;
 }
 
-function CommentCard({ comment, onResolve, onReply, onDelete, onClick }: CommentCardProps) {
+function CommentCard({ comment, onResolve, onReply, onDelete, onClick, canModify }: CommentCardProps) {
     const [isReplying, setIsReplying] = useState(false);
     const [replyContent, setReplyContent] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -190,55 +195,61 @@ function CommentCard({ comment, onResolve, onReply, onDelete, onClick }: Comment
                 <p className="text-sm mb-3 whitespace-pre-wrap">{comment.content}</p>
 
                 <div className="flex items-center justify-between">
-                    <div className="flex gap-1">
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs"
-                            onClick={() => setIsReplying(!isReplying)}
-                        >
-                            <ReplyIcon className="w-3 h-3 mr-1" />
-                            Reply
-                        </Button>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs text-muted-foreground hover:text-red-500 hover:bg-red-500/10"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                if (confirm("Are you sure you want to delete this comment?")) {
-                                    onDelete(comment.id);
-                                }
-                            }}
-                        >
-                            <Trash2 className="w-3 h-3 mr-1" />
-                            Delete
-                        </Button>
-                    </div>
+                    {canModify ? (
+                        <>
+                            <div className="flex gap-1">
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-6 px-2 text-xs"
+                                    onClick={() => setIsReplying(!isReplying)}
+                                >
+                                    <ReplyIcon className="w-3 h-3 mr-1" />
+                                    Reply
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-6 px-2 text-xs text-muted-foreground hover:text-red-500 hover:bg-red-500/10"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        if (window.confirm("Are you sure you want to delete this comment?")) {
+                                            void onDelete(comment.id);
+                                        }
+                                    }}
+                                >
+                                    <Trash2 className="w-3 h-3 mr-1" />
+                                    Delete
+                                </Button>
+                            </div>
 
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className={`h-6 px-2 text-xs ${isResolved ? 'text-green-600' : 'text-muted-foreground'}`}
-                        onClick={() => onResolve(comment.id, !isResolved)}
-                    >
-                        {isResolved ? (
-                            <>
-                                <CheckCircle className="w-3 h-3 mr-1" />
-                                Resolved
-                            </>
-                        ) : (
-                            <>
-                                <Circle className="w-3 h-3 mr-1" />
-                                Resolve
-                            </>
-                        )}
-                    </Button>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className={`h-6 px-2 text-xs ${isResolved ? 'text-green-600' : 'text-muted-foreground'}`}
+                                onClick={() => onResolve(comment.id, !isResolved)}
+                            >
+                                {isResolved ? (
+                                    <>
+                                        <CheckCircle className="w-3 h-3 mr-1" />
+                                        Resolved
+                                    </>
+                                ) : (
+                                    <>
+                                        <Circle className="w-3 h-3 mr-1" />
+                                        Resolve
+                                    </>
+                                )}
+                            </Button>
+                        </>
+                    ) : (
+                        <div className="text-xs text-muted-foreground">Read-only</div>
+                    )}
                 </div>
             </div>
 
             {/* Replies Section */}
-            {(comment.replies.length > 0 || isReplying) && (
+            {(comment.replies.length > 0 || (isReplying && canModify)) && (
                 <div className="bg-muted/20 border-t p-3 space-y-3">
                     {/* Existing Replies */}
                     {comment.replies.length > 0 && (
@@ -266,7 +277,7 @@ function CommentCard({ comment, onResolve, onReply, onDelete, onClick }: Comment
                     )}
 
                     {/* Reply Input */}
-                    {isReplying && (
+                    {isReplying && canModify && (
                         <div className="flex items-end gap-2 mt-2 pt-2 animate-in fade-in slide-in-from-top-1">
                             <textarea
                                 value={replyContent}

--- a/frontend/src/components/documentation-browser.tsx
+++ b/frontend/src/components/documentation-browser.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, lazy, useEffect, useMemo, useState } from "react";
 import { Download, File, FileText, Folder, ChevronRight, ChevronDown, Eye, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
-import "github-markdown-css/github-markdown-dark.css";
 import { FileItem, TreeNode, formatBytes, buildFileTree } from "@/lib/file-utils";
+
+const MarkdownContent = lazy(() =>
+    import("@/components/markdown-content").then((module) => ({ default: module.MarkdownContent }))
+);
 
 interface DocumentationBrowserProps {
     projectId: string;
@@ -170,22 +170,14 @@ export function DocumentationBrowser({ projectId, commit }: DocumentationBrowser
                         Close
                     </Button>
                 </div>
-                <div className="markdown-body" style={{ background: 'transparent' }}>
-                    <ReactMarkdown
-                        remarkPlugins={[remarkGfm]}
-                        rehypePlugins={[rehypeRaw]}
-                        components={{
-                            img: ({ src, alt }) => {
-                                const imgSrc = src?.startsWith('http')
-                                    ? src
-                                    : `/api/projects/${projectId}/asset/docs/${src}`;
-                                return <img src={imgSrc} alt={alt || ''} />;
-                            }
-                        }}
-                    >
-                        {viewingDoc.content}
-                    </ReactMarkdown>
-                </div>
+                <Suspense fallback={<div className="text-sm text-muted-foreground">Loading document...</div>}>
+                    <MarkdownContent
+                        content={viewingDoc.content}
+                        resolveImageSrc={(src) =>
+                            src?.startsWith('http') ? src : `/api/projects/${projectId}/asset/docs/${src}`
+                        }
+                    />
+                </Suspense>
             </div>
         );
     }

--- a/frontend/src/components/documentation-browser.tsx
+++ b/frontend/src/components/documentation-browser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Download, File, FileText, Folder, ChevronRight, ChevronDown, Eye, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -154,7 +154,7 @@ export function DocumentationBrowser({ projectId, commit }: DocumentationBrowser
         window.open(url, '_blank');
     };
 
-    const tree = buildFileTree(files);
+    const tree = useMemo(() => buildFileTree(files), [files]);
 
     if (loading) {
         return <Skeleton className="h-64 w-full" />;

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -32,6 +32,7 @@ interface CommitsResponse {
 interface HistoryViewerProps {
     projectId: string;
     onViewCommit: (commitHash: string) => void;
+    canCompareDiffs: boolean;
 }
 
 function formatDate(isoDate: string): string {
@@ -53,9 +54,10 @@ interface CommitItemProps {
     onViewCommit: (hash: string) => void;
     isSelected: boolean;
     onSelect: () => void;
+    selectable: boolean;
 }
 
-function CommitItem({ commit, onViewCommit, isSelected, onSelect }: CommitItemProps) {
+function CommitItem({ commit, onViewCommit, isSelected, onSelect, selectable }: CommitItemProps) {
     const [copied, setCopied] = useState(false);
 
     const handleCopy = async () => {
@@ -72,12 +74,16 @@ function CommitItem({ commit, onViewCommit, isSelected, onSelect }: CommitItemPr
         <div className={`border rounded-lg p-4 transition-colors ${isSelected ? 'bg-primary/5 border-primary/50' : 'hover:bg-muted/50'}`}>
             <div className="flex items-start gap-3">
                 <div className="flex-shrink-0 mt-1 flex items-center justify-center">
-                    <input
-                        type="checkbox"
-                        checked={isSelected}
-                        onChange={onSelect}
-                        className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer accent-primary"
-                    />
+                    {selectable ? (
+                        <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={onSelect}
+                            className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer accent-primary"
+                        />
+                    ) : (
+                        <GitCommit className="h-4 w-4 text-muted-foreground" />
+                    )}
                 </div>
                 <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-4 mb-2">
@@ -128,7 +134,7 @@ function CommitItem({ commit, onViewCommit, isSelected, onSelect }: CommitItemPr
     );
 }
 
-export function HistoryViewer({ projectId, onViewCommit }: HistoryViewerProps) {
+export function HistoryViewer({ projectId, onViewCommit, canCompareDiffs }: HistoryViewerProps) {
     const [releases, setReleases] = useState<Release[]>([]);
     const [commits, setCommits] = useState<Commit[]>([]);
     const [loading, setLoading] = useState(true);
@@ -157,6 +163,9 @@ export function HistoryViewer({ projectId, onViewCommit }: HistoryViewerProps) {
     }, [commits, selectedCommits]);
 
     const handleSelectCommit = (hash: string) => {
+        if (!canCompareDiffs) {
+            return;
+        }
         setSelectedCommits(prev => {
             if (prev.includes(hash)) {
                 return prev.filter(h => h !== hash);
@@ -169,6 +178,12 @@ export function HistoryViewer({ projectId, onViewCommit }: HistoryViewerProps) {
             return [...prev, hash];
         });
     };
+
+    useEffect(() => {
+        if (!canCompareDiffs) {
+            setSelectedCommits([]);
+        }
+    }, [canCompareDiffs]);
 
     useEffect(() => {
         const currentHashes = new Set(commits.map((commit) => commit.full_hash));
@@ -317,7 +332,7 @@ export function HistoryViewer({ projectId, onViewCommit }: HistoryViewerProps) {
                         <GitCommit className="h-5 w-5" />
                         Commits
                     </h3>
-                    {selectedCommits.length === 2 && (
+                    {canCompareDiffs && selectedCommits.length === 2 && (
                         <div className="flex items-center gap-2">
                             <Button
                                 variant="default"
@@ -346,6 +361,7 @@ export function HistoryViewer({ projectId, onViewCommit }: HistoryViewerProps) {
                                 onViewCommit={onViewCommit}
                                 isSelected={selectedCommits.includes(commit.full_hash)}
                                 onSelect={() => handleSelectCommit(commit.full_hash)}
+                                selectable={canCompareDiffs}
                             />
                         ))}
                     </div>

--- a/frontend/src/components/import-dialog.tsx
+++ b/frontend/src/components/import-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
 import {
   Dialog,
   DialogContent,
@@ -76,8 +76,40 @@ export function ImportDialog({
   const [state, setState] = useState<ImportState>({ step: "input" });
   const [url, setUrl] = useState("");
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
+  const pollTimeoutRef = useRef<number | null>(null);
+  const pollControllerRef = useRef<AbortController | null>(null);
+  const pollingTokenRef = useRef(0);
+
+  const clearPollingHandles = useCallback(() => {
+    if (pollTimeoutRef.current !== null) {
+      window.clearTimeout(pollTimeoutRef.current);
+      pollTimeoutRef.current = null;
+    }
+    if (pollControllerRef.current) {
+      pollControllerRef.current.abort();
+      pollControllerRef.current = null;
+    }
+  }, []);
+
+  const stopPolling = useCallback(() => {
+    pollingTokenRef.current += 1;
+    clearPollingHandles();
+  }, [clearPollingHandles]);
+
+  useEffect(() => {
+    return () => {
+      stopPolling();
+    };
+  }, [stopPolling]);
+
+  useEffect(() => {
+    if (!open) {
+      stopPolling();
+    }
+  }, [open, stopPolling]);
 
   const reset = () => {
+    stopPolling();
     setState({ step: "input" });
     setUrl("");
     setSelectedPaths(new Set());
@@ -91,6 +123,7 @@ export function ImportDialog({
   const analyzeRepo = async () => {
     if (!url.trim()) return;
 
+    stopPolling();
     setState({ step: "analyzing", url });
 
     try {
@@ -120,12 +153,19 @@ export function ImportDialog({
   };
 
   const pollAnalysisJob = async (jobId: string, repoUrl: string) => {
+    stopPolling();
+    const pollingToken = pollingTokenRef.current;
+
     const poll = async () => {
+      const controller = new AbortController();
       try {
-        const res = await fetch(`/api/projects/jobs/${jobId}`);
+        pollControllerRef.current = controller;
+        const res = await fetch(`/api/projects/jobs/${jobId}`, { signal: controller.signal });
+        if (pollingTokenRef.current !== pollingToken) return;
         if (!res.ok) throw new Error("Failed to get job status");
 
         const status: JobStatus = await res.json();
+        if (pollingTokenRef.current !== pollingToken) return;
 
         // Update state with ongoing job status
         setState({ step: "analyzing", url: repoUrl, jobId, status });
@@ -155,18 +195,28 @@ export function ImportDialog({
           });
         } else {
           // Continue polling
-          setTimeout(poll, 1000);
+          pollTimeoutRef.current = window.setTimeout(() => {
+            void poll();
+          }, 1000);
         }
       } catch (error: any) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        if (pollingTokenRef.current !== pollingToken) return;
         setState({
           step: "complete",
           success: false,
           message: error.message || "Failed to check analysis status",
         });
+      } finally {
+        if (pollControllerRef.current === controller) {
+          pollControllerRef.current = null;
+        }
       }
     };
 
-    poll();
+    void poll();
   };
 
   const startImport = async () => {
@@ -179,6 +229,7 @@ export function ImportDialog({
         : Array.from(selectedPaths);
 
     try {
+      stopPolling();
       const res = await fetch("/api/projects/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -208,6 +259,9 @@ export function ImportDialog({
   };
 
   const pollJobStatus = async (jobId: string, repoUrl: string) => {
+    stopPolling();
+    const pollingToken = pollingTokenRef.current;
+
     const fetchCommentsSourceUrls = async (projectIds: string[]): Promise<CommentsSourceUrls[]> => {
       const entries = await Promise.all(
         projectIds.map(async (id) => {
@@ -225,11 +279,15 @@ export function ImportDialog({
     };
 
     const poll = async () => {
+      const controller = new AbortController();
       try {
-        const res = await fetch(`/api/projects/jobs/${jobId}`);
+        pollControllerRef.current = controller;
+        const res = await fetch(`/api/projects/jobs/${jobId}`, { signal: controller.signal });
+        if (pollingTokenRef.current !== pollingToken) return;
         if (!res.ok) throw new Error("Failed to get job status");
 
         const status: JobStatus = await res.json();
+        if (pollingTokenRef.current !== pollingToken) return;
 
         setState({ step: "importing", url: repoUrl, jobId, status });
 
@@ -243,6 +301,8 @@ export function ImportDialog({
               console.warn("Unable to load comments source URLs", error);
             }
           }
+
+          if (pollingTokenRef.current !== pollingToken) return;
 
           setState({
             step: "complete",
@@ -260,19 +320,29 @@ export function ImportDialog({
           });
         } else {
           // Continue polling
-          setTimeout(poll, 1000);
+          pollTimeoutRef.current = window.setTimeout(() => {
+            void poll();
+          }, 1000);
         }
       } catch (error: any) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        if (pollingTokenRef.current !== pollingToken) return;
         setState({
           step: "complete",
           success: false,
           message: error.message || "Failed to check import status",
           commentsSourceUrls: undefined,
         });
+      } finally {
+        if (pollControllerRef.current === controller) {
+          pollControllerRef.current = null;
+        }
       }
     };
 
-    poll();
+    void poll();
   };
 
   const toggleProjectSelection = (relativePath: string) => {

--- a/frontend/src/components/login-page.tsx
+++ b/frontend/src/components/login-page.tsx
@@ -1,4 +1,4 @@
-import { GoogleLogin, type CredentialResponse } from "@react-oauth/google";
+import { GoogleLogin, GoogleOAuthProvider, type CredentialResponse } from "@react-oauth/google";
 import { useEffect, useState } from "react";
 import { Binary, Loader2 } from "lucide-react";
 
@@ -10,6 +10,7 @@ import { User } from "@/types/auth";
 
 interface LoginPageProps {
   onLoginSuccess: (user: User) => void;
+  googleClientId: string;
   devMode?: boolean;
   workspaceName?: string;
   initialError?: string | null;
@@ -22,6 +23,7 @@ const DEFAULT_GITHUB_REPO = "krishna-swaroop/KiCAD-Prism";
 
 export function LoginPage({
   onLoginSuccess,
+  googleClientId,
   devMode = false,
   workspaceName = "KiCAD Prism",
   initialError = null,
@@ -117,83 +119,85 @@ export function LoginPage({
   };
 
   return (
-    <div className="grid min-h-screen bg-background text-foreground lg:grid-cols-[minmax(0,1.15fr)_minmax(420px,560px)]">
-      <section className="relative hidden border-r bg-card lg:flex lg:flex-col lg:justify-between lg:p-10">
-        <div className="relative z-10 flex items-center gap-3">
-          <img src={prismLogoHorizontal} alt="KiCAD Prism" className="h-10 w-auto" />
-        </div>
+    <GoogleOAuthProvider clientId={googleClientId}>
+      <div className="grid min-h-screen bg-background text-foreground lg:grid-cols-[minmax(0,1.15fr)_minmax(420px,560px)]">
+        <section className="relative hidden border-r bg-card lg:flex lg:flex-col lg:justify-between lg:p-10">
+          <div className="relative z-10 flex items-center gap-3">
+            <img src={prismLogoHorizontal} alt="KiCAD Prism" className="h-10 w-auto" />
+          </div>
 
-        <div className="relative z-10 max-w-xl space-y-6">
-          <div className="space-y-3">
-            <p className="text-sm font-medium uppercase tracking-[0.22em] text-primary">{workspaceName}</p>
-            <h1 className="text-5xl font-semibold tracking-tight">Visualizing KiCAD Projects.</h1>
-            <p className="max-w-lg text-base text-muted-foreground">
-              A web-based platform for viewing, reviewing, and collaborating on KiCAD projects.
+          <div className="relative z-10 max-w-xl space-y-6">
+            <div className="space-y-3">
+              <p className="text-sm font-medium uppercase tracking-[0.22em] text-primary">{workspaceName}</p>
+              <h1 className="text-5xl font-semibold tracking-tight">Visualizing KiCAD Projects.</h1>
+              <p className="max-w-lg text-base text-muted-foreground">
+                A web-based platform for viewing, reviewing, and collaborating on KiCAD projects.
+              </p>
+            </div>
+          </div>
+
+          <div className="relative z-10 flex items-center gap-3 text-xs text-muted-foreground">
+            <Binary className="h-3.5 w-3.5" />
+            <span>Release {releaseTag}</span>
+          </div>
+        </section>
+
+        <section className="relative flex items-center justify-center px-6 py-8 sm:px-10">
+          <div className="w-full max-w-xl space-y-6 rounded-2xl border border-border/70 bg-card/70 p-5 backdrop-blur-sm sm:p-7">
+            <div className="flex items-center justify-center gap-3 lg:hidden">
+              <img src={prismLogoMark} alt="KiCAD Prism" className="h-10 w-10" />
+              <p className="text-2xl font-semibold tracking-tight">{workspaceName}</p>
+            </div>
+
+            <Card className="relative overflow-hidden border-primary/40 bg-card ring-1 ring-primary/30">
+              <div className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-border/80" />
+              <CardHeader className="space-y-2 pb-7">
+                <CardTitle className="text-2xl">Sign In</CardTitle>
+                <CardDescription>Sign in with your Google account.</CardDescription>
+              </CardHeader>
+
+              <CardContent className="space-y-5 pb-7">
+                <div className="flex justify-center">
+                  <GoogleLogin
+                    onSuccess={handleSuccess}
+                    onError={() => setError("Google sign-in failed")}
+                    useOneTap
+                    auto_select
+                    theme="outline"
+                    shape="pill"
+                    size="large"
+                    width="100%"
+                  />
+                </div>
+
+                {isLoading && (
+                  <div className="flex items-center justify-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>Authenticating…</span>
+                  </div>
+                )}
+
+                {error && (
+                  <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                    {error}
+                  </div>
+                )}
+
+                {devMode && (
+                  <Button variant="outline" className="w-full" onClick={handleDevBypass}>
+                    <Binary className="mr-2 h-4 w-4" />
+                    Skip Authentication (Dev Mode)
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+
+            <p className="text-center text-xs text-muted-foreground">
+              Restricted Access  |  Contact your administrator for access.
             </p>
           </div>
-        </div>
-
-        <div className="relative z-10 flex items-center gap-3 text-xs text-muted-foreground">
-          <Binary className="h-3.5 w-3.5" />
-          <span>Release {releaseTag}</span>
-        </div>
-      </section>
-
-      <section className="relative flex items-center justify-center px-6 py-8 sm:px-10">
-        <div className="w-full max-w-xl space-y-6 rounded-2xl border border-border/70 bg-card/70 p-5 backdrop-blur-sm sm:p-7">
-          <div className="flex items-center justify-center gap-3 lg:hidden">
-            <img src={prismLogoMark} alt="KiCAD Prism" className="h-10 w-10" />
-            <p className="text-2xl font-semibold tracking-tight">{workspaceName}</p>
-          </div>
-
-          <Card className="relative overflow-hidden border-primary/40 bg-card ring-1 ring-primary/30">
-            <div className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-border/80" />
-            <CardHeader className="space-y-2 pb-7">
-              <CardTitle className="text-2xl">Sign In</CardTitle>
-              <CardDescription>Sign in with your Google account.</CardDescription>
-            </CardHeader>
-
-            <CardContent className="space-y-5 pb-7">
-              <div className="flex justify-center">
-                <GoogleLogin
-                  onSuccess={handleSuccess}
-                  onError={() => setError("Google sign-in failed")}
-                  useOneTap
-                  auto_select
-                  theme="outline"
-                  shape="pill"
-                  size="large"
-                  width="100%"
-                />
-              </div>
-
-              {isLoading && (
-                <div className="flex items-center justify-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span>Authenticating…</span>
-                </div>
-              )}
-
-              {error && (
-                <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                  {error}
-                </div>
-              )}
-
-              {devMode && (
-                <Button variant="outline" className="w-full" onClick={handleDevBypass}>
-                  <Binary className="mr-2 h-4 w-4" />
-                  Skip Authentication (Dev Mode)
-                </Button>
-              )}
-            </CardContent>
-          </Card>
-
-          <p className="text-center text-xs text-muted-foreground">
-            Restricted Access  |  Contact your administrator for access.
-          </p>
-        </div>
-      </section>
-    </div>
+        </section>
+      </div>
+    </GoogleOAuthProvider>
   );
 }

--- a/frontend/src/components/login-page.tsx
+++ b/frontend/src/components/login-page.tsx
@@ -6,11 +6,13 @@ import prismLogoHorizontal from "@/assets/branding/kicad-prism/kicad-prism-logo-
 import prismLogoMark from "@/assets/branding/kicad-prism/kicad-prism-icon.svg";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { User } from "@/types/auth";
 
 interface LoginPageProps {
-  onLoginSuccess: (user: any) => void;
+  onLoginSuccess: (user: User) => void;
   devMode?: boolean;
   workspaceName?: string;
+  initialError?: string | null;
 }
 
 const RELEASE_CACHE_KEY = "kicad_prism_latest_release_tag";
@@ -18,10 +20,19 @@ const RELEASE_CACHE_TIME_KEY = "kicad_prism_latest_release_tag_fetched_at";
 const RELEASE_CACHE_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_GITHUB_REPO = "krishna-swaroop/KiCAD-Prism";
 
-export function LoginPage({ onLoginSuccess, devMode = false, workspaceName = "KiCAD Prism" }: LoginPageProps) {
-  const [error, setError] = useState<string | null>(null);
+export function LoginPage({
+  onLoginSuccess,
+  devMode = false,
+  workspaceName = "KiCAD Prism",
+  initialError = null,
+}: LoginPageProps) {
+  const [error, setError] = useState<string | null>(initialError);
   const [isLoading, setIsLoading] = useState(false);
   const [releaseTag, setReleaseTag] = useState("...");
+
+  useEffect(() => {
+    setError(initialError);
+  }, [initialError]);
 
   useEffect(() => {
     const cachedTag = window.sessionStorage.getItem(RELEASE_CACHE_KEY);
@@ -82,6 +93,7 @@ export function LoginPage({ onLoginSuccess, devMode = false, workspaceName = "Ki
       const response = await fetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ token: credentialResponse.credential }),
       });
 
@@ -101,7 +113,7 @@ export function LoginPage({ onLoginSuccess, devMode = false, workspaceName = "Ki
 
   const handleDevBypass = () => {
     window.history.replaceState(null, "", "/");
-    onLoginSuccess({ name: "Dev User", email: "dev@pixxel.co.in" });
+    onLoginSuccess({ name: "Dev User", email: "dev@pixxel.co.in", role: "admin" });
   };
 
   return (

--- a/frontend/src/components/markdown-content.tsx
+++ b/frontend/src/components/markdown-content.tsx
@@ -1,0 +1,25 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import "github-markdown-css/github-markdown-dark.css";
+
+interface MarkdownContentProps {
+  content: string;
+  resolveImageSrc: (src?: string) => string | undefined;
+}
+
+export function MarkdownContent({ content, resolveImageSrc }: MarkdownContentProps) {
+  return (
+    <div className="markdown-body" style={{ background: "transparent" }}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw]}
+        components={{
+          img: ({ src, alt }) => <img src={resolveImageSrc(src)} alt={alt || ""} />,
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/frontend/src/components/path-config-dialog.tsx
+++ b/frontend/src/components/path-config-dialog.tsx
@@ -32,13 +32,15 @@ interface PathConfig {
     thumbnail?: string;
     readme?: string;
     jobset?: string;
-    projectName?: string;
+    project_name?: string;
+    description?: string;
     workflows?: unknown[];
 }
 
-interface ProjectDetailResponse {
-    display_name?: string;
-    description: string;
+interface PathConfigResponse {
+    config?: PathConfig;
+    resolved?: Record<string, string | null>;
+    source?: string;
 }
 
 interface PathConfigDialogProps {
@@ -89,8 +91,6 @@ const PATH_LABELS: Record<string, { label: string; description: string }> = {
 export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDialogProps) {
     const [config, setConfig] = useState<PathConfig>({});
     const [originalConfig, setOriginalConfig] = useState<PathConfig>({});
-    const [description, setDescription] = useState<string>("");
-    const [originalDescription, setOriginalDescription] = useState<string>("");
     const [workflowsText, setWorkflowsText] = useState<string>("[]");
     const [workflowsError, setWorkflowsError] = useState<string | null>(null);
     const [resolvedPaths, setResolvedPaths] = useState<Record<string, string | null>>({});
@@ -98,31 +98,24 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
     const [saving, setSaving] = useState(false);
     const [detecting, setDetecting] = useState(false);
 
+    const formatWorkflows = useCallback(
+        (workflows?: unknown[]) => JSON.stringify(Array.isArray(workflows) ? workflows : [], null, 2),
+        []
+    );
+
     const fetchConfig = useCallback(async (signal?: AbortSignal) => {
         try {
-            const [configResponse, projectResponse] = await Promise.all([
-                fetch(`/api/projects/${projectId}/config`, { signal }),
-                fetch(`/api/projects/${projectId}`, { signal })
-            ]);
-            
-            if (configResponse.ok) {
-                const data = await configResponse.json();
-                setConfig(data.config || {});
-                setOriginalConfig(data.config || {});
+            const response = await fetch(`/api/projects/${projectId}/config`, { signal });
+
+            if (response.ok) {
+                const data = (await response.json()) as PathConfigResponse;
+                const nextConfig = data.config || {};
+                setConfig(nextConfig);
+                setOriginalConfig(nextConfig);
                 setResolvedPaths(data.resolved || {});
                 setSource(data.source || "auto-detected");
-                const workflows = Array.isArray(data?.config?.workflows) ? data.config.workflows : [];
-                setWorkflowsText(JSON.stringify(workflows, null, 2));
+                setWorkflowsText(formatWorkflows(nextConfig.workflows));
                 setWorkflowsError(null);
-            }
-            
-            if (projectResponse.ok) {
-                const projectData = (await projectResponse.json()) as ProjectDetailResponse;
-                setConfig(prev => ({ ...prev, projectName: projectData.display_name }));
-                setOriginalConfig(prev => ({ ...prev, projectName: projectData.display_name }));
-                const currentDescription = projectData?.description || "";
-                setDescription(currentDescription);
-                setOriginalDescription(currentDescription);
             }
         } catch (err) {
             if (err instanceof DOMException && err.name === "AbortError") {
@@ -130,7 +123,7 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
             }
             console.error("Failed to fetch config:", err);
         }
-    }, [projectId]);
+    }, [formatWorkflows, projectId]);
 
     const detectPaths = async () => {
         setDetecting(true);
@@ -170,50 +163,50 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
 
         setSaving(true);
         try {
+            const shouldSaveName =
+                config.project_name !== originalConfig.project_name && Boolean(config.project_name?.trim());
+            const normalizedName = config.project_name?.trim();
             const configPayload = {
                 ...config,
+                description: config.description ?? "",
                 workflows: parsedWorkflows,
             };
+            delete configPayload.project_name;
 
-            // Save both path config and project name
-            const [configResponse, nameResponse, descriptionResponse] = await Promise.all([
+            const [configResponse, nameResponse] = await Promise.all([
                 fetch(`/api/projects/${projectId}/config`, {
                     method: "PUT",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(configPayload),
                 }),
-                // Only save project name if it has changed
-                config.projectName !== originalConfig.projectName && config.projectName
+                shouldSaveName
                     ? fetch(`/api/projects/${projectId}/name`, {
                         method: "PUT",
                         headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ display_name: config.projectName }),
-                    })
-                    : Promise.resolve({ ok: true }),
-                description !== originalDescription
-                    ? fetch(`/api/projects/${projectId}/description`, {
-                        method: "PUT",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ description }),
+                        body: JSON.stringify({ display_name: config.project_name?.trim() }),
                     })
                     : Promise.resolve({ ok: true })
             ]);
             
             if (configResponse.ok) {
-                const data = await configResponse.json();
-                setConfig(configPayload);
-                setOriginalConfig(configPayload);
+                const data = (await configResponse.json()) as PathConfigResponse;
+                const normalizedDescription =
+                    config.description?.trim() ? config.description.trim() : data.config?.description;
+                const nextConfig = {
+                    ...config,
+                    project_name: shouldSaveName && nameResponse.ok ? normalizedName : config.project_name,
+                    description: normalizedDescription,
+                    workflows: parsedWorkflows,
+                };
+                const nextOriginalConfig = {
+                    ...nextConfig,
+                    project_name: shouldSaveName && nameResponse.ok ? normalizedName : originalConfig.project_name,
+                };
+
+                setConfig(nextConfig);
+                setOriginalConfig(nextOriginalConfig);
                 setResolvedPaths(data.resolved || {});
                 setSource("explicit");
-            }
-            
-            if (nameResponse.ok && config.projectName !== originalConfig.projectName) {
-                // Project name saved successfully
-                console.log("Project name updated");
-            }
-
-            if (descriptionResponse.ok && description !== originalDescription) {
-                setOriginalDescription(description);
             }
         } catch (err) {
             console.error("Failed to save config:", err);
@@ -236,8 +229,7 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
 
     const hasChanges =
         JSON.stringify(config) !== JSON.stringify(originalConfig) ||
-        description !== originalDescription ||
-        workflowsText !== JSON.stringify(Array.isArray(originalConfig.workflows) ? originalConfig.workflows : [], null, 2);
+        workflowsText !== formatWorkflows(originalConfig.workflows);
 
     const getStatusIcon = (key: string) => {
         const resolved = resolvedPaths[key];
@@ -305,8 +297,8 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
                             </div>
                             <Input
                                 id="projectName"
-                                value={config.projectName || ""}
-                                onChange={(e) => handleChange("projectName", e.target.value)}
+                                value={config.project_name || ""}
+                                onChange={(e) => handleChange("project_name", e.target.value)}
                                 placeholder="Enter custom project name"
                                 className="h-8"
                             />
@@ -321,8 +313,8 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
                             </Label>
                             <Textarea
                                 id="projectDescription"
-                                value={description}
-                                onChange={(e) => setDescription(e.target.value)}
+                                value={config.description || ""}
+                                onChange={(e) => handleChange("description", e.target.value)}
                                 placeholder="Describe this project"
                                 className="min-h-20"
                             />

--- a/frontend/src/components/path-config-dialog.tsx
+++ b/frontend/src/components/path-config-dialog.tsx
@@ -36,6 +36,11 @@ interface PathConfig {
     workflows?: unknown[];
 }
 
+interface ProjectDetailResponse {
+    display_name?: string;
+    description: string;
+}
+
 interface PathConfigDialogProps {
     projectId: string;
     open: boolean;
@@ -95,11 +100,9 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
 
     const fetchConfig = useCallback(async (signal?: AbortSignal) => {
         try {
-            // Fetch both path config and project name
-            const [configResponse, nameResponse, descriptionResponse] = await Promise.all([
+            const [configResponse, projectResponse] = await Promise.all([
                 fetch(`/api/projects/${projectId}/config`, { signal }),
-                fetch(`/api/projects/${projectId}/name`, { signal }),
-                fetch(`/api/projects/${projectId}/description`, { signal })
+                fetch(`/api/projects/${projectId}`, { signal })
             ]);
             
             if (configResponse.ok) {
@@ -113,15 +116,11 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
                 setWorkflowsError(null);
             }
             
-            if (nameResponse.ok) {
-                const nameData = await nameResponse.json();
-                setConfig(prev => ({ ...prev, projectName: nameData.display_name }));
-                setOriginalConfig(prev => ({ ...prev, projectName: nameData.display_name }));
-            }
-
-            if (descriptionResponse.ok) {
-                const descriptionData = await descriptionResponse.json();
-                const currentDescription = descriptionData?.description || "";
+            if (projectResponse.ok) {
+                const projectData = (await projectResponse.json()) as ProjectDetailResponse;
+                setConfig(prev => ({ ...prev, projectName: projectData.display_name }));
+                setOriginalConfig(prev => ({ ...prev, projectName: projectData.display_name }));
+                const currentDescription = projectData?.description || "";
                 setDescription(currentDescription);
                 setOriginalDescription(currentDescription);
             }
@@ -141,7 +140,7 @@ export function PathConfigDialog({ projectId, open, onOpenChange }: PathConfigDi
             });
             if (response.ok) {
                 const data = await response.json();
-                setConfig(data.detected || {});
+                setConfig((prev) => ({ ...prev, ...(data.detected || {}) }));
                 setSource("auto-detected (preview)");
             }
         } catch (err) {

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -3,23 +3,33 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
-import { GitBranch, Copy, FileCode } from "lucide-react";
+import { GitBranch, Copy, FileCode, Shield, Plus, Trash2 } from "lucide-react";
+import { User, UserRole } from "@/types/auth";
+import { fetchApi, readApiError } from "@/lib/api";
 
 interface SettingsDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
+    user: User | null;
 }
 
-type SettingsTab = "git" | "general";
+type SettingsTab = "git" | "access" | "general";
 
-export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
+interface RoleAssignment {
+    email: string;
+    role: UserRole;
+    source: string;
+}
+
+export function SettingsDialog({ open, onOpenChange, user }: SettingsDialogProps) {
     const [activeTab, setActiveTab] = useState<SettingsTab>("git");
+    const isAdmin = user?.role === "admin";
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-w-4xl p-0 overflow-hidden flex h-[600px]">
-                {/* Sidebar */}
                 <div className="w-64 bg-muted/30 border-r p-4 flex flex-col gap-2">
                     <div className="mb-4 px-2">
                         <h2 className="text-lg font-semibold tracking-tight">Settings</h2>
@@ -36,6 +46,15 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                     </Button>
 
                     <Button
+                        variant={activeTab === "access" ? "secondary" : "ghost"}
+                        className="justify-start"
+                        onClick={() => setActiveTab("access")}
+                    >
+                        <Shield className="mr-2 h-4 w-4" />
+                        Access Control
+                    </Button>
+
+                    <Button
                         variant={activeTab === "general" ? "secondary" : "ghost"}
                         className="justify-start opacity-50 cursor-not-allowed"
                         title="Coming soon"
@@ -45,9 +64,9 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                     </Button>
                 </div>
 
-                {/* Content Area */}
                 <div className="flex-1 overflow-y-auto p-6">
-                    {activeTab === "git" && <GitSettings />}
+                    {activeTab === "git" && <GitSettings user={user} />}
+                    {activeTab === "access" && <AccessControlSettings isAdmin={isAdmin} />}
                     {activeTab === "general" && (
                         <div className="flex items-center justify-center h-full text-muted-foreground">
                             General settings coming soon.
@@ -59,16 +78,16 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     );
 }
 
-function GitSettings() {
+function GitSettings({ user }: { user: User | null }) {
     const [sshKey, setSshKey] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
     const [generating, setGenerating] = useState(false);
-    const [email] = useState("kicad-prism@example.com"); // Hardcoded for now or fetch from user profile if available
+    const [email] = useState(user?.email || "kicad-prism@example.com");
 
     const fetchSshKey = useCallback(async (signal?: AbortSignal) => {
         setLoading(true);
         try {
-            const res = await fetch("/api/settings/ssh-key", { signal });
+            const res = await fetchApi("/api/settings/ssh-key", { signal });
             if (res.ok) {
                 const data = await res.json();
                 setSshKey(data.public_key);
@@ -88,16 +107,16 @@ function GitSettings() {
 
     useEffect(() => {
         const controller = new AbortController();
-        fetchSshKey(controller.signal);
+        void fetchSshKey(controller.signal);
         return () => controller.abort();
     }, [fetchSshKey]);
 
     const generateKey = async () => {
-        if (!confirm("This will overwrite any existing SSH key. Continue?")) return;
+        if (!window.confirm("This will overwrite any existing SSH key. Continue?")) return;
 
         setGenerating(true);
         try {
-            const res = await fetch("/api/settings/ssh-key/generate", {
+            const res = await fetchApi("/api/settings/ssh-key/generate", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ email }),
@@ -107,8 +126,7 @@ function GitSettings() {
                 setSshKey(data.public_key);
                 toast.success("New SSH key generated successfully");
             } else {
-                const err = await res.json();
-                toast.error(err.detail || "Failed to generate SSH key.");
+                toast.error(await readApiError(res, "Failed to generate SSH key."));
             }
         } catch {
             toast.error("An error occurred while connecting to the backend.");
@@ -119,7 +137,7 @@ function GitSettings() {
 
     const copyToClipboard = () => {
         if (sshKey) {
-            navigator.clipboard.writeText(sshKey);
+            void navigator.clipboard.writeText(sshKey);
             toast.success("SSH Key copied to clipboard");
         }
     };
@@ -176,43 +194,175 @@ function GitSettings() {
                     </div>
                 )}
             </div>
+        </div>
+    );
+}
 
-            <div className="space-y-4">
-                <h4 className="text-sm font-medium">Setup Instructions</h4>
+function AccessControlSettings({ isAdmin }: { isAdmin: boolean }) {
+    const [loading, setLoading] = useState(false);
+    const [assignments, setAssignments] = useState<RoleAssignment[]>([]);
+    const [newEmail, setNewEmail] = useState("");
+    const [newRole, setNewRole] = useState<UserRole>("viewer");
 
-                <div className="grid gap-4 md:grid-cols-2">
-                    {/* GitHub Instructions */}
-                    <div className="border rounded-lg p-4 space-y-3">
-                        <div className="flex items-center gap-2">
-                            <div className="h-8 w-8 rounded-full bg-black flex items-center justify-center text-white">
-                                <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" /></svg>
-                            </div>
-                            <span className="font-semibold">GitHub</span>
-                        </div>
-                        <ol className="text-sm text-muted-foreground list-decimal pl-4 space-y-1">
-                            <li>Copy the SSH key above.</li>
-                            <li>Go to <a href="https://github.com/settings/ssh/new" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">GitHub SSH Settings</a>.</li>
-                            <li>Click "New SSH Key".</li>
-                            <li>Paste the key and save.</li>
-                        </ol>
-                    </div>
+    const loadAssignments = useCallback(async () => {
+        if (!isAdmin) {
+            setAssignments([]);
+            return;
+        }
 
-                    {/* GitLab Instructions */}
-                    <div className="border rounded-lg p-4 space-y-3">
-                        <div className="flex items-center gap-2">
-                            <div className="h-8 w-8 rounded-full bg-orange-600 flex items-center justify-center text-white">
-                                <svg viewBox="0 0 24 24" className="h-5 w-5 fill-current"><path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .41.26l2.47 7.6h8.6l2.47-7.6A.43.43 0 0 1 19.18 2a.42.42 0 0 1 .11.16l2.44 7.51 1.22 3.78a.84.84 0 0 1-.3.94z" /></svg>
-                            </div>
-                            <span className="font-semibold">GitLab</span>
-                        </div>
-                        <ol className="text-sm text-muted-foreground list-decimal pl-4 space-y-1">
-                            <li>Copy the SSH key above.</li>
-                            <li>Go to <a href="https://gitlab.com/-/profile/keys" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">GitLab SSH Keys</a>.</li>
-                            <li>Paste the key into the "Key" field.</li>
-                            <li>Click "Add key".</li>
-                        </ol>
-                    </div>
+        setLoading(true);
+        try {
+            const response = await fetchApi("/api/settings/access/users");
+            if (!response.ok) {
+                throw new Error(await readApiError(response, "Failed to load role assignments"));
+            }
+            const data = (await response.json()) as RoleAssignment[];
+            setAssignments(data);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Failed to load role assignments";
+            toast.error(message);
+        } finally {
+            setLoading(false);
+        }
+    }, [isAdmin]);
+
+    useEffect(() => {
+        void loadAssignments();
+    }, [loadAssignments]);
+
+    const upsertRole = async (email: string, role: UserRole) => {
+        const normalizedEmail = email.trim().toLowerCase();
+        if (!normalizedEmail) {
+            toast.error("Email is required");
+            return;
+        }
+        try {
+            const response = await fetchApi(`/api/settings/access/users/${encodeURIComponent(normalizedEmail)}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ role }),
+            });
+            if (!response.ok) {
+                throw new Error(await readApiError(response, "Failed to update role assignment"));
+            }
+            toast.success("Role assignment updated");
+            setNewEmail("");
+            setNewRole("viewer");
+            await loadAssignments();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Failed to update role assignment";
+            toast.error(message);
+        }
+    };
+
+    const removeRole = async (email: string) => {
+        if (!window.confirm(`Remove role assignment for ${email}?`)) {
+            return;
+        }
+
+        try {
+            const response = await fetchApi(`/api/settings/access/users/${encodeURIComponent(email)}`, {
+                method: "DELETE",
+            });
+            if (!response.ok) {
+                throw new Error(await readApiError(response, "Failed to remove role assignment"));
+            }
+            toast.success("Role assignment removed");
+            await loadAssignments();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Failed to remove role assignment";
+            toast.error(message);
+        }
+    };
+
+    if (!isAdmin) {
+        return (
+            <div className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
+                Admin role is required to view and manage user access.
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-medium">Access Control</h3>
+                <p className="text-sm text-muted-foreground">
+                    Manage role assignments for workspace users.
+                </p>
+            </div>
+
+            <div className="rounded-lg border p-4 space-y-3">
+                <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_auto] gap-2">
+                    <Input
+                        placeholder="user@example.com"
+                        value={newEmail}
+                        onChange={(event) => setNewEmail(event.target.value)}
+                    />
+                    <select
+                        className="h-10 rounded-md border bg-background px-3 text-sm"
+                        value={newRole}
+                        onChange={(event) => setNewRole(event.target.value as UserRole)}
+                    >
+                        <option value="viewer">viewer</option>
+                        <option value="designer">designer</option>
+                        <option value="admin">admin</option>
+                    </select>
+                    <Button onClick={() => void upsertRole(newEmail, newRole)}>
+                        <Plus className="h-4 w-4 mr-2" />
+                        Add / Update
+                    </Button>
                 </div>
+            </div>
+
+            <div className="rounded-lg border overflow-hidden">
+                <div className="grid grid-cols-[2fr_1fr_1fr_auto] border-b bg-muted/30 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    <div>Email</div>
+                    <div>Role</div>
+                    <div>Source</div>
+                    <div />
+                </div>
+                {loading ? (
+                    <div className="p-4 text-sm text-muted-foreground">Loading assignments...</div>
+                ) : assignments.length === 0 ? (
+                    <div className="p-4 text-sm text-muted-foreground">No role assignments found.</div>
+                ) : (
+                    assignments.map((assignment) => {
+                        const isBootstrap = assignment.source === "bootstrap";
+                        return (
+                            <div
+                                key={assignment.email}
+                                className="grid grid-cols-[2fr_1fr_1fr_auto] items-center border-b px-4 py-2 gap-2"
+                            >
+                                <div className="truncate text-sm">{assignment.email}</div>
+                                <select
+                                    className="h-8 rounded-md border bg-background px-2 text-sm"
+                                    value={assignment.role}
+                                    disabled={isBootstrap}
+                                    onChange={(event) =>
+                                        void upsertRole(assignment.email, event.target.value as UserRole)
+                                    }
+                                >
+                                    <option value="viewer">viewer</option>
+                                    <option value="designer">designer</option>
+                                    <option value="admin">admin</option>
+                                </select>
+                                <div className="text-sm text-muted-foreground">{assignment.source}</div>
+                                <div className="flex justify-end">
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        disabled={isBootstrap}
+                                        onClick={() => void removeRole(assignment.email)}
+                                        aria-label={`Remove role assignment for ${assignment.email}`}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            </div>
+                        );
+                    })
+                )}
             </div>
         </div>
     );

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -7,6 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { CommentOverlay } from "./comment-overlay";
 import { CommentForm } from "./comment-form";
 import { CommentPanel } from "./comment-panel";
+import { fetchApi } from "@/lib/api";
 import type { User } from "@/types/auth";
 import type { Comment, CommentContext } from "@/types/comments";
 import type {
@@ -100,6 +101,7 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
     const [commentsSourceUrls, setCommentsSourceUrls] = useState<CommentsSourceUrls | null>(null);
     const [isUrlsPopoverOpen, setIsUrlsPopoverOpen] = useState(false);
     const [copiedField, setCopiedField] = useState<string | null>(null);
+    const canModifyComments = user?.role === "admin" || user?.role === "designer";
     const lastCrossProbeRef = useRef<Record<CrossProbeContext, string | null>>({
         SCH: null,
         PCB: null,
@@ -523,6 +525,9 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
         if (!schematicViewer && !pcbViewer) return;
 
         const handleCommentClick = (e: CustomEvent) => {
+            if (!canModifyComments) {
+                return;
+            }
             if (activeCommentContext !== "SCH" && activeCommentContext !== "PCB") {
                 return;
             }
@@ -564,10 +569,13 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
                 pcbViewer.removeEventListener("kicanvas:sheet:loaded", handleSheetLoad as EventListener);
             }
         };
-    }, [activeCommentContext, schematicViewerElement, pcbViewerElement]);
+    }, [activeCommentContext, canModifyComments, schematicViewerElement, pcbViewerElement]);
 
     // Toggle Comment Mode
     const toggleCommentMode = () => {
+        if (!canModifyComments) {
+            return;
+        }
         setCommentMode((previous) => {
             const next = !previous;
             applyCommentModeToViewer(schematicViewerRef.current, next);
@@ -641,11 +649,11 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
 
     // Submit Comment
     const handleSubmitComment = async (content: string) => {
-        if (!pendingLocation) return;
+        if (!pendingLocation || !canModifyComments) return;
         setIsSubmittingComment(true);
         try {
             const location = { ...pendingLocation, page: pendingContext === "SCH" ? activePage : "" };
-            const response = await fetch(`/api/projects/${projectId}/comments`, {
+            const response = await fetchApi(`/api/projects/${projectId}/comments`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -694,7 +702,8 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
 
     // Resolving/Replying
     const handleResolveComment = async (commentId: string, resolved: boolean) => {
-        const response = await fetch(`/api/projects/${projectId}/comments/${commentId}`, {
+        if (!canModifyComments) return;
+        const response = await fetchApi(`/api/projects/${projectId}/comments/${commentId}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ status: resolved ? "RESOLVED" : "OPEN" })
@@ -706,7 +715,8 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
     };
 
     const handleReplyComment = async (commentId: string, content: string) => {
-        const response = await fetch(`/api/projects/${projectId}/comments/${commentId}/replies`, {
+        if (!canModifyComments) return;
+        const response = await fetchApi(`/api/projects/${projectId}/comments/${commentId}/replies`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
@@ -721,8 +731,9 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
     };
 
     const handleDeleteComment = async (commentId: string) => {
+        if (!canModifyComments) return;
         try {
-            const response = await fetch(`/api/projects/${projectId}/comments/${commentId}`, {
+            const response = await fetchApi(`/api/projects/${projectId}/comments/${commentId}`, {
                 method: "DELETE",
             });
             if (response.ok) {
@@ -735,11 +746,12 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
 
     // Export comments.json artifact from DB snapshot
     const handlePushComments = async () => {
+        if (!canModifyComments) return;
         setIsPushingComments(true);
         setPushMessage(null);
 
         try {
-            const response = await fetch(`/api/projects/${projectId}/comments/push`, {
+            const response = await fetchApi(`/api/projects/${projectId}/comments/push`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({}),
@@ -888,6 +900,7 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
                             variant={commentMode ? "default" : "ghost"}
                             size="sm"
                             onClick={toggleCommentMode}
+                            disabled={!canModifyComments}
                             className={`text-xs h-8 ${commentMode ? "bg-amber-600 text-white hover:bg-amber-700" : ""}`}
                         >
                             <MessageSquarePlus className="w-3 h-3 mr-2" />
@@ -905,16 +918,18 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
                                 {comments.length}
                             </span>
                         </Button>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => setShowPushDialog(true)}
-                            className="text-xs h-8 ml-1"
-                            title="Generate comments.json artifact from DB"
-                        >
-                            <GitBranch className="w-3 h-3 mr-2" />
-                            Generate JSON
-                        </Button>
+                        {canModifyComments && (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setShowPushDialog(true)}
+                                className="text-xs h-8 ml-1"
+                                title="Generate comments.json artifact from DB"
+                            >
+                                <GitBranch className="w-3 h-3 mr-2" />
+                                Generate JSON
+                            </Button>
+                        )}
                     </>
                 )}
             </div>
@@ -1049,6 +1064,7 @@ export function Visualizer({ projectId, user }: VisualizerProps) {
                             onReply={handleReplyComment}
                             onDelete={handleDeleteComment}
                             onCommentClick={handleCommentNavigate}
+                            canModify={canModifyComments}
                         />
                     </div>
                 )}

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { toast } from "sonner";
 
+import { User } from "@/types/auth";
 import { FolderTreeItem, Project } from "@/types/project";
 import { ImportDialog } from "./import-dialog";
 import { SettingsDialog } from "./settings-dialog";
@@ -26,9 +27,10 @@ import { WorkspaceSection, ViewMode } from "./workspace/workspace-types";
 
 interface WorkspaceProps {
   searchQuery: string;
+  user: User | null;
 }
 
-export function Workspace({ searchQuery }: WorkspaceProps) {
+export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -56,6 +58,8 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
 
   const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
   const [isDeletingProject, setIsDeletingProject] = useState(false);
+  const canManageProjects = user?.role === "admin" || user?.role === "designer";
+  const canOpenSettings = user?.role === "admin";
 
   const getProjectDisplayName = (project: Project) => project.display_name || project.name;
   const folderFromUrl = searchParams.get("folder");
@@ -125,6 +129,11 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
   };
 
   const handleCreateFolder = async (name: string) => {
+    if (!canManageProjects) {
+      toast.error("You do not have permission to create folders");
+      return;
+    }
+
     setIsCreatingFolder(true);
     try {
       const result = await createFolder(name, currentFolderId);
@@ -141,6 +150,11 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
   };
 
   const handleRenameFolder = async (folderId: string, name: string) => {
+    if (!canManageProjects) {
+      toast.error("You do not have permission to rename folders");
+      return;
+    }
+
     setIsRenamingFolder(true);
     try {
       const result = await renameFolder(folderId, name);
@@ -157,6 +171,11 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
   };
 
   const handleDeleteFolder = async (folderId: string) => {
+    if (!canManageProjects) {
+      toast.error("You do not have permission to delete folders");
+      return;
+    }
+
     setIsDeletingFolder(true);
     try {
       const deletedFolderName = folderToDelete?.name || "folder";
@@ -174,6 +193,11 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
   };
 
   const handleMoveProject = async (projectId: string, folderId: string | null) => {
+    if (!canManageProjects) {
+      toast.error("You do not have permission to move projects");
+      return;
+    }
+
     setIsMovingProject(true);
     try {
       const movedProjectName = projectToMove ? getProjectDisplayName(projectToMove) : "project";
@@ -191,6 +215,11 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
   };
 
   const handleDeleteProject = async (projectId: string) => {
+    if (!canManageProjects) {
+      toast.error("You do not have permission to delete projects");
+      return;
+    }
+
     setIsDeletingProject(true);
     try {
       const deletedProjectName = projectToDelete ? getProjectDisplayName(projectToDelete) : "project";
@@ -238,10 +267,12 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
               <WorkspaceProjectToolbar
                 viewMode={viewMode}
                 onViewModeChange={setViewMode}
-                onImport={() => setIsImportOpen(true)}
-                onCreateFolder={() => setIsCreateFolderOpen(true)}
+                onImport={() => canManageProjects && setIsImportOpen(true)}
+                onCreateFolder={() => canManageProjects && setIsCreateFolderOpen(true)}
                 onRefresh={() => void refresh()}
-                onOpenSettings={() => setIsSettingsOpen(true)}
+                onOpenSettings={() => canOpenSettings && setIsSettingsOpen(true)}
+                canManageProjects={canManageProjects}
+                canOpenSettings={canOpenSettings}
               />
             )}
           </header>
@@ -276,6 +307,7 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
                     onDeleteFolder={setFolderToDelete}
                     onMoveProject={setProjectToMove}
                     onDeleteProject={setProjectToDelete}
+                    canManageProjects={canManageProjects}
                   />
                 ) : (
                   <WorkspaceListView
@@ -291,6 +323,7 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
                     onDeleteFolder={setFolderToDelete}
                     onMoveProject={setProjectToMove}
                     onDeleteProject={setProjectToDelete}
+                    canManageProjects={canManageProjects}
                   />
                 )}
               </div>
@@ -300,7 +333,7 @@ export function Workspace({ searchQuery }: WorkspaceProps) {
       </div>
 
       <ImportDialog open={isImportOpen} onOpenChange={setIsImportOpen} onImportComplete={refresh} />
-      <SettingsDialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen} />
+      <SettingsDialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen} user={user} />
 
       <CreateFolderDialog
         open={isCreateFolderOpen}

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -1,21 +1,13 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { toast } from "sonner";
 
-import { User } from "@/types/auth";
-import { FolderTreeItem, Project } from "@/types/project";
-import { ImportDialog } from "./import-dialog";
-import { SettingsDialog } from "./settings-dialog";
+import type { User } from "@/types/auth";
+import type { FolderTreeItem, Project } from "@/types/project";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceData } from "@/hooks/use-workspace-data";
 import { useWorkspaceSearch } from "@/hooks/use-workspace-search";
-
-import { CreateFolderDialog } from "./workspace/create-folder-dialog";
-import { DeleteFolderDialog } from "./workspace/delete-folder-dialog";
-import { DeleteProjectDialog } from "./workspace/delete-project-dialog";
-import { MoveProjectDialog } from "./workspace/move-project-dialog";
-import { RenameFolderDialog } from "./workspace/rename-folder-dialog";
 import { WorkspaceAppsPlaceholder } from "./workspace/workspace-apps-placeholder";
 import { WorkspaceBreadcrumbs } from "./workspace/workspace-breadcrumbs";
 import { WorkspaceGalleryView } from "./workspace/workspace-gallery-view";
@@ -24,6 +16,28 @@ import { WorkspaceLoadingState } from "./workspace/workspace-loading-state";
 import { WorkspaceProjectToolbar } from "./workspace/workspace-project-toolbar";
 import { WorkspaceSidebar } from "./workspace/workspace-sidebar";
 import { WorkspaceSection, ViewMode } from "./workspace/workspace-types";
+
+const ImportDialog = lazy(() =>
+  import("./import-dialog").then((module) => ({ default: module.ImportDialog }))
+);
+const SettingsDialog = lazy(() =>
+  import("./settings-dialog").then((module) => ({ default: module.SettingsDialog }))
+);
+const CreateFolderDialog = lazy(() =>
+  import("./workspace/create-folder-dialog").then((module) => ({ default: module.CreateFolderDialog }))
+);
+const DeleteFolderDialog = lazy(() =>
+  import("./workspace/delete-folder-dialog").then((module) => ({ default: module.DeleteFolderDialog }))
+);
+const DeleteProjectDialog = lazy(() =>
+  import("./workspace/delete-project-dialog").then((module) => ({ default: module.DeleteProjectDialog }))
+);
+const MoveProjectDialog = lazy(() =>
+  import("./workspace/move-project-dialog").then((module) => ({ default: module.MoveProjectDialog }))
+);
+const RenameFolderDialog = lazy(() =>
+  import("./workspace/rename-folder-dialog").then((module) => ({ default: module.RenameFolderDialog }))
+);
 
 interface WorkspaceProps {
   searchQuery: string;
@@ -332,42 +346,70 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
         </div>
       </div>
 
-      <ImportDialog open={isImportOpen} onOpenChange={setIsImportOpen} onImportComplete={refresh} />
-      <SettingsDialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen} user={user} />
+      {isImportOpen && (
+        <Suspense fallback={null}>
+          <ImportDialog open={isImportOpen} onOpenChange={setIsImportOpen} onImportComplete={refresh} />
+        </Suspense>
+      )}
+      {isSettingsOpen && (
+        <Suspense fallback={null}>
+          <SettingsDialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen} user={user} />
+        </Suspense>
+      )}
 
-      <CreateFolderDialog
-        open={isCreateFolderOpen}
-        isSubmitting={isCreatingFolder}
-        onOpenChange={setIsCreateFolderOpen}
-        onSubmit={handleCreateFolder}
-      />
-      <RenameFolderDialog
-        folder={folderToRename}
-        isSubmitting={isRenamingFolder}
-        onClose={() => setFolderToRename(null)}
-        onSubmit={handleRenameFolder}
-      />
-      <DeleteFolderDialog
-        folder={folderToDelete}
-        isDeleting={isDeletingFolder}
-        onClose={() => setFolderToDelete(null)}
-        onConfirm={handleDeleteFolder}
-      />
-      <MoveProjectDialog
-        project={projectToMove}
-        folders={folders}
-        isMoving={isMovingProject}
-        onClose={() => setProjectToMove(null)}
-        onConfirm={handleMoveProject}
-        getProjectDisplayName={getProjectDisplayName}
-      />
-      <DeleteProjectDialog
-        project={projectToDelete}
-        isDeleting={isDeletingProject}
-        onClose={() => setProjectToDelete(null)}
-        onConfirm={handleDeleteProject}
-        getProjectDisplayName={getProjectDisplayName}
-      />
+      {isCreateFolderOpen && (
+        <Suspense fallback={null}>
+          <CreateFolderDialog
+            open={isCreateFolderOpen}
+            isSubmitting={isCreatingFolder}
+            onOpenChange={setIsCreateFolderOpen}
+            onSubmit={handleCreateFolder}
+          />
+        </Suspense>
+      )}
+      {folderToRename && (
+        <Suspense fallback={null}>
+          <RenameFolderDialog
+            folder={folderToRename}
+            isSubmitting={isRenamingFolder}
+            onClose={() => setFolderToRename(null)}
+            onSubmit={handleRenameFolder}
+          />
+        </Suspense>
+      )}
+      {folderToDelete && (
+        <Suspense fallback={null}>
+          <DeleteFolderDialog
+            folder={folderToDelete}
+            isDeleting={isDeletingFolder}
+            onClose={() => setFolderToDelete(null)}
+            onConfirm={handleDeleteFolder}
+          />
+        </Suspense>
+      )}
+      {projectToMove && (
+        <Suspense fallback={null}>
+          <MoveProjectDialog
+            project={projectToMove}
+            folders={folders}
+            isMoving={isMovingProject}
+            onClose={() => setProjectToMove(null)}
+            onConfirm={handleMoveProject}
+            getProjectDisplayName={getProjectDisplayName}
+          />
+        </Suspense>
+      )}
+      {projectToDelete && (
+        <Suspense fallback={null}>
+          <DeleteProjectDialog
+            project={projectToDelete}
+            isDeleting={isDeletingProject}
+            onClose={() => setProjectToDelete(null)}
+            onConfirm={handleDeleteProject}
+            getProjectDisplayName={getProjectDisplayName}
+          />
+        </Suspense>
+      )}
     </>
   );
 }

--- a/frontend/src/components/workspace/workspace-action-menus.tsx
+++ b/frontend/src/components/workspace/workspace-action-menus.tsx
@@ -15,6 +15,7 @@ interface FolderActionMenuProps {
   folder: FolderTreeItem;
   onRename: (folder: FolderTreeItem) => void;
   onDelete: (folder: FolderTreeItem) => void;
+  canManage: boolean;
 }
 
 interface ProjectActionMenuProps {
@@ -22,9 +23,14 @@ interface ProjectActionMenuProps {
   projectName: string;
   onMove: (project: Project) => void;
   onDelete: (project: Project) => void;
+  canManage: boolean;
 }
 
-export function FolderActionMenu({ folder, onRename, onDelete }: FolderActionMenuProps) {
+export function FolderActionMenu({ folder, onRename, onDelete, canManage }: FolderActionMenuProps) {
+  if (!canManage) {
+    return null;
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -66,7 +72,11 @@ export function FolderActionMenu({ folder, onRename, onDelete }: FolderActionMen
   );
 }
 
-export function ProjectActionMenu({ project, projectName, onMove, onDelete }: ProjectActionMenuProps) {
+export function ProjectActionMenu({ project, projectName, onMove, onDelete, canManage }: ProjectActionMenuProps) {
+  if (!canManage) {
+    return null;
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/frontend/src/components/workspace/workspace-gallery-view.tsx
+++ b/frontend/src/components/workspace/workspace-gallery-view.tsx
@@ -21,6 +21,7 @@ interface WorkspaceGalleryViewProps {
   onDeleteFolder: (folder: FolderTreeItem) => void;
   onMoveProject: (project: Project) => void;
   onDeleteProject: (project: Project) => void;
+  canManageProjects: boolean;
 }
 
 export function WorkspaceGalleryView({
@@ -37,6 +38,7 @@ export function WorkspaceGalleryView({
   onDeleteFolder,
   onMoveProject,
   onDeleteProject,
+  canManageProjects,
 }: WorkspaceGalleryViewProps) {
   return (
     <div className="space-y-6">
@@ -61,6 +63,7 @@ export function WorkspaceGalleryView({
                       projectName={getProjectDisplayName(project)}
                       onMove={onMoveProject}
                       onDelete={onDeleteProject}
+                      canManage={canManageProjects}
                     />
                   }
                 />
@@ -102,7 +105,12 @@ export function WorkspaceGalleryView({
                           </span>
                         </div>
                       </div>
-                      <FolderActionMenu folder={folder} onRename={onRenameFolder} onDelete={onDeleteFolder} />
+                      <FolderActionMenu
+                        folder={folder}
+                        onRename={onRenameFolder}
+                        onDelete={onDeleteFolder}
+                        canManage={canManageProjects}
+                      />
                     </div>
                   </div>
                 ))}
@@ -128,6 +136,7 @@ export function WorkspaceGalleryView({
                         projectName={getProjectDisplayName(project)}
                         onMove={onMoveProject}
                         onDelete={onDeleteProject}
+                        canManage={canManageProjects}
                       />
                     }
                   />

--- a/frontend/src/components/workspace/workspace-list-view.tsx
+++ b/frontend/src/components/workspace/workspace-list-view.tsx
@@ -18,6 +18,7 @@ interface WorkspaceListViewProps {
   onDeleteFolder: (folder: FolderTreeItem) => void;
   onMoveProject: (project: Project) => void;
   onDeleteProject: (project: Project) => void;
+  canManageProjects: boolean;
 }
 
 function resolveProjectLocation(
@@ -50,6 +51,7 @@ export function WorkspaceListView({
   onDeleteFolder,
   onMoveProject,
   onDeleteProject,
+  canManageProjects,
 }: WorkspaceListViewProps) {
   return (
     <div className="overflow-hidden rounded-xl border">
@@ -82,7 +84,12 @@ export function WorkspaceListView({
               <p className="truncate text-sm text-muted-foreground">Current Level</p>
               <p className="truncate text-sm text-muted-foreground">-</p>
               <div className="flex justify-end">
-                <FolderActionMenu folder={folder} onRename={onRenameFolder} onDelete={onDeleteFolder} />
+                <FolderActionMenu
+                  folder={folder}
+                  onRename={onRenameFolder}
+                  onDelete={onDeleteFolder}
+                  canManage={canManageProjects}
+                />
               </div>
             </div>
           ))}
@@ -110,6 +117,7 @@ export function WorkspaceListView({
                   projectName={getProjectDisplayName(project)}
                   onMove={onMoveProject}
                   onDelete={onDeleteProject}
+                  canManage={canManageProjects}
                 />
               </div>
             </div>

--- a/frontend/src/components/workspace/workspace-project-toolbar.tsx
+++ b/frontend/src/components/workspace/workspace-project-toolbar.tsx
@@ -11,6 +11,8 @@ interface WorkspaceProjectToolbarProps {
   onCreateFolder: () => void;
   onRefresh: () => void;
   onOpenSettings: () => void;
+  canManageProjects: boolean;
+  canOpenSettings: boolean;
 }
 
 export function WorkspaceProjectToolbar({
@@ -20,6 +22,8 @@ export function WorkspaceProjectToolbar({
   onCreateFolder,
   onRefresh,
   onOpenSettings,
+  canManageProjects,
+  canOpenSettings,
 }: WorkspaceProjectToolbarProps) {
   return (
     <div className="flex flex-wrap items-center gap-2 px-4 py-3 md:h-14 md:flex-nowrap md:py-0">
@@ -43,19 +47,25 @@ export function WorkspaceProjectToolbar({
       </div>
 
       <div className="ml-auto flex items-center gap-2">
-        <Button onClick={onImport}>
-          <Plus className="mr-2 h-4 w-4" />
-          Import Project
-        </Button>
-        <Button variant="outline" size="icon" onClick={onCreateFolder} aria-label="Create new folder">
-          <FolderPlus className="h-4 w-4" />
-        </Button>
+        {canManageProjects && (
+          <>
+            <Button onClick={onImport}>
+              <Plus className="mr-2 h-4 w-4" />
+              Import Project
+            </Button>
+            <Button variant="outline" size="icon" onClick={onCreateFolder} aria-label="Create new folder">
+              <FolderPlus className="h-4 w-4" />
+            </Button>
+          </>
+        )}
         <Button variant="outline" size="icon" onClick={onRefresh} aria-label="Refresh workspace">
           <RefreshCw className="h-4 w-4" />
         </Button>
-        <Button variant="outline" size="icon" onClick={onOpenSettings} aria-label="Open settings">
-          <Settings className="h-4 w-4" />
-        </Button>
+        {canOpenSettings && (
+          <Button variant="outline" size="icon" onClick={onOpenSettings} aria-label="Open settings">
+            <Settings className="h-4 w-4" />
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/use-workspace-data.ts
+++ b/frontend/src/hooks/use-workspace-data.ts
@@ -22,6 +22,11 @@ interface WorkspaceDataState {
   deleteProject: (projectId: string) => Promise<WorkspaceActionResult>;
 }
 
+interface WorkspaceBootstrapResponse {
+  projects: Project[];
+  folders: FolderTreeItem[];
+}
+
 export function useWorkspaceData(): WorkspaceDataState {
   const [projects, setProjects] = useState<Project[]>([]);
   const [folders, setFolders] = useState<FolderTreeItem[]>([]);
@@ -32,40 +37,22 @@ export function useWorkspaceData(): WorkspaceDataState {
     setLoading(true);
     setError(null);
 
-    const [projectsResult, foldersResult] = await Promise.allSettled([
-      fetchJson<Project[]>("/api/projects/", undefined, "Failed to load projects"),
-      fetchJson<FolderTreeItem[]>("/api/folders/tree", undefined, "Failed to load folders"),
-    ]);
-
-    if (projectsResult.status === "fulfilled") {
-      setProjects(projectsResult.value);
-    } else {
-      setProjects([]);
-    }
-
-    if (foldersResult.status === "fulfilled") {
-      setFolders(foldersResult.value);
-    } else {
-      setFolders([]);
-    }
-
-    if (projectsResult.status === "rejected") {
-      const message =
-        projectsResult.reason instanceof Error
-          ? projectsResult.reason.message
-          : "Failed to load projects";
-      setError(message);
-    } else if (foldersResult.status === "rejected") {
-      const message =
-        foldersResult.reason instanceof Error
-          ? foldersResult.reason.message
-          : "Failed to load folders";
-      setError(message);
-    } else {
+    try {
+      const data = await fetchJson<WorkspaceBootstrapResponse>(
+        "/api/workspace/bootstrap",
+        undefined,
+        "Failed to load workspace"
+      );
+      setProjects(data.projects);
+      setFolders(data.folders);
       setError(null);
+    } catch (error) {
+      setProjects([]);
+      setFolders([]);
+      setError(error instanceof Error ? error.message : "Failed to load workspace");
+    } finally {
+      setLoading(false);
     }
-
-    setLoading(false);
   }, []);
 
   useEffect(() => {

--- a/frontend/src/hooks/use-workspace-data.ts
+++ b/frontend/src/hooks/use-workspace-data.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { fetchJson, readApiError } from "@/lib/api";
+import { fetchApi, fetchJson, readApiError } from "@/lib/api";
 import { FolderTreeItem, Project } from "@/types/project";
 
 export interface WorkspaceActionResult {
@@ -87,7 +87,7 @@ export function useWorkspaceData(): WorkspaceDataState {
       fallbackError: string
     ): Promise<WorkspaceActionResult> => {
       try {
-        const response = await fetch(input, init);
+        const response = await fetchApi(input, init);
         if (!response.ok) {
           return { ok: false, error: await readApiError(response, fallbackError) };
         }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,39 @@ export interface ApiErrorPayload {
   message?: string;
 }
 
+export class ApiHttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiHttpError";
+    this.status = status;
+  }
+}
+
+export async function fetchApi(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+  const response = await fetch(input, {
+    ...init,
+    credentials: init?.credentials ?? "include",
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    window.dispatchEvent(
+      new CustomEvent("kicad-prism-auth-error", {
+        detail: { status: response.status, url },
+      })
+    );
+  }
+
+  return response;
+}
+
 export async function readApiError(response: Response, fallback: string): Promise<string> {
   try {
     const payload = (await response.json()) as ApiErrorPayload;
@@ -17,10 +50,9 @@ export async function fetchJson<T>(
   init?: RequestInit,
   fallbackError = "Request failed"
 ): Promise<T> {
-  const response = await fetch(input, init);
+  const response = await fetchApi(input, init);
   if (!response.ok) {
-    throw new Error(await readApiError(response, fallbackError));
+    throw new ApiHttpError(response.status, await readApiError(response, fallbackError));
   }
   return (await response.json()) as T;
 }
-

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -38,10 +38,6 @@ interface Project {
     last_modified: string;
 }
 
-interface ProjectNameResponse {
-    display_name?: string;
-}
-
 interface ReadmeResponse {
     content: string;
 }
@@ -144,13 +140,8 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                     ? `/api/projects/${projectId}/readme?commit=${currentCommit}`
                     : `/api/projects/${projectId}/readme`;
 
-                const [projectData, nameData, readmeData] = await Promise.all([
+                const [projectData, readmeData] = await Promise.all([
                     fetchJson<Project>(`/api/projects/${projectId}`, { signal: controller.signal }, "Failed to fetch project"),
-                    fetchJson<ProjectNameResponse>(
-                        `/api/projects/${projectId}/name`,
-                        { signal: controller.signal },
-                        "Failed to fetch project name"
-                    ).catch(() => null),
                     fetchJson<ReadmeResponse>(readmeUrl, { signal: controller.signal }, "README not found").catch(() => null),
                 ]);
 
@@ -158,10 +149,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                     return;
                 }
 
-                setProject({
-                    ...projectData,
-                    display_name: nameData?.display_name ?? projectData.display_name,
-                });
+                setProject(projectData);
                 setReadme(readmeData?.content ?? "");
             } catch (err) {
                 if (controller.signal.aborted) {

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -37,12 +37,13 @@ interface Project {
     last_modified: string;
 }
 
-interface ReadmeResponse {
-    content: string;
-}
-
 interface CommitDistanceResponse {
     commits_behind: number;
+}
+
+interface ProjectOverviewResponse {
+    project: Project;
+    readme: string | null;
 }
 
 interface WorkflowJobResponse {
@@ -131,21 +132,21 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
 
         const fetchProjectData = async () => {
             try {
-                const readmeUrl = currentCommit
-                    ? `/api/projects/${projectId}/readme?commit=${currentCommit}`
-                    : `/api/projects/${projectId}/readme`;
-
-                const [projectData, readmeData] = await Promise.all([
-                    fetchJson<Project>(`/api/projects/${projectId}`, { signal: controller.signal }, "Failed to fetch project"),
-                    fetchJson<ReadmeResponse>(readmeUrl, { signal: controller.signal }, "README not found").catch(() => null),
-                ]);
+                const overviewUrl = currentCommit
+                    ? `/api/projects/${projectId}/overview?commit=${encodeURIComponent(currentCommit)}`
+                    : `/api/projects/${projectId}/overview`;
+                const overview = await fetchJson<ProjectOverviewResponse>(
+                    overviewUrl,
+                    { signal: controller.signal },
+                    "Failed to fetch project overview"
+                );
 
                 if (controller.signal.aborted) {
                     return;
                 }
 
-                setProject(projectData);
-                setReadme(readmeData?.content ?? "");
+                setProject(overview.project);
+                setReadme(overview.readme ?? "");
             } catch (err) {
                 if (controller.signal.aborted) {
                     return;

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -2,7 +2,7 @@ import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { Suspense, lazy, useEffect, useState, type ComponentType } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, FileText, History, Box, FolderOpen, ChevronLeft, ChevronRight, GitBranch, RotateCcw, PlayCircle, RefreshCw, Menu, Settings } from "lucide-react";
-import { fetchJson, readApiError } from "@/lib/api";
+import { fetchApi, fetchJson, readApiError } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -83,6 +83,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
     const [visualizerLoaded, setVisualizerLoaded] = useState(false);
     const [refreshKey, setRefreshKey] = useState(0);
     const [pathConfigOpen, setPathConfigOpen] = useState(false);
+    const canMutateProject = user?.role === "admin" || user?.role === "designer";
 
     // Helper function to get display name
     const getDisplayName = (project: Project) => {
@@ -106,7 +107,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
     };
 
     const handleSync = async () => {
-        if (!projectId || syncing) return;
+        if (!projectId || syncing || !canMutateProject) return;
 
         setSyncing(true);
         setSyncMessage(null);
@@ -296,27 +297,30 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                 </div>
 
                 {/* Sync Button */}
-                <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleSync}
-                    disabled={syncing}
-                    className="flex items-center gap-2"
-                    title="Sync with remote repository"
-                >
-                    <RefreshCw className={cn("h-4 w-4", syncing && "animate-spin")} />
-                    {syncing ? 'Syncing...' : 'Sync'}
-                </Button>
+                {canMutateProject && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleSync}
+                        disabled={syncing}
+                        className="flex items-center gap-2"
+                        title="Sync with remote repository"
+                    >
+                        <RefreshCw className={cn("h-4 w-4", syncing && "animate-spin")} />
+                        {syncing ? 'Syncing...' : 'Sync'}
+                    </Button>
+                )}
 
-                {/* Path Config Button */}
-                <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setPathConfigOpen(true)}
-                    title="Project settings"
-                >
-                    <Settings className="h-4 w-4" />
-                </Button>
+                {canMutateProject && (
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setPathConfigOpen(true)}
+                        title="Project settings"
+                    >
+                        <Settings className="h-4 w-4" />
+                    </Button>
+                )}
 
                 {projectId && pathConfigOpen && (
                     <Suspense fallback={null}>
@@ -489,7 +493,12 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                             <h2 className="text-2xl font-bold mb-6">History</h2>
                             {projectId && (
                                 <Suspense fallback={<div className="text-sm text-muted-foreground">Loading history...</div>}>
-                                    <HistoryViewer key={refreshKey} projectId={projectId} onViewCommit={handleViewCommit} />
+                                    <HistoryViewer
+                                        key={refreshKey}
+                                        projectId={projectId}
+                                        onViewCommit={handleViewCommit}
+                                        canCompareDiffs={canMutateProject}
+                                    />
                                 </Suspense>
                             )}
                         </div>
@@ -515,7 +524,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
 
                     {activeSection === "workflows" && (
                         <div>
-                            <WorkflowsPanel projectId={projectId!} user={user} />
+                            <WorkflowsPanel projectId={projectId!} user={user} canRun={canMutateProject} />
                         </div>
                     )}
 
@@ -527,7 +536,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
 }
 
 // Workflows Sub-component
-function WorkflowsPanel({ projectId, user }: { projectId: string, user: User | null }) {
+function WorkflowsPanel({ projectId, user, canRun }: { projectId: string, user: User | null, canRun: boolean }) {
     const [runningJob, setRunningJob] = useState<{ id: string, type: string } | null>(null);
     const [logs, setLogs] = useState<string[]>([]);
     const [status, setStatus] = useState<string>("idle");
@@ -566,10 +575,14 @@ function WorkflowsPanel({ projectId, user }: { projectId: string, user: User | n
     }, [runningJob]);
 
     const runWorkflow = async (type: string) => {
+        if (!canRun) {
+            alert("You do not have permission to run workflows.");
+            return;
+        }
         setLogs([]);
         setStatus("running");
         try {
-            const res = await fetch(`/api/projects/${projectId}/workflows`, {
+            const res = await fetchApi(`/api/projects/${projectId}/workflows`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -602,21 +615,21 @@ function WorkflowsPanel({ projectId, user }: { projectId: string, user: User | n
                     desc="Generate Schematics, Netlists, and BOMs."
                     icon={FileText}
                     onClick={() => runWorkflow("design")}
-                    disabled={status === "running"}
+                    disabled={status === "running" || !canRun}
                 />
                 <WorkflowCard
                     title="Manufacturing Outputs"
                     desc="Generate Gerbers, Drill Files, and Pick & Place."
                     icon={Box}
                     onClick={() => runWorkflow("manufacturing")}
-                    disabled={status === "running"}
+                    disabled={status === "running" || !canRun}
                 />
                 <WorkflowCard
                     title="3D Renders"
                     desc="Generate Ray-Traced Renders of the PCB."
                     icon={Box}
                     onClick={() => runWorkflow("render")}
-                    disabled={status === "running"}
+                    disabled={status === "running" || !canRun}
                 />
             </div>
 

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -41,12 +41,8 @@ interface ReadmeResponse {
     content: string;
 }
 
-interface CommitSummary {
-    full_hash: string;
-}
-
-interface CommitsResponse {
-    commits: CommitSummary[];
+interface CommitDistanceResponse {
+    commits_behind: number;
 }
 
 interface WorkflowJobResponse {
@@ -184,18 +180,17 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
             }
 
             try {
-                const data = await fetchJson<CommitsResponse>(
-                    `/api/projects/${projectId}/commits`,
+                const data = await fetchJson<CommitDistanceResponse>(
+                    `/api/projects/${projectId}/commits/distance?commit=${encodeURIComponent(currentCommit)}`,
                     { signal: controller.signal },
-                    "Failed to fetch commit history"
+                    "Failed to fetch commit distance"
                 );
 
                 if (controller.signal.aborted) {
                     return;
                 }
 
-                const index = data.commits.findIndex((commit) => commit.full_hash === currentCommit);
-                setCommitsBehind(index >= 0 ? index : 0);
+                setCommitsBehind(data.commits_behind ?? 0);
             } catch (err) {
                 if (controller.signal.aborted) {
                     return;

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -4,10 +4,6 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft, FileText, History, Box, FolderOpen, ChevronLeft, ChevronRight, GitBranch, RotateCcw, PlayCircle, RefreshCw, Menu, Settings } from "lucide-react";
 import { fetchApi, fetchJson, readApiError } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
-import "github-markdown-css/github-markdown-dark.css";
 import { User } from "@/types/auth";
 
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -26,6 +22,9 @@ const HistoryViewer = lazy(() =>
 );
 const Visualizer = lazy(() =>
     import("@/components/visualizer").then((module) => ({ default: module.Visualizer }))
+);
+const MarkdownContent = lazy(() =>
+    import("@/components/markdown-content").then((module) => ({ default: module.MarkdownContent }))
 );
 
 interface Project {
@@ -424,28 +423,14 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                             </div>
 
                             {readme && (
-                                <div className="markdown-body" style={{ background: 'transparent' }}>
-                                    <ReactMarkdown
-                                        remarkPlugins={[remarkGfm]}
-                                        rehypePlugins={[rehypeRaw]}
-                                        components={{
-                                            img: ({ src, alt }) => {
-                                                // Convert relative image paths to use backend API
-                                                const imgSrc = src?.startsWith('http')
-                                                    ? src
-                                                    : `/api/projects/${projectId}/asset/${src}`;
-                                                return (
-                                                    <img
-                                                        src={imgSrc}
-                                                        alt={alt || ''}
-                                                    />
-                                                );
-                                            }
-                                        }}
-                                    >
-                                        {readme}
-                                    </ReactMarkdown>
-                                </div>
+                                <Suspense fallback={<div className="text-sm text-muted-foreground">Loading README...</div>}>
+                                    <MarkdownContent
+                                        content={readme}
+                                        resolveImageSrc={(src) =>
+                                            src?.startsWith('http') ? src : `/api/projects/${projectId}/asset/${src}`
+                                        }
+                                    />
+                                </Suspense>
                             )}
 
                             {!readme && (

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,7 +1,10 @@
+export type UserRole = "admin" | "designer" | "viewer";
+
 export interface User {
     name: string;
     email: string;
     picture?: string;
+    role: UserRole;
 }
 
 export interface AuthConfig {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,6 +22,31 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
+          if (id.includes("node_modules/react/") || id.includes("node_modules/react-dom/") || id.includes("node_modules/react-router")) {
+            return "framework"
+          }
+          if (
+            id.includes("node_modules/react-markdown") ||
+            id.includes("node_modules/remark-gfm") ||
+            id.includes("node_modules/rehype-raw") ||
+            id.includes("node_modules/github-markdown-css")
+          ) {
+            return "markdown-runtime"
+          }
+          if (id.includes("node_modules/@react-oauth/google")) {
+            return "auth-runtime"
+          }
+          if (
+            id.includes("node_modules/@radix-ui/") ||
+            id.includes("node_modules/radix-ui/") ||
+            id.includes("node_modules/@base-ui/") ||
+            id.includes("node_modules/sonner")
+          ) {
+            return "ui-runtime"
+          }
+          if (id.includes("node_modules/lucide-react")) {
+            return "icons-runtime"
+          }
           if (id.includes("node_modules/online-3d-viewer")) {
             return "viewer3d-runtime"
           }


### PR DESCRIPTION
## Summary

This branch brings the RBAC session-auth work to `main`, followed by a focused performance pass and a documentation refresh.

From a user perspective, the changes do four things:
- switch the app to signed session-cookie auth with RBAC-managed access control
- reduce expensive backend work in workspace load, path resolution, commit history filtering, and file/folder lookups
- reduce frontend startup cost with safer route/dialog chunking outside the visualizer surface
- update the repo documentation so Docker hosting, local development, auth, and project conventions match the current codebase

## Root Cause and User Impact

Before this branch, there were three separate problems:

First, auth and permissions were not modeled around persistent RBAC-backed user sessions. That made it harder to host the platform safely with clear viewer/designer/admin boundaries.

Second, several backend and frontend paths were doing duplicate or overly expensive work. Workspace load duplicated project/folder hydration, `.prism.json` path resolution could fall back into repeated filesystem detection, filtered subproject history scaled poorly, and some UI paths made redundant requests or left polling active longer than necessary.

Third, the repo documentation had drifted behind the code. Docker instructions, auth expectations, session-secret handling, and several feature notes no longer described the runtime accurately.

The net effect for users was slower workspace/detail flows, extra backend load on larger repos, and confusing deployment setup when trying to host the app with Docker.

## What Changed

### Auth and access control

- added RBAC-backed session auth flow
- introduced signed `HttpOnly` session cookies
- enforced viewer/designer/admin role checks across API routes
- documented the requirement for `SESSION_SECRET` when auth is enabled

### Backend performance work

- added `/api/workspace/bootstrap` so workspace initial load can fetch projects and folders together
- reduced folder-tree work by avoiding unnecessary full project hydration
- improved `.prism.json` path resolution so explicit config is honored first and missing fields alone are auto-detected
- replaced expensive subproject commit-history filtering with path-scoped git queries
- added a lightweight commit-distance endpoint for project history UI
- cached folder metadata and repeated file listings where safe
- added a project overview endpoint to combine detail and README loading

### Frontend performance work

- moved workspace data loading to the bootstrap endpoint
- removed redundant fetches in project detail and settings flows
- cleaned up import-dialog polling on close and unmount
- memoized repeated tree and size calculations in assets/docs surfaces
- route-split non-visualizer app surfaces and deferred dialog/runtime code more aggressively, while avoiding the chunking pattern that broke the production Docker bundle

### Documentation

- updated the root README to match current auth, Docker, and local-dev behavior
- rewrote deployment guidance around Docker, `.env`, `SESSION_SECRET`, and Google OAuth
- refreshed docs for comments, metadata, path mapping, workspace behavior, frontend responsibilities, and project repo structure

## Validation

The branch was validated in pieces as the work landed:

- backend modules compiled successfully with `backend/venv/bin/python -m compileall backend/app`
- frontend lint and production builds passed with `npm run lint` and `npm run build`
- local benchmark runs showed meaningful improvements in filtered history, path-config resolution, folder-tree generation, workspace load, and repeated file-listing paths
- Docker hosting was manually checked after the chunking regression was narrowed down and corrected

## Notes

- visualizer-specific implementation was intentionally left out of the performance pass except for keeping viewer-related bundles isolated
- there is an unrelated unstaged local change in `frontend/vite.config.ts` in the working tree; it is not part of this PR
