### PR TITLE
Visual diff: multi-layer view, copper pour toggle, board-outline alignment

### DIFF
--- a/backend/app/services/diff_service.py
+++ b/backend/app/services/diff_service.py
@@ -14,11 +14,11 @@ import time
 import json
 import re
 from pathlib import Path
-from typing import Callable, Optional, List, Dict
+from typing import Callable, Optional, List, Dict, Tuple
 from app.services.project_service import find_schematic_file
 from app.services.workspace_service import workspace
 from app.services import bom_diff_service
-from app.services.pcb_sexpr_service import strip_zone_fills
+from app.services.pcb_sexpr_service import strip_zone_fills, edge_cuts_bbox
 
 # Global job store
 # Structure: { job_id: { ... } }
@@ -258,12 +258,37 @@ def _colorize_svg(svg_path: Path, color: str):
         
     svg_path.write_text(content, encoding="utf-8")
 
+def _set_svg_viewbox(svg_path: Path, viewbox: Tuple[float, float, float, float]):
+    """
+    Rewrite the root <svg> width/height/viewBox to the given window
+    (min_x, min_y, w, h) in mm. Page-size-mode 1 exports use absolute
+    page coordinates in mm, so this crops both commits to the same
+    board-anchored window.
+    """
+    min_x, min_y, w, h = viewbox
+    content = svg_path.read_text(encoding="utf-8")
+    content = re.sub(r'width="[^"]*"', f'width="{w:.4f}mm"', content, count=1)
+    content = re.sub(r'height="[^"]*"', f'height="{h:.4f}mm"', content, count=1)
+    content = re.sub(
+        r'viewBox="[^"]*"',
+        f'viewBox="{min_x:.4f} {min_y:.4f} {w:.4f} {h:.4f}"',
+        content, count=1
+    )
+    svg_path.write_text(content, encoding="utf-8")
+
 def _export_pcb_svgs(pcb_file: Path, out_dir: Path, all_layers: List[str],
-                     color: str, log: Callable[[str], None]) -> List[str]:
+                     color: str, log: Callable[[str], None],
+                     viewbox: Optional[Tuple[float, float, float, float]] = None) -> List[str]:
     """
     Run kicad-cli pcb export svg --mode-multi into out_dir, normalize
     filenames to {Layer_Name}.svg, colorize, and return the matched
     layer names. Returns [] on export failure.
+
+    With viewbox set, exports in absolute page coordinates
+    (--page-size-mode 1) and crops every SVG to that window so both
+    commits share a board-anchored frame regardless of where the design
+    sits on the page. Without it, falls back to board-area cropping
+    (--page-size-mode 2).
     """
     out_dir.mkdir(exist_ok=True)
 
@@ -273,7 +298,7 @@ def _export_pcb_svgs(pcb_file: Path, out_dir: Path, all_layers: List[str],
         "--layers", ",".join(all_layers),
         "--black-and-white",
         "--exclude-drawing-sheet",
-        "--page-size-mode", "2",
+        "--page-size-mode", "1" if viewbox else "2",
         "--output", str(out_dir),
         str(pcb_file)
     ]
@@ -311,6 +336,8 @@ def _export_pcb_svgs(pcb_file: Path, out_dir: Path, all_layers: List[str],
                 svg.rename(target_svg)
 
             _colorize_svg(target_svg, color)
+            if viewbox:
+                _set_svg_viewbox(target_svg, viewbox)
             found_layers.append(matched_layer)
         else:
             log(f"Could not match PCB SVG: {leaf}")
@@ -388,6 +415,34 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
         # between commits still appear in the manifest.
         pcb_layer_union: set = set()
 
+        # Anchor each commit's PCB export window to its own board outline,
+        # with a shared window size, so a design moved on the page (or a
+        # changed bounding box) doesn't render the whole board as shifted.
+        ALIGN_MARGIN_MM = 2.0
+        pcb_viewboxes: Dict[str, Tuple[float, float, float, float]] = {}
+        try:
+            outline_bboxes = {}
+            for commit, directory in [(commit1, c1_dir), (commit2, c2_dir)]:
+                pf = next(directory.rglob("*.kicad_pcb"), None)
+                if pf:
+                    outline_bboxes[commit] = edge_cuts_bbox(
+                        pf.read_text(encoding="utf-8", errors="ignore")
+                    )
+            if len(outline_bboxes) == 2 and all(outline_bboxes.values()):
+                w = max(b[2] - b[0] for b in outline_bboxes.values()) + 2 * ALIGN_MARGIN_MM
+                h = max(b[3] - b[1] for b in outline_bboxes.values()) + 2 * ALIGN_MARGIN_MM
+                pcb_viewboxes = {
+                    c: (b[0] - ALIGN_MARGIN_MM, b[1] - ALIGN_MARGIN_MM, w, h)
+                    for c, b in outline_bboxes.items()
+                }
+                job['logs'].append(f"Anchoring PCB exports to board outline (window {w:.1f}x{h:.1f}mm)")
+            else:
+                job['logs'].append("Board outline not found in both commits; using board-area export")
+            _persist_job(job_id)
+        except Exception as e:
+            job['logs'].append(f"Outline alignment skipped: {e}")
+            _persist_job(job_id)
+
         for commit, directory, color in [(commit1, c1_dir, COLOR_NEW), (commit2, c2_dir, COLOR_OLD)]:
             # 1. Locate design files
             # Use the path-config-resolved root so kicad-cli walks the full
@@ -441,7 +496,10 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
 
                 # We export standard layers in one shot using --mode-multi
                 all_layers = _get_pcb_layers(pcb_file)
-                found_layers = _export_pcb_svgs(pcb_file, directory / "pcb", all_layers, color, log)
+                found_layers = _export_pcb_svgs(
+                    pcb_file, directory / "pcb", all_layers, color, log,
+                    viewbox=pcb_viewboxes.get(commit)
+                )
                 pcb_layer_union.update(found_layers)
 
                 # Pour-free variant: export a copy with zone fills stripped.
@@ -457,7 +515,8 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
                             encoding="utf-8"
                         )
                         nopour_layers = _export_pcb_svgs(
-                            stripped_pcb, directory / "pcb_nopours", all_layers, color, log
+                            stripped_pcb, directory / "pcb_nopours", all_layers, color, log,
+                            viewbox=pcb_viewboxes.get(commit)
                         )
                         if commit == commit1:
                             manifest["pours"] = bool(nopour_layers)

