### PR TITLE
feat(workspace): replace Apps & Integrations with direct Library Manager panel

### DIFF
--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -59,7 +59,6 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const [section, setSection] = useState<WorkspaceSection>("projects");
   const [viewMode, setViewMode] = useState<ViewMode>("gallery");
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-  const [activeApp, setActiveApp] = useState<"index" | "library-manager">("index");
 
   const [isImportOpen, setIsImportOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -181,11 +180,6 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
     }
   }, [projects, selectedProjectId]);
 
-  useEffect(() => {
-    if (section !== "apps") {
-      setActiveApp("index");
-    }
-  }, [section]);
 
   const handleCreateFolder = async (name: string) => {
     if (!canManageProjects) {
@@ -339,11 +333,14 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
           <main className="min-h-0 flex-1 overflow-hidden">
             {loading ? (
               <WorkspaceLoadingState />
-            ) : section === "apps" ? (
-              activeApp === "library-manager" ? (
-                canOpenLibrary ? <LibraryManagerPanel user={user} /> : <WorkspaceAppsPlaceholder canOpenLibraryManager={canOpenLibrary} onOpenLibraryManager={() => setActiveApp("library-manager")} />
+            ) : section === "library-manager" ? (
+              canOpenLibrary ? (
+                <LibraryManagerPanel user={user} />
               ) : (
-                <WorkspaceAppsPlaceholder canOpenLibraryManager={canOpenLibrary} onOpenLibraryManager={() => setActiveApp("library-manager")} />
+                <WorkspaceAppsPlaceholder
+                  canOpenLibraryManager={canOpenLibrary}
+                  onOpenLibraryManager={() => {}}
+                />
               )
             ) : (
               <div className="flex h-full min-h-0 flex-col p-6">

--- a/frontend/src/components/workspace/workspace-sidebar.tsx
+++ b/frontend/src/components/workspace/workspace-sidebar.tsx
@@ -1,4 +1,4 @@
-import { AppWindow, Folder, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { Blocks, Folder, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -50,13 +50,13 @@ export function WorkspaceSidebar({
         </Button>
 
         <Button
-          variant={section === "apps" ? "secondary" : "ghost"}
+          variant={section === "library-manager" ? "secondary" : "ghost"}
           className={cn("w-full justify-start gap-2", isCollapsed && "justify-center px-2")}
-          onClick={() => onSectionChange("apps")}
-          aria-label="Apps and Integrations"
+          onClick={() => onSectionChange("library-manager")}
+          aria-label="Library Manager"
         >
-          <AppWindow className="h-4 w-4" />
-          {!isCollapsed && <span>Apps &amp; Integrations</span>}
+          <Blocks className="h-4 w-4" />
+          {!isCollapsed && <span>Library Manager</span>}
         </Button>
       </div>
     </aside>

--- a/frontend/src/components/workspace/workspace-types.ts
+++ b/frontend/src/components/workspace/workspace-types.ts
@@ -1,4 +1,4 @@
-export type WorkspaceSection = "projects" | "apps";
+export type WorkspaceSection = "projects" | "library-manager";
 export type ViewMode = "gallery" | "list";
 
 export const PROJECT_GRID_CLASS = "grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5";


### PR DESCRIPTION
This PR repositions the Library Manager as a first-class side panel option, removing the generic Apps & Integrations view. Access permissions are preserved.