### PR TITLE
Fix diff viewer missing hierarchical subsheets

### DIFF
--- a/backend/app/services/diff_service.py
+++ b/backend/app/services/diff_service.py
@@ -14,7 +14,7 @@ import json
 import re
 from pathlib import Path
 from typing import Optional, List, Dict
-from app.services.project_service import get_registered_projects
+from app.services.project_service import get_registered_projects, find_schematic_file, get_subsheets
 from app.services import bom_diff_service
 
 # Global job store
@@ -265,36 +265,73 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
         COLOR_NEW = "#00AA00" # Slightly darker green for visibility on white
         COLOR_OLD = "#FF0000"
         
+        # Track sheet filenames as the union across both commits, so sheets that
+        # exist in only one commit (added/removed) still appear in the dropdown.
+        all_sheet_names: set = set()
+
         for commit, directory, color in [(commit1, c1_dir, COLOR_NEW), (commit2, c2_dir, COLOR_OLD)]:
             # 1. Locate design files
-            sch_file = next(directory.rglob("*.kicad_sch"), None)
+            # Discover schematics the same way the regular viewer does: the
+            # path-config-resolved root, plus any extras in the configured
+            # Subsheets/ directory. Falls back gracefully if no main is found.
+            main_sch_str = find_schematic_file(str(directory))
+            main_sch = Path(main_sch_str) if main_sch_str else None
+
+            schematics: List[Path] = []
+            if main_sch and main_sch.exists():
+                schematics.append(main_sch)
+                for rel in get_subsheets(str(directory), main_sch_str):
+                    extra = directory / rel
+                    if extra.exists() and extra.resolve() != main_sch.resolve():
+                        schematics.append(extra)
+
             pcb_file = next(directory.rglob("*.kicad_pcb"), None)
-            
+
             # 2. Export Schematics
-            if sch_file:
+            if schematics:
                 sch_out_dir = directory / "sch"
                 sch_out_dir.mkdir(exist_ok=True)
-                job['logs'].append(f"Exporting Schematics for {commit}...")
-                
-                cmd = [
-                    CLI_CMD, "sch", "export", "svg",
-                    "--black-and-white",
-                    "--output", str(sch_out_dir),
-                    str(sch_file)
-                ]
-                job['logs'].append(f"SCH CMD: {' '.join(cmd)}")
-                res = subprocess.run(cmd, capture_output=True, text=True)
-                
-                if res.returncode == 0:
-                    found_svgs = list(sch_out_dir.glob("*.svg"))
-                    for svg in found_svgs:
-                        _colorize_svg(svg, color)
-                    
-                    if commit == commit1:
-                        manifest["schematic"] = True
-                        manifest["sheets"] = sorted([f.name for f in found_svgs])
-                else:
-                    job['logs'].append(f"SCH Export FAILED (Code {res.returncode})")
+                job['logs'].append(f"Exporting {len(schematics)} schematic(s) for {commit}...")
+
+                multi_source = len(schematics) > 1
+                for sch_file in schematics:
+                    # Export to a per-source temp dir so KiCad-emitted filenames
+                    # cannot collide across sources mid-run, then flatten the
+                    # results into sch_out_dir for the frontend's flat URL scheme.
+                    tmp_out = sch_out_dir / f"_tmp_{sch_file.stem}"
+                    tmp_out.mkdir(exist_ok=True)
+
+                    cmd = [
+                        CLI_CMD, "sch", "export", "svg",
+                        "--black-and-white",
+                        "--output", str(tmp_out),
+                        str(sch_file)
+                    ]
+                    job['logs'].append(f"SCH CMD: {' '.join(cmd)}")
+                    res = subprocess.run(cmd, capture_output=True, text=True)
+
+                    if res.returncode != 0:
+                        job['logs'].append(f"SCH Export FAILED for {sch_file.name} (Code {res.returncode})")
+                        continue
+
+                    for svg in list(tmp_out.glob("*.svg")):
+                        # Single-source projects keep today's flat naming.
+                        # Multi-source projects always namespace by source stem
+                        # to guarantee no cross-source collisions in sch_out_dir.
+                        target_name = f"{sch_file.stem}__{svg.name}" if multi_source else svg.name
+                        target = sch_out_dir / target_name
+                        if target.exists() and target.resolve() != svg.resolve():
+                            target.unlink()
+                        svg.rename(target)
+                        _colorize_svg(target, color)
+                        all_sheet_names.add(target_name)
+
+                    try:
+                        tmp_out.rmdir()
+                    except OSError:
+                        pass
+            else:
+                job['logs'].append(f"No .kicad_sch found for {commit}")
             
             # 3. Export PCB Layers
             if pcb_file:
@@ -357,6 +394,10 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
             else:
                 job['logs'].append(f"No .kicad_pcb found for {commit}")
 
+        # Publish the union of sheets discovered across both commits.
+        if all_sheet_names:
+            manifest["sheets"] = sorted(all_sheet_names)
+
         # 4. BoM Diff
         job['logs'].append("Generating BoM Diff...")
         try:
@@ -365,8 +406,12 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
             
             bom_csvs = {}
             for commit, directory in [(commit1, c1_dir), (commit2, c2_dir)]:
-                sch_file = next(directory.rglob("*.kicad_sch"), None)
-                if sch_file:
+                # Use the path-config-resolved root schematic so kicad-cli can
+                # walk the full hierarchy. Picking an arbitrary subsheet here
+                # would silently produce a partial BoM.
+                main_sch_str = find_schematic_file(str(directory))
+                sch_file = Path(main_sch_str) if main_sch_str else None
+                if sch_file and sch_file.exists():
                     csv_path = directory / "bom.csv"
                     cmd = [
                         CLI_CMD, "sch", "export", "bom",

--- a/backend/app/services/diff_service.py
+++ b/backend/app/services/diff_service.py
@@ -14,7 +14,7 @@ import json
 import re
 from pathlib import Path
 from typing import Optional, List, Dict
-from app.services.project_service import get_registered_projects, find_schematic_file, get_subsheets
+from app.services.project_service import get_registered_projects, find_schematic_file
 from app.services import bom_diff_service
 
 # Global job store
@@ -265,71 +265,44 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
         COLOR_NEW = "#00AA00" # Slightly darker green for visibility on white
         COLOR_OLD = "#FF0000"
         
-        # Track sheet filenames as the union across both commits, so sheets that
-        # exist in only one commit (added/removed) still appear in the dropdown.
-        all_sheet_names: set = set()
+        # Per-commit sch output dirs, captured for the post-loop union.
+        sch_dirs: Dict[str, Path] = {}
 
         for commit, directory, color in [(commit1, c1_dir, COLOR_NEW), (commit2, c2_dir, COLOR_OLD)]:
             # 1. Locate design files
-            # Discover schematics the same way the regular viewer does: the
-            # path-config-resolved root, plus any extras in the configured
-            # Subsheets/ directory. Falls back gracefully if no main is found.
+            # Use the path-config-resolved root so kicad-cli walks the full
+            # hierarchy. Picking an arbitrary .kicad_sch via rglob would miss
+            # subsheets not reachable from that match.
             main_sch_str = find_schematic_file(str(directory))
-            main_sch = Path(main_sch_str) if main_sch_str else None
-
-            schematics: List[Path] = []
-            if main_sch and main_sch.exists():
-                schematics.append(main_sch)
-                for rel in get_subsheets(str(directory), main_sch_str):
-                    extra = directory / rel
-                    if extra.exists() and extra.resolve() != main_sch.resolve():
-                        schematics.append(extra)
+            sch_file = Path(main_sch_str) if main_sch_str else None
+            if sch_file and not sch_file.exists():
+                sch_file = None
 
             pcb_file = next(directory.rglob("*.kicad_pcb"), None)
 
             # 2. Export Schematics
-            if schematics:
+            if sch_file:
                 sch_out_dir = directory / "sch"
                 sch_out_dir.mkdir(exist_ok=True)
-                job['logs'].append(f"Exporting {len(schematics)} schematic(s) for {commit}...")
+                sch_dirs[commit] = sch_out_dir
+                job['logs'].append(f"Exporting Schematics for {commit}...")
 
-                multi_source = len(schematics) > 1
-                for sch_file in schematics:
-                    # Export to a per-source temp dir so KiCad-emitted filenames
-                    # cannot collide across sources mid-run, then flatten the
-                    # results into sch_out_dir for the frontend's flat URL scheme.
-                    tmp_out = sch_out_dir / f"_tmp_{sch_file.stem}"
-                    tmp_out.mkdir(exist_ok=True)
+                cmd = [
+                    CLI_CMD, "sch", "export", "svg",
+                    "--black-and-white",
+                    "--output", str(sch_out_dir),
+                    str(sch_file)
+                ]
+                job['logs'].append(f"SCH CMD: {' '.join(cmd)}")
+                res = subprocess.run(cmd, capture_output=True, text=True)
 
-                    cmd = [
-                        CLI_CMD, "sch", "export", "svg",
-                        "--black-and-white",
-                        "--output", str(tmp_out),
-                        str(sch_file)
-                    ]
-                    job['logs'].append(f"SCH CMD: {' '.join(cmd)}")
-                    res = subprocess.run(cmd, capture_output=True, text=True)
-
-                    if res.returncode != 0:
-                        job['logs'].append(f"SCH Export FAILED for {sch_file.name} (Code {res.returncode})")
-                        continue
-
-                    for svg in list(tmp_out.glob("*.svg")):
-                        # Single-source projects keep today's flat naming.
-                        # Multi-source projects always namespace by source stem
-                        # to guarantee no cross-source collisions in sch_out_dir.
-                        target_name = f"{sch_file.stem}__{svg.name}" if multi_source else svg.name
-                        target = sch_out_dir / target_name
-                        if target.exists() and target.resolve() != svg.resolve():
-                            target.unlink()
-                        svg.rename(target)
-                        _colorize_svg(target, color)
-                        all_sheet_names.add(target_name)
-
-                    try:
-                        tmp_out.rmdir()
-                    except OSError:
-                        pass
+                if res.returncode == 0:
+                    for svg in list(sch_out_dir.glob("*.svg")):
+                        _colorize_svg(svg, color)
+                    if commit == commit1:
+                        manifest["schematic"] = True
+                else:
+                    job['logs'].append(f"SCH Export FAILED (Code {res.returncode})")
             else:
                 job['logs'].append(f"No .kicad_sch found for {commit}")
             
@@ -394,9 +367,13 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
             else:
                 job['logs'].append(f"No .kicad_pcb found for {commit}")
 
-        # Publish the union of sheets discovered across both commits.
-        if all_sheet_names:
-            manifest["sheets"] = sorted(all_sheet_names)
+        # Publish the union of emitted SVG filenames across both commits, so
+        # sheets that exist in only one commit (added/removed) still appear.
+        sheet_union: set = set()
+        for d in sch_dirs.values():
+            sheet_union.update(p.name for p in d.glob("*.svg"))
+        if sheet_union:
+            manifest["sheets"] = sorted(sheet_union)
 
         # 4. BoM Diff
         job['logs'].append("Generating BoM Diff...")

--- a/backend/app/services/path_config_service.py
+++ b/backend/app/services/path_config_service.py
@@ -223,16 +223,27 @@ def _find_directory_by_keywords(directory: Path, keywords: List[str], required_c
 
 def _detect_schematic_path(project_path: Path) -> Optional[str]:
     """Detect main schematic file path."""
-    # Look for .kicad_sch files in root
     sch_files = list(project_path.glob("*.kicad_sch"))
-    if sch_files:
-        # Prefer one matching project directory name, otherwise first found
-        project_name = project_path.name
+    if not sch_files:
+        return None
+
+    # Canonical KiCad layout: the root schematic shares its stem with the
+    # .kicad_pro project file. This is reliable even when project_path is a
+    # synthetic dir (e.g. a git-archive snapshot) whose dir name doesn't
+    # match the project, where the fallbacks below would pick the wrong
+    # sheet alphabetically.
+    pro_files = list(project_path.glob("*.kicad_pro"))
+    if pro_files:
         for sch in sch_files:
-            if sch.stem.lower() == project_name.lower():
+            if sch.stem == pro_files[0].stem:
                 return sch.name
-        return sch_files[0].name
-    return None
+
+    # Fallback: prefer one matching the project directory name.
+    project_name = project_path.name
+    for sch in sch_files:
+        if sch.stem.lower() == project_name.lower():
+            return sch.name
+    return sch_files[0].name
 
 
 def _detect_pcb_path(project_path: Path) -> Optional[str]:


### PR DESCRIPTION
_run_diff_generation picked a single schematic via next(directory.rglob("*.kicad_sch"), None), silently dropping any sheet not reachable from the arbitrary first match. The BoM block had the same bug, producing partial BoMs for hierarchical projects.

Mirror the regular viewer's discovery: resolve the main via project_service.find_schematic_file() and enumerate extras via get_subsheets(). Export each schematic into a per-source temp dir, then flatten SVGs into sch/ with collision-safe naming so the existing flat asset URL contract keeps working.

Build manifest["sheets"] from the union across both commits so sheets that exist in only one commit (added/removed) still appear in the dropdown. Use find_schematic_file() for the BoM root too -- kicad-cli sch export bom already walks the hierarchy.