--- a/backend/app/services/diff_service.py
+++ b/backend/app/services/diff_service.py
@@ -14,10 +14,11 @@ import time
 import json
 import re
 from pathlib import Path
-from typing import Optional, List, Dict
+from typing import Callable, Optional, List, Dict
 from app.services.project_service import find_schematic_file
 from app.services.workspace_service import workspace
 from app.services import bom_diff_service
+from app.services.pcb_sexpr_service import strip_zone_fills
 
 # Global job store
 # Structure: { job_id: { ... } }
@@ -257,6 +258,65 @@ def _colorize_svg(svg_path: Path, color: str):
         
     svg_path.write_text(content, encoding="utf-8")
 
+def _export_pcb_svgs(pcb_file: Path, out_dir: Path, all_layers: List[str],
+                     color: str, log: Callable[[str], None]) -> List[str]:
+    """
+    Run kicad-cli pcb export svg --mode-multi into out_dir, normalize
+    filenames to {Layer_Name}.svg, colorize, and return the matched
+    layer names. Returns [] on export failure.
+    """
+    out_dir.mkdir(exist_ok=True)
+
+    cmd = [
+        CLI_CMD, "pcb", "export", "svg",
+        "--mode-multi",
+        "--layers", ",".join(all_layers),
+        "--black-and-white",
+        "--exclude-drawing-sheet",
+        "--page-size-mode", "2",
+        "--output", str(out_dir),
+        str(pcb_file)
+    ]
+    log(f"PCB CMD: {' '.join(cmd)}")
+    res = subprocess.run(cmd, capture_output=True, text=True)
+
+    if res.returncode != 0:
+        log(f"PCB Export FAILED (Code {res.returncode})")
+        log(f"STDERR: {res.stderr}")
+        return []
+
+    # KiCad names these {project}-{layer}.svg or just {layer}.svg
+    # We normalize them to {layer_name}.svg for the frontend
+    found_layers = []
+    log(f"PCB Export success. Dir content: {list(out_dir.glob('*.svg'))}")
+
+    for svg in list(out_dir.glob("*.svg")):
+        leaf = svg.name
+        layer_part = leaf
+        if leaf.startswith(pcb_file.stem + "-"):
+            layer_part = leaf[len(pcb_file.stem)+1:]
+
+        # Match back to the original layer name to ensure F.Cu vs F_Cu consistency
+        matched_layer = None
+        for l in all_layers:
+            if l.replace(".", "_") == layer_part.replace(".svg", ""):
+                matched_layer = l
+                break
+
+        if matched_layer:
+            target_svg = out_dir / (matched_layer.replace(".", "_") + ".svg")
+            log(f"Matched {leaf} -> {matched_layer} (Target: {target_svg.name})")
+            if svg.resolve() != target_svg.resolve():
+                if target_svg.exists(): target_svg.unlink()
+                svg.rename(target_svg)
+
+            _colorize_svg(target_svg, color)
+            found_layers.append(matched_layer)
+        else:
+            log(f"Could not match PCB SVG: {leaf}")
+
+    return found_layers
+
 def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: str):
     """Execute diff generation in background."""
     job = diff_jobs[job_id]
