### PR TITLE
Add kicad-monkey change-aware diff viewer

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,19 +9,24 @@ RUN npm ci
 COPY frontend/ .
 RUN npm run build:panel
 
+FROM python:3.12-slim-bookworm AS python-runtime
+
 FROM --platform=${KICAD_BASE_PLATFORM} kicad/kicad:10.0.0
 ARG KICAD_LIBRARY_UTILS_REF=7124a92887b2280f85cfe2d5abb216062978d5e1
 
 # Prevent interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/usr/local/bin:${PATH}"
 
 USER root
 
+# kicad-monkey currently publishes wheels for Python >=3.11,<3.13.
+# The KiCad 10 base image can provide Python 3.13, so copy a supported
+# Python 3.12 runtime while keeping the KiCad CLI/runtime from the base image.
+COPY --from=python-runtime /usr/local /usr/local
+
 # ─── System dependencies ────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-pip \
-    python3-venv \
     git \
     g++ \
     curl \
@@ -38,7 +43,7 @@ RUN git clone --depth 1 https://gitlab.com/kicad/libraries/kicad-library-utils.g
 WORKDIR /app
 
 COPY backend/requirements.txt .
-RUN pip install --ignore-installed --no-cache-dir --break-system-packages -r requirements.txt
+RUN python3.12 -m pip install --ignore-installed --no-cache-dir -r requirements.txt
 
 COPY backend/ .
 COPY scripts/ scripts/
@@ -48,4 +53,4 @@ COPY --from=remote-provider-panel /panel/dist/remote_provider/ /app/app/static/r
 EXPOSE 8000
 
 # Run the application. Keep workers configurable because each worker runs startup hooks.
-CMD ["sh", "-c", "python3 -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-4}"]
+CMD ["sh", "-c", "python3.12 -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS:-4}"]

