### PR TITLE
feat: auto-generate PCB thumbnails on import/sync with kicad-cli render

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -635,6 +635,22 @@ async def get_project_thumbnail(project_id: str, user: AuthenticatedUser = Depen
         raise HTTPException(status_code=404, detail="Thumbnail not found")
     return FileResponse(path, headers={"Cache-Control": "public, max-age=300"})
 
+@router.post("/{project_id}/thumbnail/regenerate", dependencies=[Depends(require_designer)])
+async def regenerate_project_thumbnail(project_id: str, user: AuthenticatedUser = Depends(require_designer)):
+    project = get_project_for_role_or_404(project_id, user.role)
+    
+    logs = []
+    success = project_import_service.generate_thumbnail_for_project(project.path, logs)
+    
+    if not success:
+        error_msg = logs[-1] if logs else "Failed to render PCB"
+        raise HTTPException(status_code=500, detail=f"Failed to generate thumbnail: {error_msg}")
+        
+    cached = project_import_service.resolve_cached_paths(project.path)
+    workspace.update_project(project_id, **cached)
+    
+    return {"status": "success", "message": "Thumbnail regenerated successfully"}
+
 @router.get("/{project_id}", response_model=project_service.Project)
 async def get_project_detail(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     """Get detailed project information."""

--- a/backend/app/services/project_import_service.py
+++ b/backend/app/services/project_import_service.py
@@ -4,6 +4,7 @@ Project Import Service for KiCAD Prism
 Handles Type-1 (single project) and Type-2 (multiple projects) imports.
 """
 import os
+import subprocess
 import shutil
 import tempfile
 import uuid
@@ -285,7 +286,7 @@ def cleanup_analysis_temp(analysis: AnalysisResult):
         shutil.rmtree(analysis.temp_path, ignore_errors=True)
 
 
-def _resolve_cached_paths(project_path: str) -> dict:
+def resolve_cached_paths(project_path: str) -> dict:
     """Resolve and return cached path info for a project directory."""
     try:
         resolved = path_config_service.resolve_paths(project_path)
@@ -336,6 +337,83 @@ def _resolve_cached_paths(project_path: str) -> dict:
         }
     except Exception:
         return {}
+
+
+def generate_thumbnail_for_project(project_path: str, logs_list: Optional[List[str]] = None) -> bool:
+    """
+    Find the main .kicad_pcb file and run kicad-cli pcb render to generate a thumbnail.
+    """
+    try:
+        resolved = path_config_service.resolve_paths(project_path)
+        pcb_file = resolved.pcb
+        if not pcb_file or not os.path.exists(pcb_file):
+            if logs_list is not None:
+                logs_list.append(f"No .kicad_pcb file found to generate thumbnail for {project_path}")
+            return False
+        
+        # Check standard paths for kicad-cli
+        cli_path = "kicad-cli"
+        # Check environment variable
+        for var in ("KICAD_CLI_PATH", "KICAD_CLI"):
+            val = os.environ.get(var, "").strip()
+            if val and os.path.exists(val):
+                cli_path = val
+                break
+        else:
+            # Check standard Mac path
+            mac_path = "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+            if os.path.exists(mac_path):
+                cli_path = mac_path
+            else:
+                # Check PATH
+                which_cli = shutil.which("kicad-cli")
+                if which_cli:
+                    cli_path = which_cli
+
+        if logs_list is not None:
+            logs_list.append(f"Generating thumbnail using {cli_path} for PCB: {pcb_file}")
+
+        # Create assets/thumbnail directory
+        thumbnail_dir = Path(project_path) / "assets" / "thumbnail"
+        thumbnail_dir.mkdir(parents=True, exist_ok=True)
+        output_path = thumbnail_dir / "thumbnail.png"
+        
+        cmd = [
+            cli_path,
+            "pcb",
+            "render",
+            "--quality", "high",
+            "--floor",
+            "--perspective",
+            "--rotate", "-45,0,45",
+            "--width", "800",
+            "--height", "600",
+            "-o", str(output_path),
+            pcb_file
+        ]
+        
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False
+        )
+        
+        if result.returncode != 0:
+            if logs_list is not None:
+                logs_list.append(f"kicad-cli render failed (code {result.returncode}): {result.stderr[:400]}")
+            return False
+            
+        if logs_list is not None:
+            logs_list.append(f"Successfully generated thumbnail at {output_path}")
+        return True
+        
+    except Exception as e:
+        if logs_list is not None:
+            logs_list.append(f"Exception during thumbnail generation: {e}")
+        return False
+
 
 
 def _run_import_job(job_id: str, repo_url: str, import_type: str, 
@@ -411,7 +489,9 @@ def _run_import_job(job_id: str, repo_url: str, import_type: str,
         imported_ids = []
         
         if import_type == "type1":
-            cached = _resolve_cached_paths(str(target_path))
+            # Generate thumbnail before resolving paths
+            generate_thumbnail_for_project(str(target_path), job['logs'])
+            cached = resolve_cached_paths(str(target_path))
             project_id = workspace.register_project(
                 repo_id=repo_id,
                 name=repo_name,
@@ -432,9 +512,11 @@ def _run_import_job(job_id: str, repo_url: str, import_type: str,
             
             for rel_path in selected_paths:
                 full_project_path = target_path / rel_path
+                # Generate thumbnail before resolving paths
+                generate_thumbnail_for_project(str(full_project_path), job['logs'])
                 pro_files = list(full_project_path.glob("*.kicad_pro"))
                 board_name = pro_files[0].stem if pro_files else os.path.basename(rel_path)
-                cached = _resolve_cached_paths(str(full_project_path))
+                cached = resolve_cached_paths(str(full_project_path))
                 project_id = workspace.register_project(
                     repo_id=repo_id,
                     name=board_name,
@@ -591,7 +673,9 @@ def sync_project(project_id: str) -> dict:
         path_config_service.clear_config_cache()
         project_path = row.get('path', '')
         if project_path and os.path.isdir(project_path):
-            cached = _resolve_cached_paths(project_path)
+            # Generate/refresh thumbnail on sync
+            generate_thumbnail_for_project(project_path)
+            cached = resolve_cached_paths(project_path)
             workspace.update_project(project_id, **cached)
 
         # Update repo last_synced_at

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { useWorkspaceData } from "@/hooks/use-workspace-data";
 import { useWorkspaceSearch } from "@/hooks/use-workspace-search";
 import { canManageProjects as roleCanManageProjects, canOpenLibraryManager } from "@/lib/roles";
+import { fetchApi, readApiError } from "@/lib/api";
 import { WorkspaceBreadcrumbs } from "./workspace/workspace-breadcrumbs";
 import { WorkspaceGalleryView } from "./workspace/workspace-gallery-view";
 import { WorkspaceListView } from "./workspace/workspace-list-view";
@@ -289,6 +290,32 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
     }
   };
 
+  const handleRegenerateThumbnail = async (project: Project) => {
+    if (!canManageProjects) {
+      toast.error("You do not have permission to regenerate thumbnails");
+      return;
+    }
+
+    const toastId = toast.loading(`Regenerating thumbnail for "${getProjectDisplayName(project)}"...`);
+    try {
+      const response = await fetchApi(`/api/projects/${project.id}/thumbnail/regenerate`, {
+        method: "POST",
+      });
+
+      if (!response.ok) {
+        const error = await readApiError(response, "Failed to regenerate thumbnail");
+        toast.error(error, { id: toastId });
+        return;
+      }
+
+      toast.success("Thumbnail regenerated successfully", { id: toastId });
+      // Refresh the workspace to reload the updated thumbnail
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to regenerate thumbnail", { id: toastId });
+    }
+  };
+
   if (error) {
     return <div className="flex h-64 items-center justify-center rounded-xl border text-destructive">{error}</div>;
   }
@@ -414,6 +441,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                         onDeleteFolder={setFolderToDelete}
                         onMoveProject={setProjectToMove}
                         onDeleteProject={setProjectToDelete}
+                        onRegenerateThumbnail={handleRegenerateThumbnail}
                         canManageProjects={canManageProjects}
                       />
                     ) : (
@@ -432,6 +460,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                         onDeleteFolder={setFolderToDelete}
                         onMoveProject={setProjectToMove}
                         onDeleteProject={setProjectToDelete}
+                        onRegenerateThumbnail={handleRegenerateThumbnail}
                         canManageProjects={canManageProjects}
                       />
                     )}

--- a/frontend/src/components/workspace/workspace-action-menus.tsx
+++ b/frontend/src/components/workspace/workspace-action-menus.tsx
@@ -1,4 +1,4 @@
-import { Folder, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Folder, MoreHorizontal, Pencil, Trash2, Image } from "lucide-react";
 
 import { FolderTreeItem, Project } from "@/types/project";
 import { Button } from "@/components/ui/button";
@@ -23,6 +23,7 @@ interface ProjectActionMenuProps {
   projectName: string;
   onMove: (project: Project) => void;
   onDelete: (project: Project) => void;
+  onRegenerateThumbnail?: (project: Project) => void;
   canManage: boolean;
 }
 
@@ -72,7 +73,7 @@ export function FolderActionMenu({ folder, onRename, onDelete, canManage }: Fold
   );
 }
 
-export function ProjectActionMenu({ project, projectName, onMove, onDelete, canManage }: ProjectActionMenuProps) {
+export function ProjectActionMenu({ project, projectName, onMove, onDelete, onRegenerateThumbnail, canManage }: ProjectActionMenuProps) {
   if (!canManage) {
     return null;
   }
@@ -101,6 +102,15 @@ export function ProjectActionMenu({ project, projectName, onMove, onDelete, canM
         >
           <Folder className="h-4 w-4" />
           Move to Folder
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={(event) => {
+            event.stopPropagation();
+            onRegenerateThumbnail?.(project);
+          }}
+        >
+          <Image className="h-4 w-4" />
+          Regenerate Thumbnail
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/frontend/src/components/workspace/workspace-gallery-view.tsx
+++ b/frontend/src/components/workspace/workspace-gallery-view.tsx
@@ -22,6 +22,7 @@ interface WorkspaceGalleryViewProps {
   onDeleteFolder: (folder: FolderTreeItem) => void;
   onMoveProject: (project: Project) => void;
   onDeleteProject: (project: Project) => void;
+  onRegenerateThumbnail: (project: Project) => void;
   canManageProjects: boolean;
 }
 
@@ -41,6 +42,7 @@ export function WorkspaceGalleryView({
   onDeleteFolder,
   onMoveProject,
   onDeleteProject,
+  onRegenerateThumbnail,
   canManageProjects,
 }: WorkspaceGalleryViewProps) {
   return (
@@ -68,6 +70,7 @@ export function WorkspaceGalleryView({
                       projectName={getProjectDisplayName(project)}
                       onMove={onMoveProject}
                       onDelete={onDeleteProject}
+                      onRegenerateThumbnail={onRegenerateThumbnail}
                       canManage={canManageProjects}
                     />
                   }
@@ -143,6 +146,7 @@ export function WorkspaceGalleryView({
                         projectName={getProjectDisplayName(project)}
                         onMove={onMoveProject}
                         onDelete={onDeleteProject}
+                        onRegenerateThumbnail={onRegenerateThumbnail}
                         canManage={canManageProjects}
                       />
                     }

--- a/frontend/src/components/workspace/workspace-list-view.tsx
+++ b/frontend/src/components/workspace/workspace-list-view.tsx
@@ -20,6 +20,7 @@ interface WorkspaceListViewProps {
   onDeleteFolder: (folder: FolderTreeItem) => void;
   onMoveProject: (project: Project) => void;
   onDeleteProject: (project: Project) => void;
+  onRegenerateThumbnail: (project: Project) => void;
   canManageProjects: boolean;
 }
 
@@ -55,6 +56,7 @@ export function WorkspaceListView({
   onDeleteFolder,
   onMoveProject,
   onDeleteProject,
+  onRegenerateThumbnail,
   canManageProjects,
 }: WorkspaceListViewProps) {
   return (
@@ -128,6 +130,7 @@ export function WorkspaceListView({
                   projectName={getProjectDisplayName(project)}
                   onMove={onMoveProject}
                   onDelete={onDeleteProject}
+                  onRegenerateThumbnail={onRegenerateThumbnail}
                   canManage={canManageProjects}
                 />
               </div>


### PR DESCRIPTION
- Add generate_thumbnail_for_project() to project_import_service Uses kicad-cli pcb render with isometric view, high quality raytracing, perspective projection, floor shadows, and post-processing
- Automatically generate thumbnails during Type-1 and Type-2 project imports
- Regenerate thumbnails on project sync (git pull)
- Add POST /api/projects/{id}/thumbnail/regenerate endpoint
- Add 'Regenerate Thumbnail' option to project card dropdown menu
- Output stored at assets/thumbnail/thumbnail.png inside the project repo