@@ -282,6 +342,9 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
             "commit2": commit2,
             "schematic": True,
             "pcb": True,
+            "layers": [],
+            "sheets": [],
+            "pours": False,
             "bom": None,
         }
         
@@ -320,6 +383,10 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
         
         # Per-commit sch output dirs, captured for the post-loop union.
         sch_dirs: Dict[str, Path] = {}
+
+        # PCB layers found across both commits, so layers added/removed
+        # between commits still appear in the manifest.
+        pcb_layer_union: set = set()
 
         for commit, directory, color in [(commit1, c1_dir, COLOR_NEW), (commit2, c2_dir, COLOR_OLD)]:
             # 1. Locate design files
@@ -365,67 +432,37 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
             
             # 3. Export PCB Layers
             if pcb_file:
-                pcb_out_dir = directory / "pcb"
-                pcb_out_dir.mkdir(exist_ok=True)
                 job['logs'].append(f"Exporting PCB Layers for {commit} from {pcb_file}...")
                 _persist_job(job_id)
-                
+
+                def log(msg, _job=job, _id=job_id):
+                    _job['logs'].append(msg)
+                    _persist_job(_id)
+
                 # We export standard layers in one shot using --mode-multi
                 all_layers = _get_pcb_layers(pcb_file)
-                cmd = [
-                    CLI_CMD, "pcb", "export", "svg",
-                    "--mode-multi",
-                    "--layers", ",".join(all_layers),
-                    "--black-and-white",
-                    "--exclude-drawing-sheet",
-                    "--page-size-mode", "2",
-                    "--output", str(pcb_out_dir),
-                    str(pcb_file)
-                ]
-                job['logs'].append(f"PCB CMD: {' '.join(cmd)}")
-                _persist_job(job_id)
-                res = subprocess.run(cmd, capture_output=True, text=True)
-                
-                if res.returncode == 0:
-                    # KiCad names these {project}-{layer}.svg or just {layer}.svg
-                    # We normalize them to {layer_name}.svg for the frontend
-                    found_layers = []
-                    job['logs'].append(f"PCB Export success. Dir content: {list(pcb_out_dir.glob('*.svg'))}")
-                    _persist_job(job_id)
-                    
-                    for svg in list(pcb_out_dir.glob("*.svg")):
-                        leaf = svg.name
-                        layer_part = leaf
-                        if leaf.startswith(pcb_file.stem + "-"):
-                            layer_part = leaf[len(pcb_file.stem)+1:]
-                        
-                        # Match back to the original layer name to ensure F.Cu vs F_Cu consistency
-                        matched_layer = None
-                        for l in all_layers:
-                            if l.replace(".", "_") == layer_part.replace(".svg", ""):
-                                matched_layer = l
-                                break
-                        
-                        if matched_layer:
-                            target_svg = pcb_out_dir / (matched_layer.replace(".", "_") + ".svg")
-                            job['logs'].append(f"Matched {leaf} -> {matched_layer} (Target: {target_svg.name})")
-                            if svg.resolve() != target_svg.resolve():
-                                if target_svg.exists(): target_svg.unlink()
-                                svg.rename(target_svg)
-                            
-                            _colorize_svg(target_svg, color)
-                            found_layers.append(matched_layer)
-                        else:
-                            job['logs'].append(f"Could not match PCB SVG: {leaf}")
-                    
-                    if commit == commit1:
-                        manifest["layers"] = sorted(list(set(found_layers)))
-                        job['logs'].append(f"Populated manifest with {len(manifest['layers'])} layers")
-                        _persist_job(job_id)
-                else:
-                    job['logs'].append(f"PCB Export FAILED (Code {res.returncode})")
-                    job['logs'].append(f"STDERR: {res.stderr}")
-                    _persist_job(job_id)
+                found_layers = _export_pcb_svgs(pcb_file, directory / "pcb", all_layers, color, log)
+                pcb_layer_union.update(found_layers)
+
+                # Pour-free variant: export a copy with zone fills stripped.
+                # Failure here must never break the main export.
+                if found_layers:
+                    try:
+                        log(f"Exporting no-pour PCB variant for {commit}...")
+                        nopours_src = directory / "_nopours_src"
+                        nopours_src.mkdir(exist_ok=True)
+                        stripped_pcb = nopours_src / pcb_file.name
+                        stripped_pcb.write_text(
+                            strip_zone_fills(pcb_file.read_text(encoding="utf-8", errors="ignore")),
+                            encoding="utf-8"
+                        )
+                        nopour_layers = _export_pcb_svgs(
+                            stripped_pcb, directory / "pcb_nopours", all_layers, color, log
+                        )
+                        if commit == commit1:
+                            manifest["pours"] = bool(nopour_layers)
+                    except Exception as e:
+                        log(f"No-pour variant failed for {commit}: {e}")
             else:
                 job['logs'].append(f"No .kicad_pcb found for {commit}")
                 _persist_job(job_id)