--- a/backend/app/api/diff.py
+++ b/backend/app/api/diff.py
@@ -2,12 +2,14 @@
 Diff API Routes (Native)
 """
 
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from app.api._helpers import get_project_for_role_or_404
 from app.core.security import AuthenticatedUser, require_designer, require_viewer
-from app.services import diff_service
+from app.services import diff_service, kicad_analysis_service
 
 router = APIRouter(dependencies=[Depends(require_viewer)])
 
@@ -46,6 +48,27 @@ async def get_manifest(project_id: str, job_id: str, user: AuthenticatedUser = D
     if not manifest:
         raise HTTPException(status_code=404, detail="Manifest not found or job not complete")
     return manifest
+
+@router.get("/{project_id}/change-aware-diff")
+async def get_change_aware_diff(
+    project_id: str,
+    commit1: str,
+    commit2: str,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
+    """Return a kicad-monkey-backed semantic diff for schematic/PCB viewers."""
+    get_project_for_role_or_404(project_id, user.role)
+    try:
+        return await asyncio.to_thread(
+            kicad_analysis_service.get_change_aware_diff,
+            project_id,
+            commit1,
+            commit2,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/{project_id}/diff/{job_id}/assets/{path:path}")
 async def get_asset(project_id: str, job_id: str, path: str, user: AuthenticatedUser = Depends(require_viewer)):

--- a/backend/app/services/kicad_analysis_service.py
+++ b/backend/app/services/kicad_analysis_service.py
@@ -1,0 +1,669 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import logging
+import posixpath
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from git import Repo
+from git.exc import BadName
+
+from app.services import path_config_service
+from app.services.workspace_service import workspace
+
+logger = logging.getLogger(__name__)
+
+ANALYSIS_SCHEMA = "kicad_prism.analysis.v1"
+CHANGE_AWARE_DIFF_SCHEMA = "kicad_prism.change_aware_diff.v1"
+
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{4,40}$")
+_CACHE_MAX_ENTRIES = 32
+_analysis_cache: dict[tuple[str, tuple[tuple[str, int, int], ...]], dict[str, Any]] = {}
+
+
+@dataclass(frozen=True)
+class DesignFileSet:
+    project_root: Path
+    project: Optional[Path]
+    schematic: Optional[Path]
+    pcb: Optional[Path]
+
+
+def clear_analysis_cache(project_path: Optional[str] = None) -> None:
+    global _analysis_cache
+    if project_path is None:
+        _analysis_cache = {}
+        return
+    root = str(Path(project_path).resolve())
+    _analysis_cache = {
+        key: value for key, value in _analysis_cache.items() if key[0] != root
+    }
+
+
+def is_valid_commit_hash(value: str) -> bool:
+    return bool(_COMMIT_RE.fullmatch(value or ""))
+
+
+def validate_commit_hash(value: str) -> str:
+    if not is_valid_commit_hash(value):
+        raise ValueError("Invalid commit hash")
+    return value
+
+
+def _normalize_git_path(path: Optional[str]) -> str:
+    if not path or path == ".":
+        return ""
+    normalized = posixpath.normpath(str(path).replace("\\", "/"))
+    if normalized in ("", "."):
+        return ""
+    if normalized.startswith("/") or normalized == ".." or normalized.startswith("../"):
+        raise ValueError("Invalid project path")
+    return normalized
+
+
+def _relative_to(root: Path, path: Optional[Path]) -> Optional[str]:
+    if path is None:
+        return None
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _file_identity(path: Path) -> tuple[str, int, int] | None:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (str(path.resolve()), int(stat.st_mtime_ns), int(stat.st_size))
+
+
+def _fingerprint(files: DesignFileSet) -> tuple[tuple[str, int, int], ...]:
+    paths: list[Path] = []
+    config_path = files.project_root / ".prism.json"
+    paths.append(config_path)
+    for candidate in (files.project, files.schematic, files.pcb):
+        if candidate is not None:
+            paths.append(candidate)
+    paths.extend(
+        path
+        for path in files.project_root.rglob("*.kicad_sch")
+        if not any(part.startswith(".") for part in path.relative_to(files.project_root).parts)
+    )
+    identities = [_file_identity(path) for path in sorted(set(paths), key=lambda item: str(item))]
+    return tuple(identity for identity in identities if identity is not None)
+
+
+def resolve_design_files(project_path: str | Path) -> DesignFileSet:
+    root = Path(project_path).resolve()
+    resolved = path_config_service.resolve_paths(str(root))
+    schematic = Path(resolved.schematic).resolve() if resolved.schematic else None
+    pcb = Path(resolved.pcb).resolve() if resolved.pcb else None
+    project = _select_project_file(root, schematic, pcb)
+    return DesignFileSet(project_root=root, project=project, schematic=schematic, pcb=pcb)
+
+
+def _select_project_file(root: Path, schematic: Optional[Path], pcb: Optional[Path]) -> Optional[Path]:
+    candidates = sorted(root.glob("*.kicad_pro"), key=lambda item: item.name.casefold())
+    if not candidates:
+        return None
+    preferred_stems = [
+        path.stem.casefold()
+        for path in (schematic, pcb)
+        if path is not None
+    ]
+    for stem in preferred_stems:
+        for candidate in candidates:
+            if candidate.stem.casefold() == stem:
+                return candidate.resolve()
+    if len(candidates) == 1:
+        return candidates[0].resolve()
+    for candidate in candidates:
+        if candidate.stem.casefold() == root.name.casefold():
+            return candidate.resolve()
+    return candidates[0].resolve()
+
+
+def analyze_project(project_path: str | Path) -> dict[str, Any]:
+    files = resolve_design_files(project_path)
+    cache_key = (str(files.project_root), _fingerprint(files))
+    cached = _analysis_cache.get(cache_key)
+    if cached is not None:
+        return deepcopy(cached)
+
+    analysis = _build_analysis(files)
+    _analysis_cache[cache_key] = deepcopy(analysis)
+    while len(_analysis_cache) > _CACHE_MAX_ENTRIES:
+        _analysis_cache.pop(next(iter(_analysis_cache)))
+    return analysis
+
+
+def _build_analysis(files: DesignFileSet) -> dict[str, Any]:
+    diagnostics: list[dict[str, Any]] = []
+    design = None
+    design_json: dict[str, Any] = {}
+    netlist_json: dict[str, Any] = {}
+
+    if not files.project:
+        diagnostics.append(_diagnostic("missing_project", "warning", "No .kicad_pro file was found."))
+    if not files.schematic:
+        diagnostics.append(_diagnostic("missing_schematic", "warning", "No root .kicad_sch file was resolved."))
+    if not files.pcb:
+        diagnostics.append(_diagnostic("missing_pcb", "info", "No .kicad_pcb file was resolved."))
+
+    try:
+        design = _load_design(files)
+    except Exception as exc:
+        logger.exception("Failed to load KiCad design from %s", files.project_root)
+        diagnostics.append(_diagnostic("parse_failed", "error", str(exc)))
+
+    if design is not None:
+        try:
+            design_json = design.to_json(include_indexes=True)
+            _augment_design_json_with_schematic_positions(design_json, design, files)
+        except Exception as exc:
+            diagnostics.append(_diagnostic("design_json_failed", "error", str(exc)))
+        try:
+            netlist_json = design.to_kicad_netlist_json()
+        except Exception as exc:
+            diagnostics.append(_diagnostic("netlist_json_failed", "error", str(exc)))
+
+    sheets = _sheet_instances(files, design)
+    diagnostics.extend(_semantic_diagnostics(design_json, sheets, files))
+
+    return {
+        "schema": ANALYSIS_SCHEMA,
+        "files": {
+            "project": _relative_to(files.project_root, files.project),
+            "schematic": _relative_to(files.project_root, files.schematic),
+            "pcb": _relative_to(files.project_root, files.pcb),
+        },
+        "sheets": sheets,
+        "diagnostics": diagnostics,
+        "design_json": design_json,
+        "netlist_json": netlist_json,
+    }
+
+
+def _load_design(files: DesignFileSet):
+    from kicad_monkey import KiCadDesign, KiCadProject
+
+    same_stem_schematic = files.project.with_suffix(".kicad_sch") if files.project else None
+    same_stem_pcb = files.project.with_suffix(".kicad_pcb") if files.project else None
+    schematic_matches_project = (
+        files.schematic is None
+        or same_stem_schematic is not None
+        and same_stem_schematic.resolve() == files.schematic.resolve()
+    )
+    pcb_matches_project = (
+        files.pcb is None
+        or same_stem_pcb is not None
+        and same_stem_pcb.resolve() == files.pcb.resolve()
+    )
+    can_use_project_loader = (
+        files.project is not None
+        and schematic_matches_project
+        and pcb_matches_project
+        and (
+            same_stem_schematic is not None
+            and same_stem_schematic.is_file()
+            or same_stem_pcb is not None
+            and same_stem_pcb.is_file()
+        )
+    )
+
+    if can_use_project_loader:
+        design = KiCadDesign.from_project_file(files.project)
+    elif files.schematic:
+        design = KiCadDesign.from_schematic_file(files.schematic)
+    elif files.pcb:
+        design = KiCadDesign.from_pcb_file(files.pcb)
+    else:
+        return None
+
+    if files.project is not None:
+        try:
+            design.project = KiCadProject.from_file(files.project)
+            design.project_path = files.project
+        except Exception:
+            logger.exception("Failed to load KiCad project metadata from %s", files.project)
+    if files.pcb is not None:
+        design.pcb_path = files.pcb
+        design._pcb = None
+    return design
+
+
+def _sheet_instances(files: DesignFileSet, design: Any) -> list[dict[str, Any]]:
+    if design is None:
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        instances = design.schematic_instances()
+    except Exception:
+        logger.exception("Failed to enumerate schematic instances for %s", files.project_root)
+        return []
+    for item in instances:
+        source = getattr(item, "source_path", None)
+        source_path = Path(source) if source else None
+        out.append({
+            "instance_index": int(getattr(item, "instance_index", 0) or 0),
+            "sheet_number": int(getattr(item, "sheet_number", 0) or 0),
+            "sheet_count": int(getattr(item, "sheet_count", 0) or 0),
+            "sheet_name": str(getattr(item, "sheet_name", "") or ""),
+            "sheet_path": str(getattr(item, "sheet_path", "") or ""),
+            "sheet_path_uuids": str(getattr(item, "sheet_path_uuids", "") or ""),
+            "sheet_instance_path": getattr(item, "sheet_instance_path", None),
+            "source_file": _relative_to(files.project_root, source_path),
+            "filename": source_path.name if source_path else "",
+            "is_top_level": bool(getattr(item, "is_top_level", False)),
+            "parent_sheet_path": getattr(item, "parent_sheet_path", None),
+        })
+    return out
+
+
+def _augment_design_json_with_schematic_positions(design_json: dict[str, Any], design: Any, files: DesignFileSet) -> None:
+    by_reference: dict[str, dict[str, Any]] = {}
+    by_uuid: dict[str, dict[str, Any]] = {}
+    for symbol, sheet_path, schematic in _walk_schematic_symbols(design):
+        reference = _string_or_none(getattr(symbol, "reference", None) or _property_value(symbol, "Reference"))
+        uuid = _string_or_none(getattr(symbol, "uuid", None))
+        source_path = Path(getattr(schematic, "source_path", "") or "")
+        metadata = {
+            "uuid": uuid,
+            "svg_id": uuid,
+            "x": _number_or_none(getattr(symbol, "at_x", None)),
+            "y": _number_or_none(getattr(symbol, "at_y", None)),
+            "sheet": _string_or_none(sheet_path),
+            "sheet_file": _relative_to(files.project_root, source_path) if source_path else None,
+            "sheet_filename": source_path.name if source_path else None,
+        }
+        metadata = {key: value for key, value in metadata.items() if value not in (None, "")}
+        if reference:
+            by_reference[reference] = metadata
+        if uuid:
+            by_uuid[uuid] = metadata
+
+    for component in design_json.get("components") or []:
+        reference = _string_or_none(component.get("designator"))
+        uuid = _string_or_none(component.get("svg_id") or (component.get("parameters") or {}).get("kicad_instance_uuid"))
+        metadata = (by_uuid.get(uuid or "") or by_reference.get(reference or "") or {}).copy()
+        if not metadata:
+            continue
+        for key, value in metadata.items():
+            component.setdefault(key, value)
+
+
+def _walk_schematic_symbols(design: Any):
+    try:
+        for entry in design.top_schematic.walk_symbols():
+            if isinstance(entry, tuple) and len(entry) >= 3:
+                yield entry[0], entry[1], entry[2]
+            else:
+                yield entry, "", design.top_schematic
+        return
+    except Exception:
+        pass
+
+    schematics = getattr(design, "schematics", []) or []
+    if callable(schematics):
+        try:
+            schematics = schematics()
+        except Exception:
+            schematics = []
+    for schematic in schematics:
+        for symbol in getattr(schematic, "symbols", []) or []:
+            yield symbol, "", schematic
+
+
+def _property_value(item: Any, key: str) -> Optional[str]:
+    getter = getattr(item, "get_property_value", None)
+    if callable(getter):
+        try:
+            return _string_or_none(getter(key))
+        except Exception:
+            return None
+    return None
+
+
+def _semantic_diagnostics(design_json: dict[str, Any], sheets: list[dict[str, Any]], files: DesignFileSet) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    hierarchy = design_json.get("schematic_hierarchy") or {}
+    for row in hierarchy.get("unresolved") or []:
+        diagnostics.append(_diagnostic(
+            "unresolved_sheet",
+            "warning",
+            f"Sheet '{row.get('name') or row.get('child_filename')}' points to unresolved file '{row.get('child_filename')}'.",
+            path=row.get("child_filename"),
+        ))
+
+    seen_sources = {
+        sheet.get("source_file")
+        for sheet in sheets
+        if sheet.get("source_file")
+    }
+    if files.schematic and _relative_to(files.project_root, files.schematic) not in seen_sources:
+        diagnostics.append(_diagnostic("root_sheet_not_in_hierarchy", "warning", "Resolved root schematic was not present in the hierarchy."))
+    return diagnostics
+
+
+def get_design_json(project_path: str | Path) -> dict[str, Any]:
+    return deepcopy(analyze_project(project_path).get("design_json") or {})
+
+
+def diff_design_json(old_design: dict[str, Any], new_design: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": CHANGE_AWARE_DIFF_SCHEMA,
+        "components": _diff_maps(
+            _component_map(old_design),
+            _component_map(new_design),
+            fields=("value", "footprint", "library_ref", "parameters", "sheet", "x", "y"),
+        ),
+        "nets": _diff_maps(
+            _net_map(old_design),
+            _net_map(new_design),
+            fields=("terminals", "net_class", "aliases"),
+        ),
+        "sheets": _diff_maps(
+            _sheet_map(old_design),
+            _sheet_map(new_design),
+            fields=("filename", "path", "title", "revision", "date"),
+        ),
+        "placements": _diff_maps(
+            _placement_map(old_design),
+            _placement_map(new_design),
+            fields=("layer", "footprint", "center_x", "center_y", "rotation"),
+        ),
+    }
+
+
+def get_change_aware_diff(project_id: str, commit1: str, commit2: str) -> dict[str, Any]:
+    commit1 = validate_commit_hash(commit1)
+    commit2 = validate_commit_hash(commit2)
+    row = workspace.get_project_by_id(project_id)
+    if not row:
+        raise ValueError("Project not found")
+
+    repo_root = Path(row.get("parent_repo_path") or row.get("path") or "").resolve()
+    if not repo_root:
+        raise ValueError("Project repository path is not available")
+    repo = Repo(repo_root)
+    old_commit = _resolve_commit(repo, commit2)
+    new_commit = _resolve_commit(repo, commit1)
+    relative_prefix = _normalize_git_path(row.get("relative_path"))
+
+    with tempfile.TemporaryDirectory(prefix="prism_semantic_diff_") as tmp:
+        tmp_root = Path(tmp)
+        old_dir = tmp_root / "old"
+        new_dir = tmp_root / "new"
+        _snapshot_tree(old_commit, relative_prefix, old_dir)
+        _snapshot_tree(new_commit, relative_prefix, new_dir)
+
+        old_design = get_design_json(old_dir)
+        new_design = get_design_json(new_dir)
+        design_diff = diff_design_json(old_design, new_design)
+
+        return {
+            "schema": CHANGE_AWARE_DIFF_SCHEMA,
+            "commit1": commit1,
+            "commit2": commit2,
+            "schematic": {
+                "files": _paired_source_files(old_commit, new_commit, relative_prefix, ".kicad_sch"),
+                "diff": _normalise_schematic_diff(design_diff),
+            },
+            "pcb": {
+                "files": _paired_source_files(old_commit, new_commit, relative_prefix, ".kicad_pcb"),
+                "diff": _normalise_pcb_diff(design_diff),
+            },
+            "raw_design_diff": design_diff,
+        }
+
+
+def _resolve_commit(repo: Repo, commit_hash: str):
+    try:
+        return repo.commit(commit_hash)
+    except BadName as error:
+        raise ValueError(f"Commit not found: {commit_hash}") from error
+
+
+def _tree_at_prefix(commit, relative_prefix: str):
+    if not relative_prefix:
+        return commit.tree
+    try:
+        entry = commit.tree / relative_prefix
+    except KeyError as error:
+        raise ValueError("Project path was not found at one of the selected commits") from error
+    if entry.type != "tree":
+        raise ValueError("Project path is not a directory at one of the selected commits")
+    return entry
+
+
+def _snapshot_tree(commit, relative_prefix: str, destination: Path) -> None:
+    root = _tree_at_prefix(commit, relative_prefix)
+    destination.mkdir(parents=True, exist_ok=True)
+    for entry in root.traverse():
+        if entry.type != "blob":
+            continue
+        rel_path = Path(entry.path).relative_to(root.path) if root.path else Path(entry.path)
+        if any(part.startswith(".git") for part in rel_path.parts):
+            continue
+        target = destination / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(entry.data_stream.read())
+
+
+def _blob_paths(commit, relative_prefix: str, suffix: str) -> list[str]:
+    root = _tree_at_prefix(commit, relative_prefix)
+    paths: list[str] = []
+    for entry in root.traverse():
+        if entry.type != "blob" or not entry.path.endswith(suffix):
+            continue
+        rel_path = Path(entry.path).relative_to(root.path).as_posix() if root.path else entry.path
+        paths.append(rel_path)
+    return sorted(paths, key=str.casefold)
+
+
+def _read_blob(commit, relative_prefix: str, rel_path: str) -> Optional[str]:
+    tree_path = posixpath.join(relative_prefix, rel_path) if relative_prefix else rel_path
+    try:
+        entry = commit.tree / tree_path
+    except KeyError:
+        return None
+    if entry.type != "blob":
+        return None
+    return entry.data_stream.read().decode("utf-8", errors="replace")
+
+
+def _paired_source_files(old_commit, new_commit, relative_prefix: str, suffix: str) -> list[dict[str, Any]]:
+    paths = sorted(
+        set(_blob_paths(old_commit, relative_prefix, suffix)) |
+        set(_blob_paths(new_commit, relative_prefix, suffix)),
+        key=str.casefold,
+    )
+    return [
+        {
+            "filename": path,
+            "old_content": _read_blob(old_commit, relative_prefix, path),
+            "new_content": _read_blob(new_commit, relative_prefix, path),
+        }
+        for path in paths
+    ]
+
+
+def _component_map(design_json: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in design_json.get("components") or []:
+        designator = row.get("designator")
+        if not designator:
+            continue
+        out[str(designator)] = {
+            "type": "symbol",
+            "reference": str(designator),
+            "uuid": row.get("uuid") or row.get("svg_id") or (row.get("parameters") or {}).get("kicad_instance_uuid"),
+            "sheet_file": row.get("sheet_file") or row.get("sheet_filename"),
+            "value": row.get("value", ""),
+            "footprint": row.get("footprint", ""),
+            "lib_id": row.get("library_ref", ""),
+            "library_ref": row.get("library_ref", ""),
+            "parameters": row.get("parameters") or {},
+            "sheet": row.get("sheet") or row.get("sheet_path") or "",
+            "x": _number_or_none(row.get("x") or row.get("center_x")),
+            "y": _number_or_none(row.get("y") or row.get("center_y")),
+        }
+    return out
+
+
+def _net_map(design_json: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in design_json.get("nets") or []:
+        name = str(row.get("name", ""))
+        if not name:
+            continue
+        terminals = [
+            f"{term.get('designator')}:{term.get('pin')}"
+            for term in row.get("terminals") or []
+        ]
+        out[name] = {
+            "type": "wire",
+            "name": name,
+            "text": name,
+            "net_name": name,
+            "terminals": sorted(terminals),
+            "net_class": row.get("net_class", ""),
+            "aliases": sorted(row.get("aliases") or []),
+        }
+    return out
+
+
+def _sheet_map(design_json: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        str(row.get("sheet_path") or row.get("path") or row.get("filename")): {
+            "type": "sheet",
+            "sheet_name": row.get("title") or row.get("name") or row.get("filename") or "",
+            "sheet_file": row.get("filename", ""),
+            "filename": row.get("filename", ""),
+            "path": row.get("path", ""),
+            "title": row.get("title", ""),
+            "revision": row.get("revision", ""),
+            "date": row.get("date", ""),
+        }
+        for row in design_json.get("sheets") or []
+        if row.get("sheet_path") or row.get("path") or row.get("filename")
+    }
+
+
+def _placement_map(design_json: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    placements = ((design_json.get("pnp") or {}).get("placements") or [])
+    return {
+        str(row.get("designator")): {
+            "type": "footprint",
+            "reference": str(row.get("designator")),
+            "layer": row.get("layer", ""),
+            "footprint": row.get("footprint", ""),
+            "x": _number_or_none(row.get("center_x")),
+            "y": _number_or_none(row.get("center_y")),
+            "center_x": _number_or_none(row.get("center_x")),
+            "center_y": _number_or_none(row.get("center_y")),
+            "rotation": _number_or_none(row.get("rotation")),
+        }
+        for row in placements
+        if row.get("designator")
+    }
+
+
+def _diff_maps(old: dict[str, dict[str, Any]], new: dict[str, dict[str, Any]], *, fields: tuple[str, ...]) -> dict[str, Any]:
+    added = sorted(set(new) - set(old))
+    removed = sorted(set(old) - set(new))
+    changed: list[dict[str, Any]] = []
+    for key in sorted(set(old) & set(new)):
+        diffs = {
+            field: {"old": old[key].get(field), "new": new[key].get(field)}
+            for field in fields
+            if old[key].get(field) != new[key].get(field)
+        }
+        if diffs:
+            changed.append({"id": key, "diffs": diffs, "old": old[key], "new": new[key]})
+    return {
+        "summary": {"added": len(added), "removed": len(removed), "changed": len(changed)},
+        "added": [{"id": key, "new": new[key]} for key in added],
+        "removed": [{"id": key, "old": old[key]} for key in removed],
+        "changed": changed,
+    }
+
+
+def _normalise_schematic_diff(design_diff: dict[str, Any]) -> dict[str, Any]:
+    return _normalise_diff_sections(design_diff, ("components", "nets", "sheets"))
+
+
+def _normalise_pcb_diff(design_diff: dict[str, Any]) -> dict[str, Any]:
+    return _normalise_diff_sections(design_diff, ("placements", "nets"))
+
+
+def _normalise_diff_sections(design_diff: dict[str, Any], sections: Iterable[str]) -> dict[str, Any]:
+    added: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+    changed: list[dict[str, Any]] = []
+    for section in sections:
+        payload = design_diff.get(section) or {}
+        for row in payload.get("added") or []:
+            added.append(_normalise_item(row["id"], row.get("new") or {}, section))
+        for row in payload.get("removed") or []:
+            removed.append(_normalise_item(row["id"], row.get("old") or {}, section))
+        for row in payload.get("changed") or []:
+            changed.append({
+                "item": _normalise_item(row["id"], row.get("new") or {}, section),
+                "old_item": _normalise_item(row["id"], row.get("old") or {}, section),
+                "changes": row.get("diffs") or {},
+            })
+    return {
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "summary": {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+        },
+    }
+
+
+def _normalise_item(item_id: str, payload: dict[str, Any], section: str) -> dict[str, Any]:
+    item = dict(payload)
+    item["id"] = item.get("id") or item_id
+    item["uuid"] = item.get("uuid") or item.get("svg_id") or item_id
+    if "type" not in item:
+        item["type"] = {
+            "components": "symbol",
+            "placements": "footprint",
+            "nets": "wire",
+            "sheets": "sheet",
+        }.get(section, "other")
+    if section == "nets":
+        item.setdefault("net_name", item_id)
+        item.setdefault("text", item_id)
+    if section in {"components", "placements"}:
+        item.setdefault("reference", item_id)
+    return item
+
+
+def _diagnostic(kind: str, severity: str, message: str, **extra: Any) -> dict[str, Any]:
+    out = {"kind": kind, "severity": severity, "message": message}
+    out.update({key: value for key, value in extra.items() if value not in (None, "", [])})
+    return out
+
+
+def _number_or_none(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _string_or_none(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,5 @@ requests
 PyJWT[crypto]
 kiutils
 python-multipart
+kicad-monkey==2026.6.3
+kicad-cruncher==2026.6.6

--- a/backend/tests/test_kicad_analysis_service.py
+++ b/backend/tests/test_kicad_analysis_service.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services import kicad_analysis_service  # noqa: E402
+
+
+class KiCadAnalysisServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        kicad_analysis_service.clear_analysis_cache()
+
+    def test_validate_commit_hash_rejects_non_hash_input(self) -> None:
+        for value in ("HEAD", "main", "../abc", "abc123 -- path", ""):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    kicad_analysis_service.validate_commit_hash(value)
+
+    def test_load_design_uses_project_loader_for_same_stem_project_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project = root / "Demo.kicad_pro"
+            schematic = root / "Demo.kicad_sch"
+            pcb = root / "Demo.kicad_pcb"
+            for path in (project, schematic, pcb):
+                path.write_text("", encoding="utf-8")
+
+            design = SimpleNamespace(project=None, project_path=None, pcb_path=None, _pcb=None)
+            fake_module = types.ModuleType("kicad_monkey")
+            fake_module.KiCadDesign = SimpleNamespace(
+                from_project_file=lambda _path: None,
+                from_schematic_file=lambda _path: None,
+            )
+            fake_module.KiCadProject = SimpleNamespace(from_file=lambda _path: None)
+            with patch.dict(sys.modules, {"kicad_monkey": fake_module}), \
+                patch("kicad_monkey.KiCadDesign.from_project_file", return_value=design) as from_project, \
+                patch("kicad_monkey.KiCadDesign.from_schematic_file") as from_schematic, \
+                patch("kicad_monkey.KiCadProject.from_file", return_value=object()):
+                loaded = kicad_analysis_service._load_design(
+                    kicad_analysis_service.DesignFileSet(root, project, schematic, pcb)
+                )
+
+            self.assertIs(loaded, design)
+            from_project.assert_called_once_with(project)
+            from_schematic.assert_not_called()
+            self.assertEqual(loaded.project_path, project)
+            self.assertEqual(loaded.pcb_path, pcb)
+
+    def test_design_diff_tracks_component_net_sheet_and_placement_changes(self) -> None:
+        old_design = {
+            "components": [
+                {"designator": "R1", "value": "10k", "footprint": "R_0603", "library_ref": "Device:R", "parameters": {}},
+                {"designator": "C1", "value": "1u", "footprint": "C_0603", "library_ref": "Device:C", "parameters": {}},
+            ],
+            "nets": [
+                {"name": "GND", "terminals": [{"designator": "R1", "pin": "1"}], "net_class": "", "aliases": []},
+                {"name": "OLD", "terminals": [], "net_class": "", "aliases": []},
+            ],
+            "sheets": [
+                {"sheet_path": "/", "filename": "root.kicad_sch", "path": "/", "title": "Root", "revision": "A", "date": ""},
+            ],
+            "pnp": {"placements": [
+                {"designator": "R1", "layer": "top", "footprint": "R_0603", "center_x": 1, "center_y": 2, "rotation": 0}
+            ]},
+        }
+        new_design = {
+            "components": [
+                {"designator": "R1", "value": "22k", "footprint": "R_0603", "library_ref": "Device:R", "parameters": {}},
+                {"designator": "U1", "value": "MCU", "footprint": "QFN", "library_ref": "MCU:U", "parameters": {}},
+            ],
+            "nets": [
+                {"name": "GND", "terminals": [{"designator": "R1", "pin": "2"}], "net_class": "", "aliases": []},
+                {"name": "NEW", "terminals": [], "net_class": "", "aliases": []},
+            ],
+            "sheets": [
+                {"sheet_path": "/", "filename": "root.kicad_sch", "path": "/", "title": "Root", "revision": "B", "date": ""},
+                {"sheet_path": "/Child/", "filename": "child.kicad_sch", "path": "/Child/", "title": "Child", "revision": "", "date": ""},
+            ],
+            "pnp": {"placements": [
+                {"designator": "R1", "layer": "bottom", "footprint": "R_0603", "center_x": 1, "center_y": 2, "rotation": 0}
+            ]},
+        }
+
+        diff = kicad_analysis_service.diff_design_json(old_design, new_design)
+
+        self.assertEqual(diff["components"]["summary"], {"added": 1, "removed": 1, "changed": 1})
+        self.assertEqual(diff["nets"]["summary"], {"added": 1, "removed": 1, "changed": 1})
+        self.assertEqual(diff["sheets"]["summary"], {"added": 1, "removed": 0, "changed": 1})
+        self.assertEqual(diff["placements"]["summary"], {"added": 0, "removed": 0, "changed": 1})
+
+    def test_schematic_symbol_geometry_is_preserved_for_overlays(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            schematic_path = root / "child.kicad_sch"
+            schematic_path.write_text("", encoding="utf-8")
+
+            symbol = SimpleNamespace(
+                reference="R42",
+                uuid="symbol-uuid",
+                at_x=12.5,
+                at_y=34.75,
+            )
+            schematic = SimpleNamespace(source_path=schematic_path)
+            design = SimpleNamespace(
+                top_schematic=SimpleNamespace(
+                    walk_symbols=lambda: [(symbol, "/child/", schematic)]
+                )
+            )
+            design_json = {
+                "components": [
+                    {
+                        "designator": "R42",
+                        "value": "10k",
+                        "footprint": "R_0603",
+                        "library_ref": "Device:R",
+                        "parameters": {},
+                    }
+                ]
+            }
+
+            kicad_analysis_service._augment_design_json_with_schematic_positions(
+                design_json,
+                design,
+                kicad_analysis_service.DesignFileSet(root, None, schematic_path, None),
+            )
+
+        component = design_json["components"][0]
+        self.assertEqual(component["uuid"], "symbol-uuid")
+        self.assertEqual(component["svg_id"], "symbol-uuid")
+        self.assertEqual(component["x"], 12.5)
+        self.assertEqual(component["y"], 34.75)
+        self.assertEqual(component["sheet_file"], "child.kicad_sch")
+
+        mapped = kicad_analysis_service._component_map(design_json)["R42"]
+        self.assertEqual(mapped["uuid"], "symbol-uuid")
+        self.assertEqual(mapped["sheet_file"], "child.kicad_sch")
+        self.assertEqual(mapped["x"], 12.5)
+        self.assertEqual(mapped["y"], 34.75)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/change-aware-diff-viewer.tsx
+++ b/frontend/src/components/change-aware-diff-viewer.tsx
@@ -1,0 +1,829 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { MutableRefObject, ReactNode } from "react";
+import { AlertCircle, CircuitBoard, Cpu, Layers, Loader2, Minus, Plus, RefreshCw, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import { categorise, CATEGORY_META, type Category, type DiffKind, type GroupableItem, type KindedItem } from "@/lib/diff-grouping";
+import type { ECadViewerElement } from "@/types/ecad-viewer";
+
+type DiffDomain = "schematic" | "pcb";
+type ViewerSide = "old" | "new";
+const OVERLAY_REFRESH_INTERVAL_MS = 16;
+
+interface SourceFile {
+    filename: string;
+    old_content: string | null;
+    new_content: string | null;
+}
+
+interface DiffItem extends GroupableItem {
+    id: string;
+    uuid?: string;
+    x?: number | null;
+    y?: number | null;
+    sheet_file?: string;
+    [key: string]: unknown;
+}
+
+interface ChangedItem {
+    item: DiffItem;
+    old_item: DiffItem;
+    changes: Record<string, { old: unknown; new: unknown }>;
+}
+
+interface NormalizedDiff {
+    added: DiffItem[];
+    removed: DiffItem[];
+    changed: ChangedItem[];
+    summary: { added: number; removed: number; changed: number };
+}
+
+interface DomainPayload {
+    files: SourceFile[];
+    diff: NormalizedDiff;
+}
+
+interface ChangeAwareDiffPayload {
+    schema: string;
+    commit1: string;
+    commit2: string;
+    schematic: DomainPayload;
+    pcb: DomainPayload;
+}
+
+interface ChangeMarker {
+    kind: DiffKind;
+    item: DiffItem;
+    old_item?: DiffItem;
+    changes?: Record<string, { old: unknown; new: unknown }>;
+}
+
+interface ChangeAwareDiffViewerProps {
+    projectId: string;
+    commit1: string;
+    commit2: string;
+    onClose: () => void;
+}
+
+interface ViewerFile {
+    filename: string;
+    content: string;
+}
+
+function buildViewerKey(domain: DiffDomain, side: ViewerSide, commit: string, files: ViewerFile[]) {
+    const signature = files.map((file) => `${file.filename}:${file.content.length}`).join("|");
+    return `change-aware:${domain}:${side}:${commit}:${signature}`;
+}
+
+function EcadViewerPane({
+    title,
+    viewerKey,
+    files,
+    viewerRef,
+    onSheetLoaded,
+    children,
+}: {
+    title: string;
+    viewerKey: string;
+    files: ViewerFile[];
+    viewerRef: MutableRefObject<ECadViewerElement | null>;
+    onSheetLoaded?: (page: string | null) => void;
+    children?: ReactNode;
+}) {
+    const setViewerRef = useCallback((node: ECadViewerElement | null) => {
+        viewerRef.current = node;
+    }, [viewerRef]);
+
+    useLayoutEffect(() => {
+        const viewer = viewerRef.current;
+        if (!viewer || files.length === 0) return;
+        let cancelled = false;
+        onSheetLoaded?.(null);
+        const handleSheetLoaded = (event: Event) => {
+            const page = sheetPageFromEvent(event);
+            if (page) onSheetLoaded?.(page);
+        };
+
+        viewer.addEventListener("kicanvas:sheet:loaded", handleSheetLoaded);
+
+        const hydrate = async () => {
+            await customElements.whenDefined("ecad-blob");
+            if (cancelled || !viewerRef.current) return;
+            const activeViewer = viewerRef.current;
+            activeViewer.querySelectorAll("ecad-blob").forEach((blob) => blob.remove());
+            for (const file of files) {
+                const blob = document.createElement("ecad-blob") as HTMLElement & {
+                    filename?: string;
+                    content?: string;
+                };
+                blob.filename = file.filename;
+                blob.content = file.content;
+                activeViewer.appendChild(blob);
+            }
+            const loadable = activeViewer as ECadViewerElement & { load_src?: () => Promise<void> | void };
+            await loadable.load_src?.();
+            activeViewer.setCrossProbeEnabled?.(true);
+        };
+
+        void hydrate();
+        return () => {
+            cancelled = true;
+            viewer.removeEventListener("kicanvas:sheet:loaded", handleSheetLoaded);
+        };
+    }, [files, viewerKey, viewerRef, onSheetLoaded]);
+
+    return (
+        <section className="relative min-h-0 flex-1 overflow-hidden border-r last:border-r-0 bg-background">
+            <div className="absolute left-3 top-3 z-20 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium shadow-sm">
+                {title}
+            </div>
+            <ecad-viewer
+                key={viewerKey}
+                ref={setViewerRef}
+                style={{ width: "100%", height: "100%" }}
+                show-header="true"
+                header-sections="beginning,end"
+            />
+            {children}
+        </section>
+    );
+}
+
+function itemCoordinate(item: DiffItem | undefined) {
+    if (!item) return null;
+    if (typeof item.x !== "number" || typeof item.y !== "number") return null;
+    if (!Number.isFinite(item.x) || !Number.isFinite(item.y)) return null;
+    return { x: item.x, y: item.y };
+}
+
+function sheetPageFromEvent(event: Event): string | null {
+    const detail = (event as CustomEvent<unknown>).detail;
+    if (typeof detail === "string") return detail;
+    if (!detail || typeof detail !== "object") return null;
+    const row = detail as Record<string, unknown>;
+    for (const key of ["filename", "sheetName", "page", "name"]) {
+        const value = row[key];
+        if (typeof value === "string" && value.trim()) return value;
+    }
+    return null;
+}
+
+function normalisePageId(value: string | null | undefined) {
+    return (value ?? "").trim().replace(/\\/g, "/");
+}
+
+function pageBasename(value: string) {
+    return value.split("/").pop() ?? value;
+}
+
+function pagesMatch(itemPage: string | null | undefined, currentPage: string | null | undefined) {
+    const item = normalisePageId(itemPage);
+    const current = normalisePageId(currentPage);
+    if (!item || !current) return false;
+    if (item === current) return true;
+    return pageBasename(item) === pageBasename(current);
+}
+
+function itemLabel(item: DiffItem) {
+    return item.reference || item.net_name || item.text || item.name || item.sheet_name || item.sheet_file || item.id || item.type;
+}
+
+function kindLabel(kind: DiffKind) {
+    return kind === "added" ? "Added" : kind === "removed" ? "Removed" : "Changed";
+}
+
+function kindClass(kind: DiffKind) {
+    if (kind === "added") return "border-green-500/50 text-green-500";
+    if (kind === "removed") return "border-red-500/50 text-red-500";
+    return "border-amber-500/50 text-amber-500";
+}
+
+function displayValue(value: unknown): string {
+    if (value === null || value === undefined || value === "") return "-";
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        return String(value);
+    }
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+function jsonBlock(value: unknown) {
+    try {
+        return JSON.stringify(value ?? null, null, 2);
+    } catch {
+        return String(value);
+    }
+}
+
+function markerIdentityFields(marker: ChangeMarker) {
+    const item = marker.kind === "removed" ? marker.old_item ?? marker.item : marker.item;
+    const keys = ["reference", "net_name", "text", "name", "type", "value", "footprint", "lib_id", "sheet_file", "layer", "x", "y", "uuid"];
+    return keys
+        .map((key) => ({ key, value: item[key] }))
+        .filter((row) => row.value !== undefined && row.value !== null && row.value !== "");
+}
+
+function ChangeDetailsDialog({
+    open,
+    onOpenChange,
+    marker,
+    side,
+    domain,
+    commit1,
+    commit2,
+}: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    marker: ChangeMarker | null;
+    side: ViewerSide | null;
+    domain: DiffDomain;
+    commit1: string;
+    commit2: string;
+}) {
+    if (!marker) {
+        return null;
+    }
+
+    const label = itemLabel(marker.item);
+    const sideLabel = side === "old" ? "Old" : "New";
+    const domainLabel = domain === "schematic" ? "Schematic" : "PCB";
+    const changedEntries = Object.entries(marker.changes ?? {});
+    const primaryItem = marker.kind === "removed" ? marker.old_item ?? marker.item : marker.item;
+    const location = primaryItem.sheet_file || primaryItem.layer;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-3xl max-h-[86vh] overflow-hidden p-0">
+                <DialogHeader className="border-b px-6 py-4">
+                    <DialogTitle className="pr-8">
+                        {kindLabel(marker.kind)} {label}
+                    </DialogTitle>
+                    <DialogDescription>
+                        {domainLabel} / {sideLabel} view / {commit2.slice(0, 7)} {"->"} {commit1.slice(0, 7)}
+                    </DialogDescription>
+                </DialogHeader>
+                <ScrollArea className="max-h-[calc(86vh-6rem)]">
+                    <div className="space-y-5 p-6">
+                        <div className="flex flex-wrap gap-2">
+                            <Badge variant="outline" className={kindClass(marker.kind)}>
+                                {kindLabel(marker.kind)}
+                            </Badge>
+                            <Badge variant="secondary">{primaryItem.type}</Badge>
+                            <Badge variant="outline">{label}</Badge>
+                            {location && <Badge variant="outline">{displayValue(location)}</Badge>}
+                        </div>
+
+                        <section className="space-y-3">
+                            <div>
+                                <h3 className="text-sm font-semibold">Summary</h3>
+                                <p className="mt-1 text-sm text-muted-foreground">
+                                    {marker.kind === "added" && "Added in the new commit."}
+                                    {marker.kind === "removed" && "Removed from the old commit."}
+                                    {marker.kind === "changed" && `${changedEntries.length} field${changedEntries.length === 1 ? "" : "s"} changed.`}
+                                </p>
+                            </div>
+
+                            {marker.kind === "changed" ? (
+                                <div className="overflow-hidden rounded-md border">
+                                    <div className="grid grid-cols-[minmax(8rem,0.7fr)_minmax(0,1fr)_minmax(0,1fr)] border-b bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground">
+                                        <span>Field</span>
+                                        <span>Old</span>
+                                        <span>New</span>
+                                    </div>
+                                    {changedEntries.map(([field, diff]) => (
+                                        <div
+                                            key={field}
+                                            className="grid grid-cols-[minmax(8rem,0.7fr)_minmax(0,1fr)_minmax(0,1fr)] border-b px-3 py-2 text-sm last:border-b-0"
+                                        >
+                                            <span className="font-medium">{field}</span>
+                                            <span className="break-words text-muted-foreground">{displayValue(diff.old)}</span>
+                                            <span className="break-words">{displayValue(diff.new)}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <div className="grid gap-2 rounded-md border p-3 sm:grid-cols-2">
+                                    {markerIdentityFields(marker).map(({ key, value }) => (
+                                        <div key={key} className="min-w-0">
+                                            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{key}</div>
+                                            <div className="mt-1 break-words text-sm">{displayValue(value)}</div>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </section>
+
+                        <section className="space-y-3">
+                            <h3 className="text-sm font-semibold">Raw Metadata</h3>
+                            <div className="grid gap-3">
+                                {[
+                                    ["item", marker.item],
+                                    ["old_item", marker.old_item ?? null],
+                                    ["changes", marker.changes ?? null],
+                                ].map(([title, value]) => (
+                                    <details key={String(title)} className="rounded-md border">
+                                        <summary className="cursor-pointer px-3 py-2 text-sm font-medium">{String(title)}</summary>
+                                        <ScrollArea className="max-h-56 border-t">
+                                            <pre className="whitespace-pre-wrap break-words p-3 font-mono text-xs text-muted-foreground">
+                                                {jsonBlock(value)}
+                                            </pre>
+                                        </ScrollArea>
+                                    </details>
+                                ))}
+                            </div>
+                        </section>
+                    </div>
+                </ScrollArea>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function changeMarkers(diff: NormalizedDiff): ChangeMarker[] {
+    return [
+        ...diff.added.map((item) => ({ kind: "added" as const, item })),
+        ...diff.removed.map((item) => ({ kind: "removed" as const, item })),
+        ...diff.changed.map((item) => ({ kind: "changed" as const, ...item })),
+    ];
+}
+
+function OverlayPins({
+    markers,
+    side,
+    domain,
+    currentPage,
+    viewerRef,
+    selectedId,
+    onSelect,
+}: {
+    markers: ChangeMarker[];
+    side: ViewerSide;
+    domain: DiffDomain;
+    currentPage: string | null;
+    viewerRef: MutableRefObject<ECadViewerElement | null>;
+    selectedId: string | null;
+    onSelect: (marker: ChangeMarker) => void;
+}) {
+    const [positions, setPositions] = useState<Record<string, { x: number; y: number }>>({});
+
+    const updatePositions = useCallback(() => {
+        const viewer = viewerRef.current;
+        if (!viewer?.getScreenLocation) return;
+        const next: Record<string, { x: number; y: number }> = {};
+        for (const marker of markers) {
+            const item = side === "old" ? marker.old_item ?? marker.item : marker.item;
+            if (domain === "schematic" && !pagesMatch(item.sheet_file, currentPage)) continue;
+            const coord = itemCoordinate(item);
+            if (!coord) continue;
+            const screen = viewer.getScreenLocation(coord.x, coord.y);
+            if (screen) next[item.id] = screen;
+        }
+        setPositions(next);
+    }, [currentPage, domain, markers, side, viewerRef]);
+
+    useEffect(() => {
+        updatePositions();
+        const viewer = viewerRef.current;
+        if (!viewer) return;
+        const handler = () => requestAnimationFrame(updatePositions);
+        viewer.addEventListener("kicanvas:mousemove", handler);
+        viewer.addEventListener("panzoom", handler);
+        viewer.addEventListener("mouseup", handler);
+        viewer.addEventListener("wheel", handler);
+        viewer.addEventListener("kicanvas:sheet:loaded", handler);
+        window.addEventListener("resize", handler);
+        const interval = window.setInterval(updatePositions, OVERLAY_REFRESH_INTERVAL_MS);
+        return () => {
+            viewer.removeEventListener("kicanvas:mousemove", handler);
+            viewer.removeEventListener("panzoom", handler);
+            viewer.removeEventListener("mouseup", handler);
+            viewer.removeEventListener("wheel", handler);
+            viewer.removeEventListener("kicanvas:sheet:loaded", handler);
+            window.removeEventListener("resize", handler);
+            window.clearInterval(interval);
+        };
+    }, [updatePositions, viewerRef]);
+
+    return (
+        <div className="pointer-events-none absolute inset-0 z-10">
+            {markers.map((marker) => {
+                const item = side === "old" ? marker.old_item ?? marker.item : marker.item;
+                if (domain === "schematic" && !pagesMatch(item.sheet_file, currentPage)) return null;
+                const position = positions[item.id];
+                if (!position) return null;
+                return (
+                    <button
+                        key={`${side}-${marker.kind}-${item.id}`}
+                        type="button"
+                        className={cn(
+                            "pointer-events-auto absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-background shadow-sm",
+                            marker.kind === "added" && "border-green-500",
+                            marker.kind === "removed" && "border-red-500",
+                            marker.kind === "changed" && "border-amber-500",
+                            selectedId === item.id && "ring-2 ring-ring ring-offset-2 ring-offset-background"
+                        )}
+                        style={{ left: position.x, top: position.y }}
+                        aria-label={`Select ${itemLabel(item)}`}
+                        onClick={() => onSelect(marker)}
+                    />
+                );
+            })}
+        </div>
+    );
+}
+
+function sourcesFor(files: SourceFile[], side: ViewerSide): ViewerFile[] {
+    return files
+        .map((file) => ({
+            filename: file.filename,
+            content: side === "old" ? file.old_content : file.new_content,
+        }))
+        .filter((file): file is ViewerFile => typeof file.content === "string" && file.content.length > 0);
+}
+
+function SummaryPill({
+    label,
+    value,
+    kind,
+    active,
+    onClick,
+}: {
+    label: string;
+    value: number;
+    kind: DiffKind;
+    active: boolean;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-xs transition-colors",
+                active ? "bg-background text-foreground" : "bg-muted/40 text-muted-foreground opacity-60"
+            )}
+            aria-pressed={active}
+        >
+            {kind === "added" && <Plus className="h-3 w-3 text-green-500" />}
+            {kind === "removed" && <Minus className="h-3 w-3 text-red-500" />}
+            {kind === "changed" && <RefreshCw className="h-3 w-3 text-amber-500" />}
+            <span className="text-muted-foreground">{label}</span>
+            <span className="font-semibold text-foreground">{value}</span>
+        </button>
+    );
+}
+
+function focusViewerOnItem(viewer: ECadViewerElement | null, item: DiffItem | undefined, domain: DiffDomain) {
+    if (!viewer || !item) return;
+    const coord = itemCoordinate(item);
+    const reference = item.reference;
+    if (domain === "schematic" && item.sheet_file) {
+        viewer.switchPage?.(item.sheet_file);
+    }
+
+    const runFocus = (attempt = 0) => {
+        if (coord) {
+            viewer.zoomToLocation?.(coord.x, coord.y);
+        }
+        if (reference) {
+            const result = viewer.requestCrossProbe?.({
+                sourceContext: domain === "schematic" ? "SCH" : "PCB",
+                targetContext: domain === "schematic" ? "SCH" : "PCB",
+                mode: "select",
+                kind: "designator",
+                value: reference,
+                designator: reference,
+            });
+            if (
+                result &&
+                !result.resolved &&
+                result.reason === "target-not-available" &&
+                attempt < 12
+            ) {
+                window.setTimeout(() => runFocus(attempt + 1), 120);
+            }
+        }
+    };
+
+    if (domain === "schematic" && item.sheet_file) {
+        window.setTimeout(() => runFocus(), 120);
+    } else {
+        runFocus();
+    }
+}
+
+export function ChangeAwareDiffViewer({ projectId, commit1, commit2, onClose }: ChangeAwareDiffViewerProps) {
+    const [payload, setPayload] = useState<ChangeAwareDiffPayload | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [domain, setDomain] = useState<DiffDomain>("schematic");
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [visibleKinds, setVisibleKinds] = useState<Record<DiffKind, boolean>>({
+        added: true,
+        removed: true,
+        changed: true,
+    });
+    const [activePages, setActivePages] = useState<Record<ViewerSide, string | null>>({
+        old: null,
+        new: null,
+    });
+    const [detailsOpen, setDetailsOpen] = useState(false);
+    const [selectedMarker, setSelectedMarker] = useState<ChangeMarker | null>(null);
+    const [selectedMarkerSide, setSelectedMarkerSide] = useState<ViewerSide | null>(null);
+    const oldViewerRef = useRef<ECadViewerElement | null>(null);
+    const newViewerRef = useRef<ECadViewerElement | null>(null);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setLoading(true);
+        setError(null);
+        const params = new URLSearchParams({ commit1, commit2 });
+        fetch(`/api/projects/${projectId}/change-aware-diff?${params}`, { signal: controller.signal })
+            .then(async (response) => {
+                if (!response.ok) {
+                    const body = await response.json().catch(() => null);
+                    throw new Error(body?.detail || `HTTP ${response.status}`);
+                }
+                return response.json() as Promise<ChangeAwareDiffPayload>;
+            })
+            .then((data) => {
+                if (controller.signal.aborted) return;
+                setPayload(data);
+                setLoading(false);
+            })
+            .catch((err: unknown) => {
+                if (controller.signal.aborted) return;
+                setError(err instanceof Error ? err.message : "Failed to load semantic diff");
+                setLoading(false);
+            });
+        return () => controller.abort();
+    }, [projectId, commit1, commit2]);
+
+    const activePayload = payload?.[domain] ?? null;
+    const allMarkers = useMemo(() => activePayload ? changeMarkers(activePayload.diff) : [], [activePayload]);
+    const markers = useMemo(
+        () => allMarkers.filter((marker) => visibleKinds[marker.kind]),
+        [allMarkers, visibleKinds]
+    );
+    const groups = useMemo(() => {
+        const input: KindedItem<DiffItem>[] = markers.map((marker) => ({ kind: marker.kind, item: marker.item }));
+        return categorise(input);
+    }, [markers]);
+    const groupedSections = useMemo(() => {
+        const sections = new Map<Category, typeof groups>();
+        for (const group of groups) {
+            const key = group.category;
+            const existing = sections.get(key) ?? [];
+            existing.push(group);
+            sections.set(key, existing);
+        }
+        return Array.from(sections.entries()).map(([category, categoryGroups]) => ({
+            category,
+            groups: categoryGroups,
+            count: categoryGroups.reduce((total, group) => total + group.members.length, 0),
+        }));
+    }, [groups]);
+    const oldFiles = useMemo(() => activePayload ? sourcesFor(activePayload.files, "old") : [], [activePayload]);
+    const newFiles = useMemo(() => activePayload ? sourcesFor(activePayload.files, "new") : [], [activePayload]);
+
+    const setActivePageForSide = useCallback((side: ViewerSide, page: string | null) => {
+        setActivePages((current) => current[side] === page ? current : { ...current, [side]: page });
+    }, []);
+    const handleOldSheetLoaded = useCallback((page: string | null) => {
+        setActivePageForSide("old", page);
+    }, [setActivePageForSide]);
+    const handleNewSheetLoaded = useCallback((page: string | null) => {
+        setActivePageForSide("new", page);
+    }, [setActivePageForSide]);
+
+    const focusMarker = useCallback((marker: ChangeMarker) => {
+        setSelectedId(marker.item.id);
+        focusViewerOnItem(newViewerRef.current, marker.item, domain);
+        focusViewerOnItem(oldViewerRef.current, marker.old_item ?? marker.item, domain);
+    }, [domain]);
+    const openMarkerDetails = useCallback((marker: ChangeMarker, side: ViewerSide) => {
+        focusMarker(marker);
+        setSelectedMarker(marker);
+        setSelectedMarkerSide(side);
+        setDetailsOpen(true);
+    }, [focusMarker]);
+
+    useEffect(() => {
+        if (!detailsOpen || !selectedMarker) return;
+        const currentMarker = markers.find((marker) =>
+            marker.kind === selectedMarker.kind &&
+            marker.item.id === selectedMarker.item.id
+        );
+        if (!currentMarker) {
+            setDetailsOpen(false);
+            setSelectedMarker(null);
+            setSelectedMarkerSide(null);
+            return;
+        }
+        if (domain === "schematic" && selectedMarkerSide) {
+            const item = selectedMarkerSide === "old"
+                ? currentMarker.old_item ?? currentMarker.item
+                : currentMarker.item;
+            if (!pagesMatch(item.sheet_file, activePages[selectedMarkerSide])) {
+                setDetailsOpen(false);
+                setSelectedMarker(null);
+                setSelectedMarkerSide(null);
+                return;
+            }
+        }
+        if (currentMarker !== selectedMarker) {
+            setSelectedMarker(currentMarker);
+        }
+    }, [activePages, detailsOpen, domain, markers, selectedMarker, selectedMarkerSide]);
+
+    const setDomainAndCloseDetails = useCallback((nextDomain: DiffDomain) => {
+        setDomain(nextDomain);
+        setDetailsOpen(false);
+        setSelectedMarker(null);
+        setSelectedMarkerSide(null);
+    }, []);
+
+    const summary = activePayload?.diff.summary ?? { added: 0, removed: 0, changed: 0 };
+    const toggleKind = useCallback((kind: DiffKind) => {
+        setVisibleKinds((current) => ({ ...current, [kind]: !current[kind] }));
+    }, []);
+
+    return (
+        <div className="fixed inset-0 z-50 flex flex-col bg-background">
+            <header className="flex min-h-14 items-center gap-3 border-b px-3">
+                <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close diff viewer">
+                    <X className="h-4 w-4" />
+                </Button>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                        <h2 className="truncate text-sm font-semibold">Change-Aware Diff</h2>
+                        <Badge variant="outline" className="font-mono">
+                            {commit2.slice(0, 7)} {"->"} {commit1.slice(0, 7)}
+                        </Badge>
+                    </div>
+                </div>
+                <div className="flex rounded-md border p-1">
+                    <Button
+                        variant={domain === "schematic" ? "secondary" : "ghost"}
+                        size="sm"
+                        onClick={() => setDomainAndCloseDetails("schematic")}
+                    >
+                        <CircuitBoard className="mr-2 h-4 w-4" />
+                        Schematic
+                    </Button>
+                    <Button
+                        variant={domain === "pcb" ? "secondary" : "ghost"}
+                        size="sm"
+                        onClick={() => setDomainAndCloseDetails("pcb")}
+                    >
+                        <Cpu className="mr-2 h-4 w-4" />
+                        PCB
+                    </Button>
+                </div>
+            </header>
+
+            {loading && (
+                <div className="flex flex-1 items-center justify-center gap-3 text-muted-foreground">
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                    Loading semantic diff...
+                </div>
+            )}
+
+            {!loading && error && (
+                <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center text-destructive">
+                    <AlertCircle className="h-8 w-8" />
+                    <div>
+                        <p className="font-semibold">Diff failed</p>
+                        <p className="mt-1 max-w-xl text-sm text-muted-foreground">{error}</p>
+                    </div>
+                </div>
+            )}
+
+            {!loading && !error && activePayload && (
+                <div className="grid min-h-0 flex-1 grid-cols-[280px_minmax(0,1fr)]">
+                    <aside className="min-h-0 border-r bg-muted/20">
+                        <div className="space-y-3 border-b p-3">
+                            <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+                                <Layers className="h-3.5 w-3.5" />
+                                Semantic Changes
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                <SummaryPill label="Added" value={summary.added} kind="added" active={visibleKinds.added} onClick={() => toggleKind("added")} />
+                                <SummaryPill label="Removed" value={summary.removed} kind="removed" active={visibleKinds.removed} onClick={() => toggleKind("removed")} />
+                                <SummaryPill label="Changed" value={summary.changed} kind="changed" active={visibleKinds.changed} onClick={() => toggleKind("changed")} />
+                            </div>
+                        </div>
+                        <ScrollArea className="h-[calc(100vh-8.5rem)]">
+                            <div className="space-y-4 p-3">
+                                {groups.length === 0 && (
+                                    <p className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
+                                        No semantic changes detected for this view.
+                                    </p>
+                                )}
+                                {groupedSections.map((section) => (
+                                    <section key={section.category} className="space-y-1">
+                                        <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                            <span>{CATEGORY_META[section.category].label}</span>
+                                            <span>{section.count}</span>
+                                        </div>
+                                        {section.groups.flatMap((group) => group.members).map((member) => {
+                                            const marker = markers.find((item) => item.item.id === member.item.id);
+                                            if (!marker) return null;
+                                            return (
+                                                <button
+                                                    key={`${member.kind}-${member.item.id}`}
+                                                    type="button"
+                                                    onClick={() => focusMarker(marker)}
+                                                    className={cn(
+                                                        "w-full rounded-md border bg-background px-3 py-2 text-left text-sm transition-colors hover:bg-accent",
+                                                        selectedId === member.item.id && "border-primary bg-primary/5"
+                                                    )}
+                                                >
+                                                    <div className="flex items-center gap-2">
+                                                        <span className={cn(
+                                                            "text-xs font-semibold",
+                                                            member.kind === "added" && "text-green-500",
+                                                            member.kind === "removed" && "text-red-500",
+                                                            member.kind === "changed" && "text-amber-500"
+                                                        )}>
+                                                            {member.kind === "added" ? "+" : member.kind === "removed" ? "-" : "~"}
+                                                        </span>
+                                                        <span className="min-w-0 flex-1 truncate font-medium">{itemLabel(member.item)}</span>
+                                                    </div>
+                                                    {marker.changes && Object.keys(marker.changes).length > 0 && (
+                                                        <p className="mt-1 truncate text-xs text-muted-foreground">
+                                                            {Object.keys(marker.changes).join(", ")}
+                                                        </p>
+                                                    )}
+                                                </button>
+                                            );
+                                        })}
+                                    </section>
+                                ))}
+                            </div>
+                        </ScrollArea>
+                    </aside>
+                    <main className="min-h-0">
+                        {(oldFiles.length === 0 && newFiles.length === 0) ? (
+                            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                                No {domain === "schematic" ? "schematic" : "PCB"} source files found at these commits.
+                            </div>
+                        ) : (
+                            <div className="flex h-full min-h-0">
+                                <EcadViewerPane
+                                    title="Old"
+                                    viewerKey={buildViewerKey(domain, "old", commit2, oldFiles)}
+                                    files={oldFiles}
+                                    viewerRef={oldViewerRef}
+                                    onSheetLoaded={handleOldSheetLoaded}
+                                >
+                                    <OverlayPins
+                                        markers={markers}
+                                        side="old"
+                                        domain={domain}
+                                        currentPage={activePages.old}
+                                        viewerRef={oldViewerRef}
+                                        selectedId={selectedId}
+                                        onSelect={(marker) => openMarkerDetails(marker, "old")}
+                                    />
+                                </EcadViewerPane>
+                                <EcadViewerPane
+                                    title="New"
+                                    viewerKey={buildViewerKey(domain, "new", commit1, newFiles)}
+                                    files={newFiles}
+                                    viewerRef={newViewerRef}
+                                    onSheetLoaded={handleNewSheetLoaded}
+                                >
+                                    <OverlayPins
+                                        markers={markers}
+                                        side="new"
+                                        domain={domain}
+                                        currentPage={activePages.new}
+                                        viewerRef={newViewerRef}
+                                        selectedId={selectedId}
+                                        onSelect={(marker) => openMarkerDetails(marker, "new")}
+                                    />
+                                </EcadViewerPane>
+                            </div>
+                        )}
+                    </main>
+                </div>
+            )}
+            <ChangeDetailsDialog
+                open={detailsOpen}
+                onOpenChange={setDetailsOpen}
+                marker={selectedMarker}
+                side={selectedMarkerSide}
+                domain={domain}
+                commit1={commit1}
+                commit2={commit2}
+            />
+        </div>
+    );
+}

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { GitCommit, Tag, Eye, Check, Copy, User, Clock, Calendar } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { VisualDiffViewer } from "./visual-diff-viewer";
+import { ChangeAwareDiffViewer } from "./change-aware-diff-viewer";
 import { fetchJson } from "@/lib/api";
 
 interface Release {
@@ -280,7 +280,7 @@ export function HistoryViewer({ projectId, onViewCommit, canCompareDiffs }: Hist
 
             {/* Visual Diff Viewer */}
             {showDiff && diffPair && (
-                <VisualDiffViewer
+                <ChangeAwareDiffViewer
                     projectId={projectId}
                     commit1={diffPair.newer.full_hash}
                     commit2={diffPair.older.full_hash}

--- a/frontend/src/lib/diff-grouping.ts
+++ b/frontend/src/lib/diff-grouping.ts
@@ -1,0 +1,298 @@
+/**
+ * Unified diff grouping - single source of truth for how diff items are
+ * categorised and rendered across the project.
+ *
+ * Used by:
+ *   - PCB diff viewer sidebar (with bbox computation layered on top)
+ *   - Schematic diff viewer sidebar
+ *   - Commit list summary (history-viewer.tsx)
+ *
+ * The categories are domain-aware: PCB items go into Components/Nets/Zones/
+ * Graphics; schematic items into Symbols/Nets/Sheets/Text. Within a category,
+ * items that have both additions and removals are merged into a "changed"
+ * (mixed) kind - this prevents visually misleading green+red splits when a
+ * net was rerouted or a zone redrawn.
+ */
+
+export type DiffKind = "added" | "removed" | "changed";
+
+/** Visual + semantic category. Stable identifiers used for grouping and ordering. */
+export type Category =
+    | "components" // PCB footprints
+    | "nets"       // PCB segments + vias OR schematic wires + labels
+    | "zones"      // PCB zones / fills
+    | "graphics"   // PCB graphic primitives (gr_text, gr_line, ...)
+    | "symbols"    // schematic symbols
+    | "sheets"     // schematic hierarchical sheets
+    | "text"       // schematic text / annotations
+    | "other";
+
+export interface CategoryMeta {
+    /** Plural label shown as a section heading. */
+    label: string;
+    /** Sort order for stable display. */
+    order: number;
+}
+
+export const CATEGORY_META: Record<Category, CategoryMeta> = {
+    components: { label: "Components", order: 0 },
+    symbols:    { label: "Symbols",    order: 0 },
+    nets:       { label: "Nets",       order: 1 },
+    zones:      { label: "Zones",      order: 2 },
+    sheets:     { label: "Sheets",     order: 3 },
+    text:       { label: "Text",       order: 4 },
+    graphics:   { label: "Graphics",   order: 5 },
+    other:      { label: "Other",      order: 9 },
+};
+
+/** Map a raw kicad item type to a category. Pure, no item context required. */
+export function categoryFor(type: string | undefined): Category {
+    if (!type) return "other";
+    switch (type) {
+        // PCB
+        case "footprint": return "components";
+        case "segment":
+        case "arc":
+        case "via":       return "nets";
+        case "zone":      return "zones";
+        case "gr_text":
+        case "gr_line":
+        case "gr_circle":
+        case "gr_rect":
+        case "gr_arc":
+        case "gr_poly":   return "graphics";
+        // Schematic
+        case "symbol":              return "symbols";
+        case "label":
+        case "global_label":
+        case "hierarchical_label":
+        case "net_label":
+        case "wire":
+        case "bus":
+        case "bus_entry":
+        case "junction":
+        case "no_connect":          return "nets";
+        case "sheet":               return "sheets";
+        case "text":                return "text";
+        default:                    return "other";
+    }
+}
+
+/**
+ * Reconcile a set of kinds within a single bucket.
+ *
+ *   { added }            -> "added"
+ *   { removed }          -> "removed"
+ *   { changed }          -> "changed"
+ *   { added, removed }   -> "changed"  (rerouted / replaced)
+ *   any with "changed"   -> "changed"
+ */
+export function mergedKind(kinds: Iterable<DiffKind>): DiffKind {
+    const set = new Set<DiffKind>();
+    for (const k of kinds) set.add(k);
+    if (set.size === 1) return set.values().next().value as DiffKind;
+    return "changed";
+}
+
+/** Minimal item shape - anything else is ignored by this module. */
+export interface GroupableItem {
+    id?: string;
+    type: string;
+    /** PCB nets are keyed on this string. */
+    net?: string | number | null;
+    net_name?: string;
+    /** Layer string (used by graphics for sub-grouping). */
+    layer?: string;
+    /** PCB component identity. */
+    reference?: string;
+    value?: string;
+    lib_id?: string;
+    /** Free-form per-type label fields. */
+    text?: string;
+    name?: string;
+    sheet_name?: string;
+    sheet_file?: string;
+}
+
+export interface KindedItem<T extends GroupableItem = GroupableItem> {
+    kind: DiffKind;
+    item: T;
+}
+
+/** Sub-group within a category - e.g. one net, one component, one layer. */
+export interface DiffGroup<T extends GroupableItem = GroupableItem> {
+    /** Stable id within the categorise() call. */
+    id: string;
+    category: Category;
+    /** Reconciled kind across all members. */
+    kind: DiffKind;
+    /** Display label (e.g. "GND - 3 wires", "U5 (LM358)"). */
+    label: string;
+    /** All items belonging to this group, with their original kinds. */
+    members: KindedItem<T>[];
+    /**
+     * Item count breakdown - useful for compact summaries without iterating
+     * `members`. Excludes the "kind" reconciliation; values reflect the raw
+     * input distribution.
+     */
+    count: { added: number; removed: number; changed: number };
+}
+
+/** Sub-grouping policy - controls how items within a category are bucketed. */
+type SubGroupPolicy =
+    | "per-item"      // one group per item (default for components, sheets, zones, symbols)
+    | "by-net"        // PCB nets and schematic nets - group by net key
+    | "by-layer";     // PCB graphics - group by layer
+
+const POLICY: Record<Category, SubGroupPolicy> = {
+    components: "per-item",
+    symbols:    "per-item",
+    sheets:     "per-item",
+    zones:      "per-item",
+    text:       "per-item",
+    other:      "per-item",
+    nets:       "by-net",
+    graphics:   "by-layer",
+};
+
+/**
+ * Group a flat list of {kind, item} into category buckets, with sub-grouping
+ * applied per category policy. Stable across calls (deterministic ordering
+ * via insertion order + `order` rank).
+ *
+ * NOTE: This is the layout for sidebars and commit-list previews. Geometric
+ * concerns (bounding boxes, polygon points) are computed separately by the
+ * diff viewers - pass the same items through this function and merge the
+ * `members` lists by group id when you need the geometry.
+ */
+export function categorise<T extends GroupableItem>(input: KindedItem<T>[]): DiffGroup<T>[] {
+    const buckets = new Map<string, DiffGroup<T>>();
+    let auto = 0;
+    let fallback = 0;
+    const nextId = () => `g${auto++}`;
+
+    for (const ki of input) {
+        const cat = categoryFor(ki.item.type);
+        const policy = POLICY[cat];
+        const subKey = subGroupKey(cat, policy, ki.item, fallback++);
+        const bucketKey = `${cat}::${subKey}`;
+        let bucket = buckets.get(bucketKey);
+        if (!bucket) {
+            bucket = {
+                id: nextId(),
+                category: cat,
+                kind: ki.kind,
+                label: "", // computed at end from members
+                members: [],
+                count: { added: 0, removed: 0, changed: 0 },
+            };
+            buckets.set(bucketKey, bucket);
+        }
+        bucket.members.push(ki);
+        bucket.count[ki.kind]++;
+    }
+
+    // Reconcile kinds + build labels.
+    const out: DiffGroup<T>[] = [];
+    for (const b of buckets.values()) {
+        b.kind = mergedKind(b.members.map(m => m.kind));
+        b.label = labelForGroup(b);
+        out.push(b);
+    }
+
+    // Sort by category order, then by label for stable presentation.
+    out.sort((a, b) => {
+        const oa = CATEGORY_META[a.category].order;
+        const ob = CATEGORY_META[b.category].order;
+        if (oa !== ob) return oa - ob;
+        return a.label.localeCompare(b.label);
+    });
+    return out;
+}
+
+function subGroupKey(cat: Category, policy: SubGroupPolicy, item: GroupableItem, fallbackIndex: number): string {
+    if (policy === "by-net") {
+        // PCB segments/vias use `net` (number) or `net_name` (string).
+        // Schematic labels expose the net name via `text` (label content).
+        const k = item.net ?? item.net_name ?? item.text ?? "(no net)";
+        return String(k);
+    }
+    if (policy === "by-layer") {
+        return item.layer ?? "(no layer)";
+    }
+    // per-item: use a unique key so each item gets its own bucket.
+    return item.id ?? [
+        cat,
+        item.type,
+        item.reference,
+        item.value,
+        item.text,
+        item.name,
+        item.sheet_name,
+        item.sheet_file,
+        fallbackIndex,
+    ].filter((part) => part !== undefined && part !== null && part !== "").join(":");
+}
+
+function labelForGroup(g: DiffGroup): string {
+    const m = g.members;
+    if (m.length === 0) return "";
+    switch (g.category) {
+        case "nets": {
+            const item = m[0].item;
+            const netLabel = item.net_name
+                ? String(item.net_name)
+                : item.net != null && item.net !== ""
+                    ? `Net ${String(item.net)}`
+                    : item.text
+                        ? String(item.text)
+                        : "No net";
+            const parts: string[] = [];
+            const segCount  = m.filter(x => x.item.type === "segment" || x.item.type === "wire" || x.item.type === "arc").length;
+            const viaCount  = m.filter(x => x.item.type === "via").length;
+            const lblCount  = m.filter(x => x.item.type === "label" || x.item.type === "global_label" || x.item.type === "hierarchical_label" || x.item.type === "net_label").length;
+            const busCount  = m.filter(x => x.item.type === "bus" || x.item.type === "bus_entry").length;
+            const jncCount  = m.filter(x => x.item.type === "junction" || x.item.type === "no_connect").length;
+            if (segCount) parts.push(`${segCount} ${segCount === 1 ? "wire" : "wires"}`);
+            if (viaCount) parts.push(`${viaCount} ${viaCount === 1 ? "via" : "vias"}`);
+            if (lblCount) parts.push(`${lblCount} ${lblCount === 1 ? "label" : "labels"}`);
+            if (busCount) parts.push(`${busCount} ${busCount === 1 ? "bus" : "buses"}`);
+            if (jncCount) parts.push(`${jncCount} ${jncCount === 1 ? "junction" : "junctions"}`);
+            return parts.length > 0 ? `${netLabel} - ${parts.join(", ")}` : netLabel;
+        }
+        case "graphics": {
+            const layer = m[0].item.layer ?? "No layer";
+            return `${layer} - ${m.length} item${m.length === 1 ? "" : "s"}`;
+        }
+        case "components": {
+            const it = m[0].item;
+            const ref = it.reference || it.lib_id || "?";
+            return it.value ? `${ref} (${it.value})` : ref;
+        }
+        case "symbols": {
+            const it = m[0].item;
+            const ref = it.reference || it.lib_id || "?";
+            return it.value ? `${ref} (${it.value})` : ref;
+        }
+        case "zones": {
+            const it = m[0].item;
+            return it.net_name && it.layer
+                ? `${it.net_name} (${it.layer})`
+                : it.net_name || it.name || "Zone";
+        }
+        case "sheets": {
+            const it = m[0].item;
+            return it.sheet_name || it.sheet_file || "Sheet";
+        }
+        case "text": {
+            const it = m[0].item;
+            const t = it.text ?? "";
+            return t.length > 32 ? `${t.slice(0, 29)}...` : (t || "Text");
+        }
+        case "other":
+        default: {
+            const it = m[0].item;
+            return it.name || it.text || it.type;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a change-aware diff viewer that combines the semantic diff source from `kicad-monkey` with the dual `ecad-viewer` comparison experience. The viewer supports schematic and PCB tabs, old/new panes, semantic change navigation, page-scoped schematic overlays, marker filtering, and detailed modal metadata for individual overlay markers.

Credit: Keybored is credited for the dual `ecad-viewer` instance layout and the grouped/overlay UI direction for presenting changes.

## What changed

- Added a backend change-aware diff endpoint under the existing project diff API.
- Added a `kicad-monkey` backed analysis/normalization service for schematic and PCB semantic changes.
- Added a full-screen frontend change-aware diff viewer wired from the history compare flow.
- Added grouped semantic change UI for added, removed, and changed items.
- Added overlay markers on old/new panes with page-aware schematic filtering.
- Added modal change details for overlay marker clicks, including old/new field values and raw metadata.
- Updated the backend Docker runtime to use Python 3.12 so the pinned `kicad-monkey` package can install on the KiCad base image.

## Validation

- `python -m pytest backend/tests` passed locally earlier on this branch.
- `npm run build` passed.
- `npm run lint` passed.
- `git diff --check` passed.

## Notes

- This intentionally does not port the from-scratch schematic/PCB parser services from PR #48.
- The semantic source of truth is `kicad-monkey`; Prism adapts its output into the viewer model.
- Auth/OIDC behavior is unchanged.
