### PR TITLE
Add workspace project properties overlay

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,15 +1,22 @@
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.api._helpers import get_project_for_role_or_404, require_output_type, resolve_path_within_root
 from app.core.security import AuthenticatedUser, require_designer, require_viewer
-from app.services import file_service, folder_service, path_config_service, project_import_service, project_service
+from app.services import (
+    file_service,
+    folder_service,
+    path_config_service,
+    project_import_service,
+    project_properties_service,
+    project_service,
+)
 from app.services.comments_url_service import build_comments_source_urls, resolve_comments_base_url
 from app.services.git_service import (
     get_commit_distance,
@@ -32,6 +39,69 @@ class Monorepo(BaseModel):
     project_count: int
     last_synced: Optional[str] = None
     repo_url: Optional[str] = None
+
+
+class ProjectPropertiesTitleBlock(BaseModel):
+    title: str = ""
+    date: str = ""
+    rev: str = ""
+    company: str = ""
+    comments: Dict[str, str] = Field(default_factory=dict)
+
+
+class ProjectPropertiesSchematicFile(BaseModel):
+    path: str
+    filename: str
+    version: Optional[int] = None
+    generator: Optional[str] = None
+    generator_version: Optional[str] = None
+    paper: Optional[str] = None
+    uuid: Optional[str] = None
+    title_block: Optional[ProjectPropertiesTitleBlock] = None
+
+
+class ProjectPropertiesPcbFile(BaseModel):
+    path: str
+    filename: str
+    version: Optional[int] = None
+    generator: Optional[str] = None
+    generator_version: Optional[str] = None
+    paper: Optional[str] = None
+    dimensions_mm: Optional[Dict[str, float]] = None
+    thickness_mm: Optional[float] = None
+    title_block: Optional[ProjectPropertiesTitleBlock] = None
+
+
+class ProjectPropertiesLatestCommit(BaseModel):
+    hash: str
+    full_hash: str
+    author: str
+    email: str
+    date: str
+    message: str
+
+
+class ProjectPropertiesTag(BaseModel):
+    tag: str
+    commit_hash: str
+    date: str
+    message: str
+
+
+class ProjectPropertiesRepository(BaseModel):
+    latest_commit: Optional[ProjectPropertiesLatestCommit] = None
+    latest_tag: Optional[ProjectPropertiesTag] = None
+
+
+class ProjectPropertiesFiles(BaseModel):
+    schematic: Optional[ProjectPropertiesSchematicFile] = None
+    pcb: Optional[ProjectPropertiesPcbFile] = None
+
+
+class ProjectPropertiesResponse(BaseModel):
+    project: project_service.Project
+    repository: ProjectPropertiesRepository
+    files: ProjectPropertiesFiles
 
 
 def _repo_context(project: project_service.Project) -> tuple[str, Optional[str]]:
@@ -394,6 +464,55 @@ async def get_project_thumbnail(project_id: str, user: AuthenticatedUser = Depen
 async def get_project_detail(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """Get detailed project information."""
     return get_project_for_role_or_404(project_id, user.role)
+
+
+@router.get("/{project_id}/properties", response_model=ProjectPropertiesResponse)
+async def get_project_properties(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+    project = get_project_for_role_or_404(project_id, user.role)
+    repo_path, relative_path = _repo_context(project)
+
+    if relative_path:
+        releases = get_releases_filtered(repo_path, relative_path)
+        latest_commits = get_commits_list_filtered(repo_path, relative_path, 1)
+    else:
+        releases = get_releases(repo_path)
+        latest_commits = get_commits_list(repo_path, 1)
+
+    latest_commit = latest_commits[0] if latest_commits else None
+    latest_tag = releases[0] if releases else None
+
+    schematic_path = project_service.find_schematic_file(project.path)
+    pcb_path = project_service.find_pcb_file(project.path)
+    schematic_metadata = project_properties_service.extract_schematic_metadata(project.path, schematic_path)
+    pcb_metadata = project_properties_service.extract_pcb_metadata(project.path, pcb_path)
+
+    return ProjectPropertiesResponse(
+        project=project,
+        repository=ProjectPropertiesRepository(
+            latest_commit=(
+                ProjectPropertiesLatestCommit(**latest_commit)
+                if latest_commit
+                else None
+            ),
+            latest_tag=(
+                ProjectPropertiesTag(**latest_tag)
+                if latest_tag
+                else None
+            ),
+        ),
+        files=ProjectPropertiesFiles(
+            schematic=(
+                ProjectPropertiesSchematicFile(**schematic_metadata)
+                if schematic_metadata
+                else None
+            ),
+            pcb=(
+                ProjectPropertiesPcbFile(**pcb_metadata)
+                if pcb_metadata
+                else None
+            ),
+        ),
+    )
 
 
 @router.get("/{project_id}/overview")

--- a/backend/app/services/project_properties_service.py
+++ b/backend/app/services/project_properties_service.py
@@ -1,10 +1,13 @@
+from copy import deepcopy
 import math
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 
 _STRING_PATTERN = r'"((?:[^"\\]|\\.)*)"'
+_FILE_METADATA_CACHE_MAX_ENTRIES = 128
+_file_metadata_cache: dict[tuple[str, str], dict[str, object]] = {}
 
 
 def _unescape_kicad_string(value: str) -> str:
@@ -188,11 +191,54 @@ def _parse_title_block(text: str) -> Optional[dict]:
     }
 
 
-def _extract_common_file_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
+def invalidate_project_properties_cache(project_path: Optional[str] = None) -> None:
+    global _file_metadata_cache
+
+    if project_path is None:
+        _file_metadata_cache = {}
+        return
+
+    resolved_project = str(Path(project_path).resolve())
+    _file_metadata_cache = {
+        key: value
+        for key, value in _file_metadata_cache.items()
+        if key[0] != resolved_project
+    }
+
+
+def _trim_file_metadata_cache() -> None:
+    while len(_file_metadata_cache) > _FILE_METADATA_CACHE_MAX_ENTRIES:
+        oldest_key = next(iter(_file_metadata_cache))
+        _file_metadata_cache.pop(oldest_key, None)
+
+
+def _load_cached_file_metadata(
+    project_path: str,
+    file_path: Optional[str],
+    parser: Callable[[str, str, str], dict],
+) -> Optional[dict]:
     if not file_path:
         return None
 
     path = Path(file_path)
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+
+    resolved_project = str(Path(project_path).resolve())
+    resolved_file = str(path.resolve())
+    cache_key = (resolved_project, resolved_file)
+    cached = _file_metadata_cache.get(cache_key)
+
+    if (
+        cached
+        and cached.get("mtime_ns") == stat.st_mtime_ns
+        and cached.get("size") == stat.st_size
+    ):
+        metadata = cached.get("metadata")
+        return deepcopy(metadata) if isinstance(metadata, dict) else None
+
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
@@ -203,46 +249,46 @@ def _extract_common_file_metadata(project_path: str, file_path: Optional[str]) -
     except ValueError:
         relative_path = path.name
 
-    return {
-        "path": relative_path,
-        "filename": path.name,
-        "text": text,
+    metadata = parser(text, relative_path, path.name)
+    _file_metadata_cache[cache_key] = {
+        "mtime_ns": stat.st_mtime_ns,
+        "size": stat.st_size,
+        "metadata": deepcopy(metadata),
     }
+    _trim_file_metadata_cache()
+    return metadata
 
 
 def extract_schematic_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
-    common = _extract_common_file_metadata(project_path, file_path)
-    if not common:
-        return None
-
-    text = common.pop("text")
-
-    return {
-        **common,
-        "version": _extract_int_value(text, "version"),
-        "generator": _extract_string_value(text, "generator"),
-        "generator_version": _extract_string_value(text, "generator_version"),
-        "paper": _extract_string_value(text, "paper"),
-        "uuid": _extract_string_value(text, "uuid"),
-        "title_block": _parse_title_block(text),
-    }
+    return _load_cached_file_metadata(
+        project_path,
+        file_path,
+        lambda text, relative_path, filename: {
+            "path": relative_path,
+            "filename": filename,
+            "version": _extract_int_value(text, "version"),
+            "generator": _extract_string_value(text, "generator"),
+            "generator_version": _extract_string_value(text, "generator_version"),
+            "paper": _extract_string_value(text, "paper"),
+            "uuid": _extract_string_value(text, "uuid"),
+            "title_block": _parse_title_block(text),
+        },
+    )
 
 
 def extract_pcb_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
-    common = _extract_common_file_metadata(project_path, file_path)
-    if not common:
-        return None
-
-    text = common.pop("text")
-    general_block = _extract_sexpr_block(text, "general") or ""
-
-    return {
-        **common,
-        "version": _extract_int_value(text, "version"),
-        "generator": _extract_string_value(text, "generator"),
-        "generator_version": _extract_string_value(text, "generator_version"),
-        "paper": _extract_string_value(text, "paper"),
-        "dimensions_mm": _extract_pcb_dimensions(text),
-        "thickness_mm": _extract_number_value(general_block, "thickness"),
-        "title_block": _parse_title_block(text),
-    }
+    return _load_cached_file_metadata(
+        project_path,
+        file_path,
+        lambda text, relative_path, filename: {
+            "path": relative_path,
+            "filename": filename,
+            "version": _extract_int_value(text, "version"),
+            "generator": _extract_string_value(text, "generator"),
+            "generator_version": _extract_string_value(text, "generator_version"),
+            "paper": _extract_string_value(text, "paper"),
+            "dimensions_mm": _extract_pcb_dimensions(text),
+            "thickness_mm": _extract_number_value(_extract_sexpr_block(text, "general") or "", "thickness"),
+            "title_block": _parse_title_block(text),
+        },
+    )

--- a/backend/app/services/project_properties_service.py
+++ b/backend/app/services/project_properties_service.py
@@ -1,0 +1,248 @@
+import math
+import re
+from pathlib import Path
+from typing import Optional
+
+
+_STRING_PATTERN = r'"((?:[^"\\]|\\.)*)"'
+
+
+def _unescape_kicad_string(value: str) -> str:
+    return value.replace(r"\\", "\\").replace(r"\"", '"')
+
+
+def _extract_sexpr_block(text: str, token: str) -> Optional[str]:
+    start = text.find(f"({token}")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+
+    for index in range(start, len(text)):
+        char = text[index]
+
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+
+    return None
+
+
+def _extract_sexpr_blocks(text: str, token: str) -> list[str]:
+    blocks: list[str] = []
+    start = 0
+
+    while True:
+        match_index = text.find(f"({token}", start)
+        if match_index == -1:
+            break
+
+        block = _extract_sexpr_block(text[match_index:], token)
+        if not block:
+            break
+
+        blocks.append(block)
+        start = match_index + len(block)
+
+    return blocks
+
+
+def _extract_string_value(block: str, key: str) -> Optional[str]:
+    match = re.search(rf"\({re.escape(key)}\s+{_STRING_PATTERN}\)", block)
+    if not match:
+        return None
+    return _unescape_kicad_string(match.group(1))
+
+
+def _extract_number_value(block: str, key: str) -> Optional[float]:
+    match = re.search(rf"\({re.escape(key)}\s+([-+]?\d+(?:\.\d+)?)\)", block)
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None
+
+
+def _extract_int_value(block: str, key: str) -> Optional[int]:
+    value = _extract_number_value(block, key)
+    if value is None:
+        return None
+    return int(value)
+
+
+def _extract_point(block: str, key: str) -> Optional[tuple[float, float]]:
+    match = re.search(rf"\({re.escape(key)}\s+([-+]?\d+(?:\.\d+)?)\s+([-+]?\d+(?:\.\d+)?)\)", block)
+    if not match:
+        return None
+
+    try:
+        return float(match.group(1)), float(match.group(2))
+    except ValueError:
+        return None
+
+
+def _extract_xy_points(block: str) -> list[tuple[float, float]]:
+    points: list[tuple[float, float]] = []
+    for left, right in re.findall(r"\(xy\s+([-+]?\d+(?:\.\d+)?)\s+([-+]?\d+(?:\.\d+)?)\)", block):
+        try:
+            points.append((float(left), float(right)))
+        except ValueError:
+            continue
+    return points
+
+
+def _round_dimension(value: float) -> float:
+    return round(value, 2)
+
+
+def _extract_pcb_dimensions(text: str) -> Optional[dict]:
+    points: list[tuple[float, float]] = []
+
+    for token in ("gr_line", "gr_rect", "gr_arc", "gr_curve", "gr_poly", "gr_circle"):
+        for block in _extract_sexpr_blocks(text, token):
+            if '(layer "Edge.Cuts")' not in block:
+                continue
+
+            token_points = [
+                point
+                for point in (
+                    _extract_point(block, "start"),
+                    _extract_point(block, "end"),
+                    _extract_point(block, "mid"),
+                    _extract_point(block, "center"),
+                )
+                if point is not None
+            ]
+            token_points.extend(_extract_xy_points(block))
+
+            if token == "gr_circle":
+                center = _extract_point(block, "center")
+                edge = _extract_point(block, "end")
+                if center and edge:
+                    radius = math.dist(center, edge)
+                    token_points.extend(
+                        [
+                            (center[0] - radius, center[1]),
+                            (center[0] + radius, center[1]),
+                            (center[0], center[1] - radius),
+                            (center[0], center[1] + radius),
+                        ]
+                    )
+
+            points.extend(token_points)
+
+    if len(points) < 2:
+        return None
+
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    width = max(xs) - min(xs)
+    height = max(ys) - min(ys)
+
+    if width <= 0 or height <= 0:
+        return None
+
+    return {
+        "width_mm": _round_dimension(width),
+        "height_mm": _round_dimension(height),
+    }
+
+
+def _relative_to_project(project_path: str, file_path: str) -> str:
+    return Path(file_path).resolve().relative_to(Path(project_path).resolve()).as_posix()
+
+
+def _parse_title_block(text: str) -> Optional[dict]:
+    block = _extract_sexpr_block(text, "title_block")
+    if not block:
+        return None
+
+    comments = {
+        index: _unescape_kicad_string(value)
+        for index, value in re.findall(rf"\(comment\s+(\d+)\s+{_STRING_PATTERN}\)", block)
+    }
+
+    return {
+        "title": _extract_string_value(block, "title") or "",
+        "date": _extract_string_value(block, "date") or "",
+        "rev": _extract_string_value(block, "rev") or "",
+        "company": _extract_string_value(block, "company") or "",
+        "comments": comments,
+    }
+
+
+def _extract_common_file_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
+    if not file_path:
+        return None
+
+    path = Path(file_path)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    try:
+        relative_path = _relative_to_project(project_path, str(path))
+    except ValueError:
+        relative_path = path.name
+
+    return {
+        "path": relative_path,
+        "filename": path.name,
+        "text": text,
+    }
+
+
+def extract_schematic_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
+    common = _extract_common_file_metadata(project_path, file_path)
+    if not common:
+        return None
+
+    text = common.pop("text")
+
+    return {
+        **common,
+        "version": _extract_int_value(text, "version"),
+        "generator": _extract_string_value(text, "generator"),
+        "generator_version": _extract_string_value(text, "generator_version"),
+        "paper": _extract_string_value(text, "paper"),
+        "uuid": _extract_string_value(text, "uuid"),
+        "title_block": _parse_title_block(text),
+    }
+
+
+def extract_pcb_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
+    common = _extract_common_file_metadata(project_path, file_path)
+    if not common:
+        return None
+
+    text = common.pop("text")
+    general_block = _extract_sexpr_block(text, "general") or ""
+
+    return {
+        **common,
+        "version": _extract_int_value(text, "version"),
+        "generator": _extract_string_value(text, "generator"),
+        "generator_version": _extract_string_value(text, "generator_version"),
+        "paper": _extract_string_value(text, "paper"),
+        "dimensions_mm": _extract_pcb_dimensions(text),
+        "thickness_mm": _extract_number_value(general_block, "thickness"),
+        "title_block": _parse_title_block(text),
+    }

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -89,12 +89,15 @@ def _save_project_registry(registry: Dict[str, dict]) -> None:
 
 
 def invalidate_project_caches() -> None:
+    from app.services import project_properties_service
+
     global _project_records_cache, _project_records_cache_time
     global _projects_cache, _projects_cache_time
     _project_records_cache = []
     _project_records_cache_time = 0
     _projects_cache = []
     _projects_cache_time = 0
+    project_properties_service.invalidate_project_properties_cache()
 
 def register_project(project_id: str, name: str, path: str, repo_url: str,
                      sub_path: Optional[str] = None, parent_repo: Optional[str] = None,

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -21,6 +21,7 @@ class Project(BaseModel):
     description: str
     path: str
     last_modified: str
+    registered_at: Optional[str] = None
     thumbnail_url: Optional[str] = None
     sub_path: Optional[str] = None  # Relative path within parent repo
     parent_repo: Optional[str] = None  # Parent monorepo name
@@ -37,6 +38,7 @@ class RegisteredProjectRecord(BaseModel):
     path: str
     description: str
     last_modified: str
+    registered_at: Optional[str] = None
     sub_path: Optional[str] = None
     parent_repo: Optional[str] = None
     repo_url: Optional[str] = None
@@ -248,6 +250,7 @@ def _record_to_project(record: RegisteredProjectRecord) -> Project:
         description=custom_description or record.description,
         path=record.path,
         last_modified=record.last_modified,
+        registered_at=record.registered_at,
         thumbnail_url=f"/api/projects/{record.id}/thumbnail" if thumbnail_path else None,
         sub_path=record.sub_path,
         parent_repo=record.parent_repo,
@@ -283,6 +286,7 @@ def get_registered_project_records() -> List[RegisteredProjectRecord]:
                 path=normalized_path,
                 description=data.get("description", f"Project {data['name']}"),
                 last_modified=_record_last_modified(normalized_path, data.get("last_modified", "Unknown")),
+                registered_at=data.get("registered_at"),
                 sub_path=data.get("sub_path"),
                 parent_repo=data.get("parent_repo"),
                 repo_url=data.get("repo_url"),

--- a/frontend/src/components/project-card.tsx
+++ b/frontend/src/components/project-card.tsx
@@ -9,7 +9,9 @@ import React from "react";
 interface ProjectCardProps {
     project: Project;
     compact?: boolean;
+    selected?: boolean;
     onClick?: () => void;
+    onDoubleClick?: () => void;
     onDelete?: () => void;
     showDelete?: boolean;
     searchQuery?: string;
@@ -37,7 +39,17 @@ function highlightMatch(text: string, query: string): React.ReactNode {
     );
 }
 
-export function ProjectCard({ project, compact, onClick, onDelete, showDelete, searchQuery = "", actions }: ProjectCardProps) {
+export function ProjectCard({
+    project,
+    compact,
+    selected,
+    onClick,
+    onDoubleClick,
+    onDelete,
+    showDelete,
+    searchQuery = "",
+    actions,
+}: ProjectCardProps) {
     const navigate = useNavigate();
 
     const thumbnailUrl = project.thumbnail_url ? project.thumbnail_url : null;
@@ -62,8 +74,9 @@ export function ProjectCard({ project, compact, onClick, onDelete, showDelete, s
     if (compact) {
         return (
             <Card
-                className="overflow-hidden hover:border-primary/50 hover:shadow-md transition-all cursor-pointer group bg-card border shadow-sm"
+                className={`overflow-hidden transition-all cursor-pointer group bg-card border shadow-sm ${selected ? "border-primary shadow-md" : "hover:border-primary/50 hover:shadow-md"}`}
                 onClick={handleClick}
+                onDoubleClick={onDoubleClick}
             >
                 <div className="flex items-center gap-3 p-3">
                     <div className="w-12 h-12 rounded-lg bg-muted flex items-center justify-center shrink-0 overflow-hidden">
@@ -86,8 +99,9 @@ export function ProjectCard({ project, compact, onClick, onDelete, showDelete, s
 
     return (
         <Card
-            className="overflow-hidden hover:border-primary/50 hover:shadow-md transition-all cursor-pointer group bg-card border shadow-sm"
+            className={`overflow-hidden transition-all cursor-pointer group bg-card border shadow-sm ${selected ? "border-primary shadow-md" : "hover:border-primary/50 hover:shadow-md"}`}
             onClick={handleClick}
+            onDoubleClick={onDoubleClick}
         >
             <div className="aspect-video w-full overflow-hidden bg-muted relative border-b">
                 {thumbnailUrl ? (

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -13,6 +13,7 @@ import { WorkspaceBreadcrumbs } from "./workspace/workspace-breadcrumbs";
 import { WorkspaceGalleryView } from "./workspace/workspace-gallery-view";
 import { WorkspaceListView } from "./workspace/workspace-list-view";
 import { WorkspaceLoadingState } from "./workspace/workspace-loading-state";
+import { WorkspaceProjectPropertiesSheet } from "./workspace/workspace-project-properties-sheet";
 import { WorkspaceProjectToolbar } from "./workspace/workspace-project-toolbar";
 import { WorkspaceSidebar } from "./workspace/workspace-sidebar";
 import { WorkspaceSection, ViewMode } from "./workspace/workspace-types";
@@ -60,6 +61,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
 
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
 
   const [folderToRename, setFolderToRename] = useState<FolderTreeItem | null>(null);
   const [isRenamingFolder, setIsRenamingFolder] = useState(false);
@@ -141,6 +143,21 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const openProject = (project: Project) => {
     navigate(`/project/${project.id}`);
   };
+
+  const selectProject = (project: Project) => {
+    setSelectedProjectId(project.id);
+  };
+
+  const selectedProject = useMemo(
+    () => projects.find((project) => project.id === selectedProjectId) ?? null,
+    [projects, selectedProjectId]
+  );
+
+  useEffect(() => {
+    if (selectedProjectId && !projects.some((project) => project.id === selectedProjectId)) {
+      setSelectedProjectId(null);
+    }
+  }, [projects, selectedProjectId]);
 
   const handleCreateFolder = async (name: string) => {
     if (!canManageProjects) {
@@ -291,13 +308,13 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
             )}
           </header>
 
-          <main className="min-h-0 flex-1 overflow-y-auto">
+          <main className="min-h-0 flex-1 overflow-hidden">
             {loading ? (
               <WorkspaceLoadingState />
             ) : section === "apps" ? (
               <WorkspaceAppsPlaceholder />
             ) : (
-              <div className="space-y-6 p-6">
+              <div className="flex h-full min-h-0 flex-col p-6">
                 <WorkspaceBreadcrumbs
                   isSearching={isSearching}
                   breadcrumbs={breadcrumbs}
@@ -306,40 +323,64 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                   onSelectFolder={(folderId) => setFolderInUrl(folderId)}
                 />
 
-                {viewMode === "gallery" ? (
-                  <WorkspaceGalleryView
-                    searchQuery={searchQuery}
-                    isSearching={isSearching}
-                    searchResults={searchResults}
-                    currentFolderId={currentFolderId}
-                    visibleFolders={visibleFolders}
-                    visibleProjects={visibleProjects}
-                    getProjectDisplayName={getProjectDisplayName}
-                    onOpenProject={openProject}
-                    onOpenFolder={(folderId) => setFolderInUrl(folderId)}
-                    onRenameFolder={setFolderToRename}
-                    onDeleteFolder={setFolderToDelete}
-                    onMoveProject={setProjectToMove}
-                    onDeleteProject={setProjectToDelete}
-                    canManageProjects={canManageProjects}
-                  />
-                ) : (
-                  <WorkspaceListView
-                    isSearching={isSearching}
-                    currentFolderId={currentFolderId}
-                    breadcrumbs={breadcrumbs}
-                    listFolders={listFolders}
-                    listProjects={listProjects}
-                    getProjectDisplayName={getProjectDisplayName}
-                    onOpenProject={openProject}
-                    onOpenFolder={(folderId) => setFolderInUrl(folderId)}
-                    onRenameFolder={setFolderToRename}
-                    onDeleteFolder={setFolderToDelete}
-                    onMoveProject={setProjectToMove}
-                    onDeleteProject={setProjectToDelete}
-                    canManageProjects={canManageProjects}
-                  />
-                )}
+                <div className="relative mt-6 min-h-0 flex-1 overflow-hidden">
+                  <div className="h-full overflow-y-auto pr-1">
+                    {viewMode === "gallery" ? (
+                      <WorkspaceGalleryView
+                        searchQuery={searchQuery}
+                        isSearching={isSearching}
+                        searchResults={searchResults}
+                        selectedProjectId={selectedProjectId}
+                        currentFolderId={currentFolderId}
+                        visibleFolders={visibleFolders}
+                        visibleProjects={visibleProjects}
+                        getProjectDisplayName={getProjectDisplayName}
+                        onSelectProject={selectProject}
+                        onOpenProject={openProject}
+                        onOpenFolder={(folderId) => setFolderInUrl(folderId)}
+                        onRenameFolder={setFolderToRename}
+                        onDeleteFolder={setFolderToDelete}
+                        onMoveProject={setProjectToMove}
+                        onDeleteProject={setProjectToDelete}
+                        canManageProjects={canManageProjects}
+                      />
+                    ) : (
+                      <WorkspaceListView
+                        isSearching={isSearching}
+                        selectedProjectId={selectedProjectId}
+                        currentFolderId={currentFolderId}
+                        breadcrumbs={breadcrumbs}
+                        listFolders={listFolders}
+                        listProjects={listProjects}
+                        getProjectDisplayName={getProjectDisplayName}
+                        onSelectProject={selectProject}
+                        onOpenProject={openProject}
+                        onOpenFolder={(folderId) => setFolderInUrl(folderId)}
+                        onRenameFolder={setFolderToRename}
+                        onDeleteFolder={setFolderToDelete}
+                        onMoveProject={setProjectToMove}
+                        onDeleteProject={setProjectToDelete}
+                        canManageProjects={canManageProjects}
+                      />
+                    )}
+                  </div>
+
+                  <div className="pointer-events-none absolute inset-y-0 right-0 z-20 flex justify-end">
+                    <div className="pointer-events-auto h-full">
+                      <WorkspaceProjectPropertiesSheet
+                        open={selectedProject !== null}
+                        project={selectedProject}
+                        folderById={folderById}
+                        onOpenChange={(open) => {
+                          if (!open) {
+                            setSelectedProjectId(null);
+                          }
+                        }}
+                        onOpenProject={openProject}
+                      />
+                    </div>
+                  </div>
+                </div>
               </div>
             )}
           </main>
@@ -410,6 +451,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
           />
         </Suspense>
       )}
+
     </>
   );
 }

--- a/frontend/src/components/workspace/workspace-gallery-view.tsx
+++ b/frontend/src/components/workspace/workspace-gallery-view.tsx
@@ -11,10 +11,12 @@ interface WorkspaceGalleryViewProps {
   searchQuery: string;
   isSearching: boolean;
   searchResults: SearchProject[];
+  selectedProjectId: string | null;
   currentFolderId: string | null;
   visibleFolders: FolderTreeItem[];
   visibleProjects: Project[];
   getProjectDisplayName: (project: Project) => string;
+  onSelectProject: (project: Project) => void;
   onOpenProject: (project: Project) => void;
   onOpenFolder: (folderId: string) => void;
   onRenameFolder: (folder: FolderTreeItem) => void;
@@ -28,10 +30,12 @@ export function WorkspaceGalleryView({
   searchQuery,
   isSearching,
   searchResults,
+  selectedProjectId,
   currentFolderId,
   visibleFolders,
   visibleProjects,
   getProjectDisplayName,
+  onSelectProject,
   onOpenProject,
   onOpenFolder,
   onRenameFolder,
@@ -55,8 +59,10 @@ export function WorkspaceGalleryView({
                 <ProjectCard
                   key={project.id}
                   project={project}
+                  selected={selectedProjectId === project.id}
                   searchQuery={searchQuery}
-                  onClick={() => onOpenProject(project)}
+                  onClick={() => onSelectProject(project)}
+                  onDoubleClick={() => onOpenProject(project)}
                   actions={
                     <ProjectActionMenu
                       project={project}
@@ -129,7 +135,9 @@ export function WorkspaceGalleryView({
                   <ProjectCard
                     key={project.id}
                     project={project}
-                    onClick={() => onOpenProject(project)}
+                    selected={selectedProjectId === project.id}
+                    onClick={() => onSelectProject(project)}
+                    onDoubleClick={() => onOpenProject(project)}
                     actions={
                       <ProjectActionMenu
                         project={project}

--- a/frontend/src/components/workspace/workspace-list-view.tsx
+++ b/frontend/src/components/workspace/workspace-list-view.tsx
@@ -7,11 +7,13 @@ import { FolderActionMenu, ProjectActionMenu } from "./workspace-action-menus";
 
 interface WorkspaceListViewProps {
   isSearching: boolean;
+  selectedProjectId: string | null;
   currentFolderId: string | null;
   breadcrumbs: FolderTreeItem[];
   listFolders: FolderTreeItem[];
   listProjects: Project[];
   getProjectDisplayName: (project: Project) => string;
+  onSelectProject: (project: Project) => void;
   onOpenProject: (project: Project) => void;
   onOpenFolder: (folderId: string) => void;
   onRenameFolder: (folder: FolderTreeItem) => void;
@@ -40,11 +42,13 @@ function resolveProjectLocation(
 
 export function WorkspaceListView({
   isSearching,
+  selectedProjectId,
   currentFolderId,
   breadcrumbs,
   listFolders,
   listProjects,
   getProjectDisplayName,
+  onSelectProject,
   onOpenProject,
   onOpenFolder,
   onRenameFolder,
@@ -97,12 +101,15 @@ export function WorkspaceListView({
           {listProjects.map((project) => (
             <div
               key={project.id}
-              className="grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] items-center border-b px-4 py-2"
+              className={`grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] items-center border-b px-4 py-2 transition-colors ${selectedProjectId === project.id ? "bg-primary/5" : "hover:bg-muted/30"}`}
+              onClick={() => onSelectProject(project)}
+              onDoubleClick={() => onOpenProject(project)}
             >
               <button
                 type="button"
                 className="truncate text-left text-sm font-medium hover:text-primary"
-                onClick={() => onOpenProject(project)}
+                onClick={() => onSelectProject(project)}
+                onDoubleClick={() => onOpenProject(project)}
               >
                 {getProjectDisplayName(project)}
               </button>
@@ -111,7 +118,11 @@ export function WorkspaceListView({
                 {resolveProjectLocation(project, isSearching, currentFolderId, breadcrumbs)}
               </p>
               <p className="truncate text-sm text-muted-foreground">{project.last_modified}</p>
-              <div className="flex justify-end">
+              <div
+                className="flex justify-end"
+                onClick={(event) => event.stopPropagation()}
+                onDoubleClick={(event) => event.stopPropagation()}
+              >
                 <ProjectActionMenu
                   project={project}
                   projectName={getProjectDisplayName(project)}

--- a/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
+++ b/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
@@ -1,0 +1,420 @@
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { Box, CalendarDays, FolderTree, GitBranch, GitCommit, PanelRightOpen, Tag, X } from "lucide-react";
+
+import { fetchJson } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type { FolderTreeItem, Project, ProjectPropertiesResponse } from "@/types/project";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface WorkspaceProjectPropertiesSheetProps {
+  open: boolean;
+  project: Project | null;
+  folderById: Map<string, FolderTreeItem>;
+  onOpenChange: (open: boolean) => void;
+  onOpenProject: (project: Project) => void;
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) {
+    return "Not available";
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const dateOnly = new Date(`${value}T00:00:00`);
+    if (!Number.isNaN(dateOnly.getTime())) {
+      return dateOnly.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    }
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatBoardSecondaryLabel(data: ProjectPropertiesResponse | null, project: Project): string {
+  const pcbTitle = data?.files.pcb?.title_block?.title?.trim();
+  if (pcbTitle) {
+    return pcbTitle;
+  }
+
+  const pcbFilename = data?.files.pcb?.filename;
+  if (pcbFilename) {
+    return pcbFilename.replace(/\.kicad_pcb$/i, "");
+  }
+
+  return project.name;
+}
+
+function resolveRepositoryLabel(project: Project): string {
+  if (project.parent_repo) {
+    return project.parent_repo;
+  }
+
+  if (project.repo_url) {
+    return project.repo_url;
+  }
+
+  return "Standalone Project";
+}
+
+function formatPcbDimensions(
+  dimensions?: { width_mm: number; height_mm: number } | null
+): string {
+  if (!dimensions) {
+    return "Not available";
+  }
+
+  return `${dimensions.width_mm} mm × ${dimensions.height_mm} mm`;
+}
+
+function formatBoardThickness(value?: number | null): string {
+  if (value == null) {
+    return "Not available";
+  }
+
+  return `${value} mm`;
+}
+
+function formatFileFormat(
+  version?: number | null,
+  generator?: string | null,
+  generatorVersion?: string | null
+): string {
+  const parts = [
+    version != null ? `v${version}` : null,
+    [generator, generatorVersion].filter(Boolean).join(" ").trim() || null,
+  ].filter(Boolean);
+
+  return parts.length > 0 ? parts.join(" • ") : "Not available";
+}
+
+function buildFolderPath(folderId: string | null | undefined, folderById: Map<string, FolderTreeItem>): string {
+  if (!folderId) {
+    return "Workspace Root";
+  }
+
+  const segments: string[] = [];
+  let currentId: string | null = folderId;
+  let guard = 0;
+
+  while (currentId && guard < 64) {
+    const folder = folderById.get(currentId);
+    if (!folder) {
+      break;
+    }
+    segments.unshift(folder.name);
+    currentId = folder.parent_id ?? null;
+    guard += 1;
+  }
+
+  return segments.length > 0 ? segments.join(" / ") : "Workspace Root";
+}
+
+function hasMetadataValue(value: ReactNode | null | undefined): boolean {
+  if (value == null) {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  return true;
+}
+
+function MetadataRow({
+  label,
+  value,
+  fallback = "Not available",
+}: {
+  label: string;
+  value?: ReactNode | null;
+  fallback?: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(0,8rem)_1fr] gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 break-words text-foreground">{hasMetadataValue(value) ? value : fallback}</span>
+    </div>
+  );
+}
+
+function MetadataSection({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: typeof Box;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3 border-t pt-5">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" />
+        <span>{title}</span>
+      </div>
+      <div className="space-y-2.5">{children}</div>
+    </section>
+  );
+}
+
+function PropertiesSkeleton() {
+  return (
+    <div className="space-y-5">
+      <Skeleton className="aspect-[4/3] w-full rounded-none" />
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-3/4 rounded-none" />
+        <Skeleton className="h-5 w-1/2 rounded-none" />
+      </div>
+      <div className="space-y-3 border-t pt-5">
+        <Skeleton className="h-4 w-24 rounded-none" />
+        <Skeleton className="h-4 w-full rounded-none" />
+        <Skeleton className="h-4 w-5/6 rounded-none" />
+        <Skeleton className="h-4 w-4/6 rounded-none" />
+      </div>
+      <div className="space-y-3 border-t pt-5">
+        <Skeleton className="h-4 w-24 rounded-none" />
+        <Skeleton className="h-16 w-full rounded-none" />
+        <Skeleton className="h-16 w-full rounded-none" />
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceProjectPropertiesSheet({
+  open,
+  project,
+  folderById,
+  onOpenChange,
+  onOpenProject,
+}: WorkspaceProjectPropertiesSheetProps) {
+  const [data, setData] = useState<ProjectPropertiesResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !project) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    void fetchJson<ProjectPropertiesResponse>(
+      `/api/projects/${project.id}/properties`,
+      { signal: controller.signal },
+      "Failed to load project properties"
+    )
+      .then((response) => {
+        if (!controller.signal.aborted) {
+          setData(response);
+        }
+      })
+      .catch((fetchError) => {
+        if (!controller.signal.aborted) {
+          setData(null);
+          setError(fetchError instanceof Error ? fetchError.message : "Failed to load project properties");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [open, project]);
+
+  const activeProject = data?.project ?? project;
+  const panelProject = activeProject ?? project;
+  const displayName = activeProject?.display_name || activeProject?.name || "Project";
+  const repositoryLabel = panelProject ? resolveRepositoryLabel(panelProject) : "Standalone Project";
+  const folderPath = useMemo(
+    () => buildFolderPath(panelProject?.folder_id ?? null, folderById),
+    [panelProject?.folder_id, folderById]
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <aside
+      className={cn(
+        "flex h-full min-w-0 shrink-0 flex-col border-l bg-background/95 backdrop-blur-sm shadow-2xl",
+        "w-[360px] lg:w-[400px] xl:w-[460px]"
+      )}
+      aria-label="Project properties panel"
+    >
+      <div className="flex min-h-full flex-col overflow-hidden">
+        <div className="space-y-3 border-b px-6 py-5 text-left">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">Properties</Badge>
+              </div>
+              <div className="space-y-1">
+                <h2 className="truncate text-2xl font-semibold leading-tight">{displayName}</h2>
+                <p className="text-sm text-muted-foreground">
+                  {project ? formatBoardSecondaryLabel(data, project) : "Project metadata"}
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {project ? (
+                <Button variant="outline" size="sm" onClick={() => onOpenProject(project)}>
+                  <PanelRightOpen className="h-4 w-4" />
+                  Open Project
+                </Button>
+              ) : null}
+              <Button variant="ghost" size="icon-sm" aria-label="Close properties panel" onClick={() => onOpenChange(false)}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex-1 space-y-5 overflow-y-auto px-6 py-5">
+          {loading ? <PropertiesSkeleton /> : null}
+
+          {!loading && error ? (
+            <div className="rounded-none border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          {!loading && !error && panelProject ? (
+            <>
+              <section className="space-y-4">
+                <div className="aspect-[4/3] overflow-hidden rounded-none border bg-muted/30">
+                  {activeProject?.thumbnail_url ? (
+                    <img
+                      src={activeProject.thumbnail_url}
+                      alt={displayName}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-muted-foreground">
+                      <Box className="h-12 w-12 opacity-30" />
+                    </div>
+                  )}
+                </div>
+              </section>
+
+              <MetadataSection title="Project Details" icon={FolderTree}>
+                <MetadataRow label="Description" value={panelProject.description} />
+                <MetadataRow label="Folder" value={folderPath} />
+                <MetadataRow
+                  label="Repository Link"
+                  value={
+                    panelProject.repo_url ? (
+                      <a
+                        href={panelProject.repo_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="break-all underline underline-offset-4 transition-colors hover:text-primary"
+                      >
+                        {panelProject.repo_url}
+                      </a>
+                    ) : (
+                      repositoryLabel
+                    )
+                  }
+                />
+              </MetadataSection>
+
+              <MetadataSection title="Versions" icon={GitBranch}>
+                <MetadataRow
+                  label="Latest Commit"
+                  value={
+                    data?.repository.latest_commit
+                      ? `${data.repository.latest_commit.hash} by ${data.repository.latest_commit.author}`
+                      : "No commits found"
+                  }
+                />
+                <div className="space-y-2">
+                  <p className="text-sm font-medium">Latest Tag</p>
+                  {data?.repository.latest_tag ? (
+                    <div className="rounded-none border bg-muted/20 p-3">
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        <Tag className="h-4 w-4 text-muted-foreground" />
+                        <span>{data.repository.latest_tag.tag}</span>
+                        <span className="text-xs text-muted-foreground">{data.repository.latest_tag.commit_hash}</span>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">{formatDateTime(data.repository.latest_tag.date)}</p>
+                      {data.repository.latest_tag.message ? (
+                        <p className="mt-2 text-sm">{data.repository.latest_tag.message.split("\n")[0]}</p>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No tags available for this project.</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <p className="text-sm font-medium">Repository Activity</p>
+                  <div className="rounded-none border bg-muted/20 p-3 text-sm">
+                    <div className="flex items-center gap-2 font-medium">
+                      <GitCommit className="h-4 w-4 text-muted-foreground" />
+                      <span>{data?.repository.latest_commit?.message?.split("\n")[0] || "No recent commit activity"}</span>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {data?.repository.latest_commit
+                        ? `${data.repository.latest_commit.author} • ${formatDateTime(data.repository.latest_commit.date)}`
+                        : "No repository activity available"}
+                    </p>
+                  </div>
+                </div>
+              </MetadataSection>
+
+              <MetadataSection title="Board Details" icon={Box}>
+                <MetadataRow label="PCB Dimensions" value={formatPcbDimensions(data?.files.pcb?.dimensions_mm)} />
+                <MetadataRow label="Board Thickness" value={formatBoardThickness(data?.files.pcb?.thickness_mm)} />
+                <MetadataRow
+                  label="SCH Format"
+                  value={formatFileFormat(
+                    data?.files.schematic?.version,
+                    data?.files.schematic?.generator,
+                    data?.files.schematic?.generator_version
+                  )}
+                />
+                <MetadataRow
+                  label="PCB Format"
+                  value={formatFileFormat(
+                    data?.files.pcb?.version,
+                    data?.files.pcb?.generator,
+                    data?.files.pcb?.generator_version
+                  )}
+                />
+              </MetadataSection>
+
+              <MetadataSection title="Dates" icon={CalendarDays}>
+                <MetadataRow label="Last Modified" value={formatDateTime(panelProject.last_modified)} />
+                <MetadataRow label="Imported" value={formatDateTime(panelProject.registered_at)} />
+                <MetadataRow label="Latest Commit" value={formatDateTime(data?.repository.latest_commit?.date)} />
+                <MetadataRow label="Schematic Date" value={data?.files.schematic?.title_block?.date} />
+                <MetadataRow label="PCB Date" value={data?.files.pcb?.title_block?.date} />
+              </MetadataSection>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -5,6 +5,7 @@ export interface Project {
     description: string;
     path: string;
     last_modified: string;
+    registered_at?: string;
     thumbnail_url?: string;
     sub_path?: string;
     parent_repo?: string;
@@ -58,4 +59,66 @@ export interface MonorepoStructure {
     current_path: string;
     folders: MonorepoFolder[];
     projects: MonorepoProject[];
+}
+
+export interface ProjectPropertiesFileTitleBlock {
+    title: string;
+    date: string;
+    rev: string;
+    company: string;
+    comments: Record<string, string>;
+}
+
+export interface ProjectPropertiesSchematicFile {
+    path: string;
+    filename: string;
+    version?: number;
+    generator?: string;
+    generator_version?: string;
+    paper?: string;
+    uuid?: string;
+    title_block?: ProjectPropertiesFileTitleBlock | null;
+}
+
+export interface ProjectPropertiesPcbFile {
+    path: string;
+    filename: string;
+    version?: number;
+    generator?: string;
+    generator_version?: string;
+    paper?: string;
+    dimensions_mm?: {
+        width_mm: number;
+        height_mm: number;
+    } | null;
+    thickness_mm?: number;
+    title_block?: ProjectPropertiesFileTitleBlock | null;
+}
+
+export interface ProjectPropertiesTag {
+    tag: string;
+    commit_hash: string;
+    date: string;
+    message: string;
+}
+
+export interface ProjectPropertiesLatestCommit {
+    hash: string;
+    full_hash: string;
+    author: string;
+    email: string;
+    date: string;
+    message: string;
+}
+
+export interface ProjectPropertiesResponse {
+    project: Project;
+    repository: {
+        latest_commit: ProjectPropertiesLatestCommit | null;
+        latest_tag: ProjectPropertiesTag | null;
+    };
+    files: {
+        schematic: ProjectPropertiesSchematicFile | null;
+        pcb: ProjectPropertiesPcbFile | null;
+    };
 }


### PR DESCRIPTION
## Summary
This PR adds a workspace project properties overlay for KiCAD Prism and scopes it to the final product requirements from review. Selecting a project in the workspace now opens a non-blocking right-side inspector instead of changing routes or shifting the surrounding layout. The overlay shows a larger preview, project details, repository version details, key dates, and board-specific metadata extracted from the KiCad source files.