@@ -437,6 +474,10 @@ def _run_diff_generation(job_id: str, project_id: str, commit1: str, commit2: st
             sheet_union.update(p.name for p in d.glob("*.svg"))
         if sheet_union:
             manifest["sheets"] = sorted(sheet_union)
+
+        manifest["layers"] = sorted(pcb_layer_union)
+        job['logs'].append(f"Populated manifest with {len(manifest['layers'])} layers")
+        _persist_job(job_id)
 
         # 4. BoM Diff
         job['logs'].append("Generating BoM Diff...")

--- a/backend/app/services/pcb_sexpr_service.py
+++ b/backend/app/services/pcb_sexpr_service.py
@@ -5,7 +5,9 @@ Stdlib-only on purpose: keeps this importable from tests without pulling
 in the workspace/database stack.
 """
 
-from typing import Optional
+import math
+import re
+from typing import List, Optional, Tuple
 
 # Tokens that hold a zone's computed fill geometry. kicad-cli plots the
 # stored fills without refilling, so removing these blocks yields
@@ -107,3 +109,67 @@ def strip_zone_fills(pcb_text: str) -> str:
             pos += 1
 
     return "".join(out_parts)
+
+
+# Board-level graphic elements that can form the board outline. Footprint
+# graphics (fp_line etc.) on Edge.Cuts are intentionally ignored — they
+# would need the footprint's position/rotation applied.
+_OUTLINE_TOKENS = ("(gr_line", "(gr_arc", "(gr_rect", "(gr_circle", "(gr_poly", "(gr_curve")
+
+_COORD_RE = re.compile(r'\((?:start|end|mid|center|xy)\s+(-?[\d.]+)\s+(-?[\d.]+)')
+_CENTER_RE = re.compile(r'\(center\s+(-?[\d.]+)\s+(-?[\d.]+)')
+_END_RE = re.compile(r'\(end\s+(-?[\d.]+)\s+(-?[\d.]+)')
+# Layer names are quoted in modern files, bare in legacy (pre-v6) ones.
+_EDGE_LAYER_RE = re.compile(r'\(layer\s+"?Edge\.Cuts"?\s*\)')
+
+
+def edge_cuts_bbox(pcb_text: str) -> Optional[Tuple[float, float, float, float]]:
+    """
+    Bounding box (min_x, min_y, max_x, max_y) in mm of the board-level
+    Edge.Cuts graphics, or None if no outline geometry is found.
+
+    Arcs are approximated by their start/mid/end points and bezier curves
+    by their control hull; both can only be off by a fraction of the
+    plot margin, which is fine for anchoring diff exports.
+    """
+    points: List[Tuple[float, float]] = []
+    pos = 0
+    n = len(pcb_text)
+    while pos < n:
+        next_idx = None
+        token_hit = None
+        for token in _OUTLINE_TOKENS:
+            idx = pcb_text.find(token, pos)
+            if idx != -1 and (next_idx is None or idx < next_idx):
+                if _is_token_boundary(pcb_text, idx, token):
+                    next_idx = idx
+                    token_hit = token
+        if next_idx is None:
+            break
+
+        close_idx = _find_matching_paren(pcb_text, next_idx)
+        if close_idx is None:
+            break
+        block = pcb_text[next_idx:close_idx + 1]
+        pos = close_idx + 1
+
+        if not _EDGE_LAYER_RE.search(block):
+            continue
+
+        if token_hit == "(gr_circle":
+            center = _CENTER_RE.search(block)
+            end = _END_RE.search(block)
+            if center and end:
+                cx, cy = float(center.group(1)), float(center.group(2))
+                r = math.dist((cx, cy), (float(end.group(1)), float(end.group(2))))
+                points.extend([(cx - r, cy - r), (cx + r, cy + r)])
+            continue
+
+        for m in _COORD_RE.finditer(block):
+            points.append((float(m.group(1)), float(m.group(2))))
+
+    if not points:
+        return None
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    return (min(xs), min(ys), max(xs), max(ys))

--- a/backend/app/services/pcb_sexpr_service.py
+++ b/backend/app/services/pcb_sexpr_service.py
@@ -1,0 +1,109 @@
+"""
+Minimal s-expression surgery for .kicad_pcb files.
+
+Stdlib-only on purpose: keeps this importable from tests without pulling
+in the workspace/database stack.
+"""
+
+from typing import Optional
+
+# Tokens that hold a zone's computed fill geometry. kicad-cli plots the
+# stored fills without refilling, so removing these blocks yields
+# pour-free exports while the zone outlines (polygon ...) still plot.
+_FILL_TOKENS = ("(filled_polygon", "(filled_segments")
+
+
+def _find_matching_paren(text: str, open_idx: int) -> Optional[int]:
+    """
+    Return the index of the ')' matching the '(' at open_idx, or None if
+    unbalanced. Skips parens inside double-quoted strings (with backslash
+    escapes), which .kicad_pcb property values may contain.
+    """
+    depth = 0
+    i = open_idx
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            i += 1
+            while i < n:
+                if text[i] == '\\':
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    break
+                i += 1
+        elif ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+def _is_token_boundary(text: str, token_start: int, token: str) -> bool:
+    """True if the token name is not just a prefix of a longer name."""
+    end = token_start + len(token)
+    return end >= len(text) or not (text[end].isalnum() or text[end] == '_')
+
+
+def strip_zone_fills(pcb_text: str) -> str:
+    """
+    Remove all (filled_polygon ...) and (filled_segments ...) blocks.
+
+    These tokens only occur inside (zone ...) elements in the .kicad_pcb
+    format, so no enclosing-zone check is needed. Zones on any layer
+    (copper or otherwise) are stripped — the toggle means "hide all
+    pours". Unfilled zones keep their (polygon ...) outline.
+    """
+    out_parts = []
+    pos = 0
+    n = len(pcb_text)
+    while pos < n:
+        # Find the nearest fill token, skipping quoted strings so a token
+        # appearing inside a property value is left alone.
+        next_idx = None
+        i = pos
+        while i < n:
+            ch = pcb_text[i]
+            if ch == '"':
+                i += 1
+                while i < n:
+                    if pcb_text[i] == '\\':
+                        i += 2
+                        continue
+                    if pcb_text[i] == '"':
+                        break
+                    i += 1
+                i += 1
+                continue
+            if ch == '(':
+                for token in _FILL_TOKENS:
+                    if pcb_text.startswith(token, i) and _is_token_boundary(pcb_text, i, token):
+                        next_idx = i
+                        break
+                if next_idx is not None:
+                    break
+            i += 1
+
+        if next_idx is None:
+            out_parts.append(pcb_text[pos:])
+            break
+
+        close_idx = _find_matching_paren(pcb_text, next_idx)
+        if close_idx is None:
+            # Unbalanced file: bail out and keep the remainder untouched.
+            out_parts.append(pcb_text[pos:])
+            break
+
+        out_parts.append(pcb_text[pos:next_idx])
+        pos = close_idx + 1
+        # Drop trailing whitespace left behind on the line we removed from.
+        while pos < n and pcb_text[pos] in ' \t':
+            pos += 1
+        if pos < n and pcb_text[pos] == '\n':
+            pos += 1
+
+    return "".join(out_parts)

--- a/backend/tests/test_pcb_sexpr_service.py
+++ b/backend/tests/test_pcb_sexpr_service.py
@@ -1,0 +1,93 @@
+from app.services.pcb_sexpr_service import strip_zone_fills
+
+SAMPLE_PCB = '''(kicad_pcb
+  (version 20240108)
+  (footprint "Package_SO:SOIC-8"
+    (property "Value" "OPAMP (dual)")
+    (property "Note" "escaped \\" quote and ) paren")
+  )
+  (zone
+    (net 1)
+    (net_name "GND")
+    (layer "F.Cu")
+    (polygon
+      (pts (xy 0 0) (xy 10 0) (xy 10 10) (xy 0 10))
+    )
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 0.1 0.1) (xy 9.9 0.1) (xy 9.9 9.9) (xy 0.1 9.9))
+    )
+    (filled_polygon
+      (layer "F.Cu")
+      (pts (xy 1 1) (xy 2 1) (xy 2 2))
+    )
+  )
+  (zone
+    (net 2)
+    (layer "B.Cu")
+    (polygon
+      (pts (xy 0 0) (xy 5 0) (xy 5 5))
+    )
+    (filled_segments
+      (layer "B.Cu")
+      (pts (xy 0 0) (xy 1 1))
+    )
+  )
+)
+'''
+
+
+def _paren_balance(text: str) -> int:
+    """Count parens outside double-quoted strings."""
+    depth = 0
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == '"':
+            i += 1
+            while i < len(text):
+                if text[i] == '\\':
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    break
+                i += 1
+        elif ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+        i += 1
+    return depth
+
+
+def test_removes_all_fill_blocks():
+    result = strip_zone_fills(SAMPLE_PCB)
+    assert "filled_polygon" not in result
+    assert "filled_segments" not in result
+
+
+def test_preserves_balance_and_outlines():
+    result = strip_zone_fills(SAMPLE_PCB)
+    assert _paren_balance(result) == 0
+    # Zone outlines and zone count untouched
+    assert result.count("(zone") == 2
+    assert result.count("(polygon") == 2
+    # Quoted strings with parens/escapes survive intact
+    assert '"OPAMP (dual)"' in result
+    assert '"escaped \\" quote and ) paren"' in result
+
+
+def test_idempotent():
+    once = strip_zone_fills(SAMPLE_PCB)
+    assert strip_zone_fills(once) == once
+
+
+def test_no_zones_unchanged():
+    text = '(kicad_pcb (version 20240108) (footprint "R_0603" (property "Value" "10k")))\n'
+    assert strip_zone_fills(text) == text
+
+
+def test_unbalanced_input_returned_safely():
+    # Truncated file: stripper must not crash or drop the remainder
+    text = '(kicad_pcb (zone (filled_polygon (pts (xy 0 0)'
+    assert strip_zone_fills(text) == text

--- a/backend/tests/test_pcb_sexpr_service.py
+++ b/backend/tests/test_pcb_sexpr_service.py
@@ -1,4 +1,4 @@
-from app.services.pcb_sexpr_service import strip_zone_fills
+from app.services.pcb_sexpr_service import strip_zone_fills, edge_cuts_bbox
 
 SAMPLE_PCB = '''(kicad_pcb
   (version 20240108)
@@ -91,3 +91,41 @@ def test_unbalanced_input_returned_safely():
     # Truncated file: stripper must not crash or drop the remainder
     text = '(kicad_pcb (zone (filled_polygon (pts (xy 0 0)'
     assert strip_zone_fills(text) == text
+
+
+OUTLINE_PCB = '''(kicad_pcb
+  (gr_line (start 10 20) (end 110 20) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 110 20) (end 110 80) (layer "Edge.Cuts") (width 0.1))
+  (gr_arc (start 110 80) (mid 60 95) (end 10 80) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 10 80) (end 10 20) (layer "Edge.Cuts") (width 0.1))
+  (gr_line (start 0 0) (end 300 0) (layer "Dwgs.User") (width 0.1))
+  (segment (start -5 -5) (end 400 400) (layer "F.Cu"))
+)
+'''
+
+
+def test_edge_cuts_bbox_basic():
+    bbox = edge_cuts_bbox(OUTLINE_PCB)
+    assert bbox is not None
+    min_x, min_y, max_x, max_y = bbox
+    # Arc mid (60, 95) extends the bbox below the straight edges;
+    # non-Edge.Cuts geometry (Dwgs.User drawing, F.Cu segment) is ignored
+    assert (min_x, min_y) == (10.0, 20.0)
+    assert (max_x, max_y) == (110.0, 95.0)
+
+
+def test_edge_cuts_bbox_circle():
+    text = '(kicad_pcb (gr_circle (center 50 50) (end 70 50) (layer "Edge.Cuts")))'
+    assert edge_cuts_bbox(text) == (30.0, 30.0, 70.0, 70.0)
+
+
+def test_edge_cuts_bbox_none_without_outline():
+    text = '(kicad_pcb (gr_line (start 0 0) (end 10 10) (layer "F.SilkS")))'
+    assert edge_cuts_bbox(text) is None
+    assert edge_cuts_bbox("(kicad_pcb)") is None
+
+
+def test_edge_cuts_bbox_ignores_footprint_graphics():
+    # fp_line on Edge.Cuts would need the footprint transform; it is ignored
+    text = '(kicad_pcb (footprint "X" (at 100 100) (fp_line (start 0 0) (end 5 5) (layer "Edge.Cuts"))))'
+    assert edge_cuts_bbox(text) is None

--- a/frontend/src/components/visual-diff-viewer.tsx
+++ b/frontend/src/components/visual-diff-viewer.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from "react";
-import { X, Loader2, AlertCircle, Eye, ZoomIn, ZoomOut, RotateCcw, CircuitBoard, Cpu, ClipboardList } from "lucide-react";
+import { X, Loader2, AlertCircle, Eye, ZoomIn, ZoomOut, RotateCcw, CircuitBoard, Cpu, ClipboardList, ChevronDown, Layers } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuCheckboxItem } from "@/components/ui/dropdown-menu";
 import { Slider } from "@/components/ui/slider";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
@@ -28,6 +29,7 @@ interface DiffManifest {
     pcb: boolean;
     sheets: string[]; // filenames
     layers: string[]; // layer names like F.Cu
+    pours?: boolean; // pour-free PCB variant available under pcb_nopours/
     bom: {
         summary: { added: number; removed: number; changed: number };
         changes: Array<{
@@ -41,6 +43,17 @@ interface DiffManifest {
     } | null;
 }
 
+// Physical stacking order: copper at the bottom, decoration and board
+// outline on top, so multi-layer views read like the real board.
+const layerRank = (l: string) =>
+    l.endsWith(".Cu") ? 0
+    : l.endsWith(".Mask") ? 1
+    : l.endsWith(".Paste") ? 2
+    : l.endsWith(".SilkS") ? 3
+    : l.endsWith(".Fab") ? 4
+    : l === "Edge.Cuts" ? 6
+    : 5;
+
 export function VisualDiffViewer({ projectId, commit1, commit2, onClose }: VisualDiffViewerProps) {
     const [jobId, setJobId] = useState<string | null>(null);
     const [status, setStatus] = useState<DiffJobStatus | null>(null);
@@ -50,7 +63,8 @@ export function VisualDiffViewer({ projectId, commit1, commit2, onClose }: Visua
     // View State
     const [viewMode, setViewMode] = useState<"schematic" | "pcb" | "bom">("schematic");
     const [selectedSheet, setSelectedSheet] = useState<string>("");
-    const [selectedLayer, setSelectedLayer] = useState<string>("");
+    const [selectedLayers, setSelectedLayers] = useState<string[]>([]);
+    const [showPours, setShowPours] = useState(true);
     const [opacity, setOpacity] = useState([50]); // 0-100, 50 = mix
 
     // BoM Filtering
@@ -116,7 +130,7 @@ setManifest(mData);
 
 // Set defaults
 if (mData.sheets.length > 0) setSelectedSheet(mData.sheets[0]);
-if (mData.layers.length > 0) setSelectedLayer(mData.layers[0]);
+if (mData.layers.length > 0) setSelectedLayers([mData.layers[0]]);
 if (!mData.schematic && mData.pcb) setViewMode("pcb");
 }
 }
@@ -144,11 +158,11 @@ logsEndRef.current.scrollIntoView({ behavior: "smooth" });
 
 
 // Asset URLs
-const getAssetUrl = (commit: string, type: "sch" | "pcb", item: string) => {
+const getAssetUrl = (commit: string, type: "sch" | "pcb" | "pcb_nopours", item: string) => {
 if (!jobId) return "";
 // item is filename for sch, layer name for pcb
 let filename = item;
-if (type === "pcb") {
+if (type !== "sch") {
 filename = item.replace(/\./g, "_") + ".svg";
 }
 return `/api/projects/${projectId}/diff/${jobId}/assets/${commit}/${type}/${encodeURIComponent(filename)}`;
@@ -268,13 +282,31 @@ No entries match the selected filters
 }
 
 const isSch = viewMode === "schematic";
-const currentItem = isSch ? selectedSheet : selectedLayer;
 
-if (!currentItem) return <div className="flex items-center justify-center h-full text-muted-foreground">No assets found</div>;
+if (isSch && !selectedSheet) return <div className="flex items-center justify-center h-full text-muted-foreground">No assets found</div>;
+if (!isSch && selectedLayers.length === 0) return <div className="flex items-center justify-center h-full text-muted-foreground">No layers selected</div>;
 
+const oldImg = getAssetUrl(commit2, "sch", selectedSheet);
+const newImg = getAssetUrl(commit1, "sch", selectedSheet);
 
-const oldImg = getAssetUrl(commit2, isSch ? "sch" : "pcb", currentItem);
-const newImg = getAssetUrl(commit1, isSch ? "sch" : "pcb", currentItem);
+// PCB: stack the selected layers in physical order; the SVG exports have
+// transparent backgrounds, so per-commit groups composite cleanly.
+const pcbDir = manifest.pours && !showPours ? "pcb_nopours" : "pcb";
+const orderedLayers = [...selectedLayers].sort((a, b) => layerRank(a) - layerRank(b));
+// Slight per-layer darkening so simultaneous layers are distinguishable
+// while keeping the red/green old/new semantics.
+const layerFilter = (idx: number) => `brightness(${Math.max(0.5, 1 - idx * 0.12)})`;
+const renderLayerStack = (commit: string) =>
+    orderedLayers.map((l, idx) => (
+        <img
+            key={`${l}-${pcbDir}-${commit}`}
+            src={getAssetUrl(commit, pcbDir, l)}
+            className="absolute inset-0 w-full h-full object-contain pointer-events-none"
+            style={{ filter: layerFilter(idx) }}
+            onError={e => { e.currentTarget.style.visibility = "hidden"; }}
+            alt={l}
+        />
+    ));
 
 return (
 <TransformWrapper
@@ -300,6 +332,8 @@ centerOnInit
 
 <TransformComponent wrapperClass="!w-full !h-full" contentClass="!w-full !h-full flex items-center justify-center">
 <div className="relative shadow-2xl border bg-white" style={{ minWidth: "1200px", minHeight: "800px" }}>
+{isSch ? (
+<>
 {/* Old Commit (Bottom) */}
 <img
 src={oldImg}
@@ -314,6 +348,24 @@ className="absolute inset-0 w-full h-full object-contain bg-white transition-opa
 style={{ opacity: opacity[0] / 100 }}
 alt="New Version"
 />
+</>
+) : (
+<>
+{/* Old Commit layers (Bottom) */}
+<div className="absolute inset-0">
+{renderLayerStack(commit2)}
+</div>
+
+{/* New Commit layers (Top) - one white backdrop on the group so the
+    cross-fade covers the old group without occluding stacked layers */}
+<div
+className="absolute inset-0 bg-white transition-opacity duration-150"
+style={{ opacity: opacity[0] / 100 }}
+>
+{renderLayerStack(commit1)}
+</div>
+</>
+)}
 </div>
 </TransformComponent>
 </>
@@ -383,16 +435,48 @@ disabled={!manifest.bom}
 </SelectContent>
 </Select>
 ) : viewMode === "pcb" ? (
-<Select value={selectedLayer} onValueChange={setSelectedLayer}>
-<SelectTrigger className="h-8">
-<SelectValue placeholder="Select Layer" />
-</SelectTrigger>
-<SelectContent>
-{manifest.layers.map(l => <SelectItem key={l} value={l}>{l}</SelectItem>)}
-</SelectContent>
-</Select>
+<DropdownMenu>
+<DropdownMenuTrigger asChild>
+<Button variant="outline" size="sm" className="h-8 w-full justify-between font-normal">
+{selectedLayers.length === 0
+? "Select Layers"
+: selectedLayers.length === 1
+? selectedLayers[0]
+: `${selectedLayers.length} layers`}
+<ChevronDown className="h-4 w-4 opacity-50" />
+</Button>
+</DropdownMenuTrigger>
+<DropdownMenuContent className="w-64 max-h-80 overflow-y-auto">
+{manifest.layers.map(l => (
+<DropdownMenuCheckboxItem
+key={l}
+checked={selectedLayers.includes(l)}
+onCheckedChange={(checked) =>
+setSelectedLayers(prev => checked ? [...prev, l] : prev.filter(x => x !== l))
+}
+onSelect={e => e.preventDefault()}
+>
+{l}
+</DropdownMenuCheckboxItem>
+))}
+</DropdownMenuContent>
+</DropdownMenu>
 ) : null}
 </div>
+
+{/* Pour Toggle */}
+{viewMode === "pcb" && (
+<Button
+variant={showPours ? "secondary" : "outline"}
+size="sm"
+className="h-8"
+disabled={!manifest.pours}
+title={manifest.pours ? "Toggle copper pours" : "Pour-free export unavailable"}
+onClick={() => setShowPours(p => !p)}
+>
+<Layers className="h-4 w-4 mr-2" /> Pours
+</Button>
+)}
 
 <div className="flex-1" />
 


### PR DESCRIPTION
## What

Two additions to the PCB visual diff viewer:

1. **Multi-layer view** — the layer dropdown is now a multi-select (checkbox items, menu stays open while toggling). Selected layers render stacked in physical order (copper → mask → paste → silk → fab → Edge.Cuts on top), with a small per-layer brightness step so simultaneous layers remain distinguishable while keeping the red=old / green=new diff semantics. The existing Old/New cross-fade slider now applies to each commit's layer group as a whole (the white backdrop moved from the single image to the new-commit group, since the SVG exports are transparent).

2. **Copper pour toggle** — a new *Pours* button hides zone fills. `kicad-cli pcb export svg` has no flag to exclude zone fills, but it plots the fills stored in the file without refilling, so the backend exports a second variant of each snapshot with `(filled_polygon ...)` / `(filled_segments ...)` blocks stripped (new `pcb_sexpr_service.strip_zone_fills()`, a balanced-paren scanner that skips quoted strings). The variant lands in `{commit}/pcb_nopours/` and is advertised via a new `pours` manifest flag; the asset route already serves arbitrary subpaths, so no API changes. A variant failure is logged and never breaks the main diff.

## Also in this change

- The export/normalize/colorize block in `diff_service.py` is extracted into `_export_pcb_svgs()` so it runs for both variants without duplication.
- Manifest now defaults `layers`/`sheets` to `[]` — previously a failed PCB export left them undefined and crashed the viewer on `manifest.layers.length`.
- `manifest.layers` is now the union across both commits (mirroring the existing sheet union), so layers added or removed between commits still appear; the viewer hides one-sided 404s via `img onError`.
- Old jobs without the variant keep working: the Pours button is disabled when `pours` is absent/false.

## Testing

- New unit tests for the stripper: `backend/tests/test_pcb_sexpr_service.py` (removal, paren balance, quoted-string safety, idempotency, truncated input). Full backend suite passes (30 tests).
- `tsc -b` clean.
- Verified against KiCad 10 in the Docker image: stripped boards export pour-free (copper SVGs shrink ~3x), fills are not regenerated, and viewBoxes are identical across layers and variants so the stacked overlay aligns.
- Manual: multi-layer stacking, cross-fade, pour toggle, empty selection, and schematic view exercised in the browser.