### PR TITLE
Add user-scoped branch viewing

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -25,6 +25,7 @@ from app.services import (
 from app.services.workspace_service import workspace
 from app.services.comments_url_service import build_comments_source_urls, resolve_comments_base_url
 from app.services.git_service import (
+    get_branches,
     get_commit_distance,
     get_commits_list,
     get_commits_list_filtered,
@@ -619,6 +620,17 @@ async def trigger_workflow(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
+@router.get("/{project_id}/branches")
+async def get_project_branches(
+    project_id: str,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
+    """List branch refs that can be viewed without switching the working checkout."""
+    project = get_project_for_role_or_404(project_id, user.role)
+    repo_path, relative_path = _repo_context(project)
+    return await asyncio.to_thread(get_branches, repo_path, relative_path)
+
 @router.get("/{project_id}/thumbnail")
 async def get_project_thumbnail(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
     project = get_project_for_role_or_404(project_id, user.role)
@@ -961,7 +973,11 @@ async def get_doc_file_content(
     }
 
 @router.get("/{project_id}/releases")
-async def get_project_releases(project_id: str, user: AuthenticatedUser = Depends(require_viewer)):
+async def get_project_releases(
+    project_id: str,
+    ref: Optional[str] = None,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
     """
     Get list of Git releases/tags for a project.
     For Type-2 projects, uses parent repo with subproject file tracking.
@@ -970,9 +986,9 @@ async def get_project_releases(project_id: str, user: AuthenticatedUser = Depend
     
     repo_path, relative_path = _repo_context(project)
     if relative_path:
-        releases = get_releases_filtered(repo_path, relative_path)
+        releases = get_releases_filtered(repo_path, relative_path, ref)
     else:
-        releases = get_releases(project.path)
+        releases = get_releases(project.path, ref)
     
     return {"releases": releases}
 
@@ -980,6 +996,7 @@ async def get_project_releases(project_id: str, user: AuthenticatedUser = Depend
 async def get_project_commit_distance(
     project_id: str,
     commit: str,
+    ref: Optional[str] = None,
     user: AuthenticatedUser = Depends(require_viewer),
 ):
     """
@@ -989,13 +1006,14 @@ async def get_project_commit_distance(
     project = get_project_for_role_or_404(project_id, user.role)
 
     repo_path, relative_path = _repo_context(project)
-    commits_behind = get_commit_distance(repo_path, commit, relative_path)
+    commits_behind = get_commit_distance(repo_path, commit, relative_path, ref)
     return {"commits_behind": commits_behind}
 
 @router.get("/{project_id}/commits")
 async def get_project_commits(
     project_id: str,
     limit: int = Query(default=50, ge=1, le=500),
+    ref: Optional[str] = None,
     user: AuthenticatedUser = Depends(require_viewer),
 ):
     """
@@ -1006,9 +1024,9 @@ async def get_project_commits(
     
     repo_path, relative_path = _repo_context(project)
     if relative_path:
-        commits = get_commits_list_filtered(repo_path, relative_path, limit)
+        commits = get_commits_list_filtered(repo_path, relative_path, limit, ref)
     else:
-        commits = get_commits_list(project.path, limit)
+        commits = get_commits_list(project.path, limit, ref)
     
     return {"commits": commits}
 

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -27,24 +27,48 @@ def _serialize_commit(commit) -> Dict[str, str]:
     }
 
 
-def _get_commits(repo_path: str, limit: int, relative_path: str = None):
+def _commit_has_path(commit, relative_path: str | None) -> bool:
+    if not relative_path:
+        return True
+    try:
+        commit.tree / relative_path
+        return True
+    except Exception:
+        return False
+
+
+def _resolve_commit(repo: Repo, ref: str | None):
+    try:
+        return repo.commit(ref or "HEAD")
+    except BadName as error:
+        raise HTTPException(status_code=404, detail=f"Git ref not found: {ref}") from error
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
+
+
+def _get_commits(repo_path: str, limit: int, relative_path: str = None, ref: str = None):
     repo = _open_repo(repo_path)
     iter_kwargs = {"max_count": limit}
+    if ref:
+        _resolve_commit(repo, ref)
+        iter_kwargs["rev"] = ref
     if relative_path:
         iter_kwargs["paths"] = relative_path
 
     try:
         return [_serialize_commit(commit) for commit in repo.iter_commits(**iter_kwargs)]
+    except HTTPException:
+        raise
     except Exception as error:
         raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
 
 
-def get_commits_list_filtered(repo_path: str, relative_path: str = None, limit: int = 50):
+def get_commits_list_filtered(repo_path: str, relative_path: str = None, limit: int = 50, ref: str = None):
     """
     Get list of commits from repository, optionally filtered to a subdirectory.
     For Type-2 projects, relative_path scopes commits to the subproject.
     """
-    return _get_commits(repo_path, limit, relative_path)
+    return _get_commits(repo_path, limit, relative_path, ref)
 
 
 def _count_tree_entries(commit, relative_path: str) -> int | None:
@@ -68,12 +92,23 @@ def _commit_touches_path(repo: Repo, commit, relative_path: str) -> bool:
         return False
 
 
-def _get_releases(repo_path: str, relative_path: str = None):
+def _is_ancestor(repo: Repo, ancestor: str, descendant: str) -> bool:
+    try:
+        repo.git.merge_base("--is-ancestor", ancestor, descendant)
+        return True
+    except GitCommandError:
+        return False
+
+
+def _get_releases(repo_path: str, relative_path: str = None, ref: str = None):
     repo = _open_repo(repo_path)
     releases = []
     try:
+        resolved_ref = _resolve_commit(repo, ref).hexsha if ref else None
         for tag in repo.tags:
             commit = tag.commit
+            if resolved_ref and not _is_ancestor(repo, commit.hexsha, resolved_ref):
+                continue
             if relative_path and not _commit_touches_path(repo, commit, relative_path):
                 continue
             release = {
@@ -88,16 +123,18 @@ def _get_releases(repo_path: str, relative_path: str = None):
 
         releases.sort(key=lambda item: item["date"], reverse=True)
         return releases
+    except HTTPException:
+        raise
     except Exception as error:
         raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
 
 
-def get_releases_filtered(repo_path: str, relative_path: str = None):
+def get_releases_filtered(repo_path: str, relative_path: str = None, ref: str = None):
     """
     Get list of Git tags/releases from repository.
     For Type-2 projects, shows file count under relative_path for each tag.
     """
-    return _get_releases(repo_path, relative_path)
+    return _get_releases(repo_path, relative_path, ref)
 
 
 def get_file_from_commit_with_prefix(repo_path: str, commit_hash: str, file_path: str, relative_prefix: str = None) -> str:
@@ -147,20 +184,20 @@ def file_exists_in_commit_with_prefix(repo_path: str, commit_hash: str, file_pat
     except:
         return False
 
-def get_releases(repo_path: str):
+def get_releases(repo_path: str, ref: str = None):
     """
     Get list of Git tags/releases from repository.
     """
-    return _get_releases(repo_path)
+    return _get_releases(repo_path, ref=ref)
 
-def get_commits_list(repo_path: str, limit: int = 50):
+def get_commits_list(repo_path: str, limit: int = 50, ref: str = None):
     """
     Get list of commits from repository.
     """
-    return _get_commits(repo_path, limit)
+    return _get_commits(repo_path, limit, ref=ref)
 
 
-def get_commit_distance(repo_path: str, commit_hash: str, relative_path: str = None) -> int:
+def get_commit_distance(repo_path: str, commit_hash: str, relative_path: str = None, ref: str = None) -> int:
     """
     Count commits between the requested commit and HEAD.
     When relative_path is provided, only count commits that affect that path.
@@ -168,8 +205,10 @@ def get_commit_distance(repo_path: str, commit_hash: str, relative_path: str = N
     try:
         repo = _open_repo(repo_path)
         repo.commit(commit_hash)
+        target_ref = ref or "HEAD"
+        repo.commit(target_ref)
 
-        rev_list_args = ["--count", f"{commit_hash}..HEAD"]
+        rev_list_args = ["--count", f"{commit_hash}..{target_ref}"]
         if relative_path:
             rev_list_args.extend(["--", relative_path])
 
@@ -183,6 +222,76 @@ def get_commit_distance(repo_path: str, commit_hash: str, relative_path: str = N
         raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
     except Exception as error:
         raise HTTPException(status_code=500, detail=f"Git error: {str(error)}") from error
+
+
+def get_branches(repo_path: str, relative_path: str = None) -> dict[str, Any]:
+    """
+    Return local and remote branch refs without changing the working tree.
+    For Type-2 projects, branches that do not contain the subproject path are omitted.
+    """
+    repo = _open_repo(repo_path)
+    branches: list[dict[str, Any]] = []
+    seen_refs: set[str] = set()
+
+    try:
+        active_branch = repo.active_branch.name if not repo.head.is_detached else None
+    except (TypeError, ValueError):
+        active_branch = None
+
+    def add_branch(*, name: str, ref: str, source: str, is_current: bool = False) -> None:
+        if ref in seen_refs:
+            return
+        commit = _resolve_commit(repo, ref)
+        if not _commit_has_path(commit, relative_path):
+            return
+        seen_refs.add(ref)
+        branches.append(
+            {
+                "name": name,
+                "ref": ref,
+                "source": source,
+                "is_current": is_current,
+                "hash": commit.hexsha[:7],
+                "commit": commit.hexsha,
+                "author": commit.author.name,
+                "email": commit.author.email,
+                "date": datetime.datetime.fromtimestamp(commit.committed_date).isoformat(),
+                "message": commit.message.strip(),
+            }
+        )
+
+    for branch in repo.heads:
+        add_branch(
+            name=branch.name,
+            ref=branch.name,
+            source="local",
+            is_current=branch.name == active_branch,
+        )
+
+    for remote in repo.remotes:
+        for remote_ref in remote.refs:
+            if remote_ref.remote_head == "HEAD":
+                continue
+            add_branch(
+                name=remote_ref.remote_head,
+                ref=remote_ref.name,
+                source="remote",
+            )
+
+    branches.sort(
+        key=lambda item: (
+            0 if item["is_current"] else 1,
+            0 if item["source"] == "local" else 1,
+            item["name"].casefold(),
+            item["ref"].casefold(),
+        )
+    )
+    default_branch = next((item for item in branches if item["is_current"]), None) or (branches[0] if branches else None)
+    return {
+        "branches": branches,
+        "current_branch": active_branch,
+        "default_ref": default_branch["ref"] if default_branch else None,
+    }
 
 def get_file_from_commit(repo_path: str, commit_hash: str, file_path: str) -> str:
     """

--- a/backend/tests/test_git_branch_viewing.py
+++ b/backend/tests/test_git_branch_viewing.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from git import Actor, Repo
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services import git_service  # noqa: E402
+
+
+AUTHOR = Actor("Prism Test", "prism@example.com")
+
+
+def _commit_all(repo: Repo, message: str):
+    repo.git.add(A=True)
+    return repo.index.commit(message, author=AUTHOR, committer=AUTHOR)
+
+
+class GitBranchViewingTests(unittest.TestCase):
+    def test_lists_only_branches_containing_the_subproject_without_switching_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = Repo.init(root)
+            (root / "README.md").write_text("root", encoding="utf-8")
+            initial = _commit_all(repo, "initial")
+            repo.create_head("without-project", initial)
+
+            project_file = root / "boards" / "demo" / "README.md"
+            project_file.parent.mkdir(parents=True)
+            project_file.write_text("project", encoding="utf-8")
+            project_commit = _commit_all(repo, "add project")
+            repo.create_head("feature/project", project_commit)
+
+            original_head = repo.head.commit.hexsha
+            branches = git_service.get_branches(str(root), "boards/demo")
+
+            self.assertEqual(repo.head.commit.hexsha, original_head)
+            self.assertEqual(
+                {branch["ref"] for branch in branches["branches"]},
+                {repo.active_branch.name, "feature/project"},
+            )
+            self.assertEqual(branches["default_ref"], repo.active_branch.name)
+
+    def test_lists_fetched_remote_branches(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_path = root / "source"
+            source = Repo.init(source_path)
+            (source_path / "README.md").write_text("initial", encoding="utf-8")
+            initial = _commit_all(source, "initial")
+            source.create_head("remote-feature", initial)
+
+            remote_path = root / "remote.git"
+            source.clone(str(remote_path), bare=True)
+            checkout_path = root / "checkout"
+            checkout = Repo.clone_from(str(remote_path), checkout_path)
+            checkout.remotes.origin.fetch()
+
+            branches = git_service.get_branches(str(checkout_path))
+
+            self.assertIn("origin/remote-feature", {branch["ref"] for branch in branches["branches"]})
+
+    def test_scopes_history_and_distance_to_the_selected_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = Repo.init(root)
+            (root / "README.md").write_text("initial", encoding="utf-8")
+            initial = _commit_all(repo, "initial")
+            repo.create_head("feature/project", initial)
+            repo.git.checkout("feature/project")
+            (root / "README.md").write_text("feature", encoding="utf-8")
+            feature_commit = _commit_all(repo, "feature work")
+            repo.git.checkout(repo.heads[0].name)
+
+            commits = git_service.get_commits_list(str(root), ref="feature/project")
+
+            self.assertEqual(commits[0]["full_hash"], feature_commit.hexsha)
+            self.assertEqual(
+                git_service.get_commit_distance(str(root), initial.hexsha, ref="feature/project"),
+                1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -31,6 +31,7 @@ interface CommitsResponse {
 
 interface HistoryViewerProps {
     projectId: string;
+    branchRef?: string | null;
     onViewCommit: (commitHash: string) => void;
     canCompareDiffs: boolean;
 }
@@ -134,7 +135,7 @@ function CommitItem({ commit, onViewCommit, isSelected, onSelect, selectable }: 
     );
 }
 
-export function HistoryViewer({ projectId, onViewCommit, canCompareDiffs }: HistoryViewerProps) {
+export function HistoryViewer({ projectId, branchRef, onViewCommit, canCompareDiffs }: HistoryViewerProps) {
     const [releases, setReleases] = useState<Release[]>([]);
     const [commits, setCommits] = useState<Commit[]>([]);
     const [loading, setLoading] = useState(true);
@@ -196,14 +197,15 @@ export function HistoryViewer({ projectId, onViewCommit, canCompareDiffs }: Hist
         setError(null);
 
         const fetchHistory = async () => {
+            const refQuery = branchRef ? `?ref=${encodeURIComponent(branchRef)}` : "";
             const [releasesResult, commitsResult] = await Promise.allSettled([
                 fetchJson<ReleasesResponse>(
-                    `/api/projects/${projectId}/releases`,
+                    `/api/projects/${projectId}/releases${refQuery}`,
                     { signal: controller.signal },
                     "Failed to load releases"
                 ),
                 fetchJson<CommitsResponse>(
-                    `/api/projects/${projectId}/commits`,
+                    `/api/projects/${projectId}/commits${refQuery}`,
                     { signal: controller.signal },
                     "Failed to load commits"
                 ),
@@ -259,7 +261,7 @@ export function HistoryViewer({ projectId, onViewCommit, canCompareDiffs }: Hist
         });
 
         return () => controller.abort();
-    }, [projectId]);
+    }, [projectId, branchRef]);
 
     if (loading) {
         return (

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { Suspense, lazy, useEffect, useState, type ComponentType } from "react";
+import { Suspense, lazy, useEffect, useMemo, useState, type ComponentType } from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, FileText, History, Box, FolderOpen, ChevronLeft, ChevronRight, GitBranch, RotateCcw, PlayCircle, RefreshCw, Menu, Settings } from "lucide-react";
 import { fetchApi, fetchJson, readApiError } from "@/lib/api";
@@ -46,6 +46,19 @@ interface ProjectOverviewResponse {
     readme: string | null;
 }
 
+interface ProjectBranch {
+    name: string;
+    ref: string;
+    source: "local" | "remote" | string;
+    is_current: boolean;
+    hash: string;
+    commit: string;
+}
+
+interface ProjectBranchesResponse {
+    branches: ProjectBranch[];
+}
+
 interface WorkflowJobResponse {
     job_id: string;
 }
@@ -75,6 +88,9 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
     const [visualizerLoaded, setVisualizerLoaded] = useState(false);
     const [refreshKey, setRefreshKey] = useState(0);
     const [pathConfigOpen, setPathConfigOpen] = useState(false);
+    const [branches, setBranches] = useState<ProjectBranch[]>([]);
+    const [branchesLoading, setBranchesLoading] = useState(false);
+    const [branchError, setBranchError] = useState<string | null>(null);
     const canMutateProject = user?.role === "admin" || user?.role === "designer";
 
     // Helper function to get display name
@@ -88,14 +104,32 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
         }
     }, [activeSection]);
 
+    const selectedBranchRef = searchParams.get('branch');
     const currentCommit = searchParams.get('commit');
+    const selectedBranch = useMemo(
+        () => branches.find((branch) => branch.ref === selectedBranchRef) || null,
+        [branches, selectedBranchRef]
+    );
+    const activeCommit = currentCommit || selectedBranch?.commit || null;
 
     const handleViewCommit = (commitHash: string) => {
-        setSearchParams({ commit: commitHash });
+        const next: Record<string, string> = { commit: commitHash };
+        if (selectedBranchRef) {
+            next.branch = selectedBranchRef;
+        }
+        setSearchParams(next);
     };
 
     const handleResetToLatest = () => {
+        if (currentCommit && selectedBranchRef) {
+            setSearchParams({ branch: selectedBranchRef });
+            return;
+        }
         setSearchParams({});
+    };
+
+    const handleBranchChange = (branchRef: string) => {
+        setSearchParams(branchRef ? { branch: branchRef } : {});
     };
 
     const handleSync = async () => {
@@ -123,6 +157,42 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
 
     useEffect(() => {
         if (!projectId) {
+            setBranches([]);
+            return;
+        }
+
+        const controller = new AbortController();
+        setBranchesLoading(true);
+        setBranchError(null);
+
+        const fetchBranches = async () => {
+            try {
+                const data = await fetchJson<ProjectBranchesResponse>(
+                    `/api/projects/${projectId}/branches`,
+                    { signal: controller.signal },
+                    "Failed to load branches"
+                );
+                if (!controller.signal.aborted) {
+                    setBranches(data.branches || []);
+                }
+            } catch (err) {
+                if (!controller.signal.aborted) {
+                    setBranches([]);
+                    setBranchError(err instanceof Error ? err.message : "Failed to load branches");
+                }
+            } finally {
+                if (!controller.signal.aborted) {
+                    setBranchesLoading(false);
+                }
+            }
+        };
+
+        void fetchBranches();
+        return () => controller.abort();
+    }, [projectId, refreshKey]);
+
+    useEffect(() => {
+        if (!projectId) {
             setLoading(false);
             return;
         }
@@ -132,8 +202,8 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
 
         const fetchProjectData = async () => {
             try {
-                const overviewUrl = currentCommit
-                    ? `/api/projects/${projectId}/overview?commit=${encodeURIComponent(currentCommit)}`
+                const overviewUrl = activeCommit
+                    ? `/api/projects/${projectId}/overview?commit=${encodeURIComponent(activeCommit)}`
                     : `/api/projects/${projectId}/overview`;
                 const overview = await fetchJson<ProjectOverviewResponse>(
                     overviewUrl,
@@ -163,7 +233,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
 
         void fetchProjectData();
         return () => controller.abort();
-    }, [projectId, currentCommit, refreshKey]);
+    }, [projectId, activeCommit, refreshKey]);
 
     // Calculate commits behind when viewing specific commit
     useEffect(() => {
@@ -181,8 +251,9 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
             }
 
             try {
+                const refQuery = selectedBranchRef ? `&ref=${encodeURIComponent(selectedBranchRef)}` : "";
                 const data = await fetchJson<CommitDistanceResponse>(
-                    `/api/projects/${projectId}/commits/distance?commit=${encodeURIComponent(currentCommit)}`,
+                    `/api/projects/${projectId}/commits/distance?commit=${encodeURIComponent(currentCommit)}${refQuery}`,
                     { signal: controller.signal },
                     "Failed to fetch commit distance"
                 );
@@ -202,7 +273,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
 
         void calculateCommitsBehind();
         return () => controller.abort();
-    }, [currentCommit, projectId]);
+    }, [currentCommit, projectId, selectedBranchRef]);
 
     if (loading) {
         return <div className="flex items-center justify-center h-screen">Loading...</div>;
@@ -233,7 +304,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
         if (!src) return src;
         if (src.startsWith('http')) return src;
         const assetUrl = `/api/projects/${projectId}/asset/${src}`;
-        return currentCommit ? `${assetUrl}?commit=${encodeURIComponent(currentCommit)}` : assetUrl;
+        return activeCommit ? `${assetUrl}?commit=${encodeURIComponent(activeCommit)}` : assetUrl;
     };
 
     return (
@@ -284,6 +355,25 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                 <div className="flex-1">
                     <h1 className="text-xl font-bold truncate max-w-[200px] md:max-w-none">{project ? getDisplayName(project) : ''}</h1>
                     <p className="text-sm text-muted-foreground hidden md:block">{project?.description}</p>
+                </div>
+
+                <div className="hidden min-w-0 items-center gap-2 md:flex">
+                    <GitBranch className="h-4 w-4 text-muted-foreground" />
+                    <select
+                        value={selectedBranchRef || ""}
+                        onChange={(event) => handleBranchChange(event.target.value)}
+                        disabled={branchesLoading}
+                        title={branchError || "View this project on another branch"}
+                        className="h-9 max-w-[260px] rounded-md border border-input bg-background px-3 text-sm text-foreground shadow-sm outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        <option value="">{branchesLoading ? "Loading branches..." : "Current checkout"}</option>
+                        {branches.map((branch) => (
+                            <option key={branch.ref} value={branch.ref}>
+                                {branch.source === "remote" ? branch.ref : branch.name}
+                                {branch.is_current ? " (current)" : ""}
+                            </option>
+                        ))}
+                    </select>
                 </div>
 
                 {/* Sync Button */}
@@ -342,13 +432,18 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
             )}
 
             {/* Version Banner */}
-            {currentCommit && (
+            {(currentCommit || selectedBranch) && (
                 <div className="bg-amber-500/10 border-b border-amber-500/20 px-6 py-3 flex items-center justify-between">
                     <div className="flex items-center gap-2 text-sm">
                         <GitBranch className="h-4 w-4 text-amber-500" />
                         <span className="font-medium">
-                            Viewing commit {currentCommit.substring(0, 7)}
-                            {commitsBehind > 0 && (
+                            {currentCommit
+                                ? `Viewing commit ${currentCommit.substring(0, 7)}`
+                                : `Viewing branch ${selectedBranch?.ref || selectedBranchRef}`}
+                            {selectedBranch && (
+                                <span className="text-muted-foreground ml-2">@ {selectedBranch.hash}</span>
+                            )}
+                            {currentCommit && commitsBehind > 0 && (
                                 <span className="text-muted-foreground ml-2">
                                     ({commitsBehind} {commitsBehind === 1 ? 'commit' : 'commits'} behind latest)
                                 </span>
@@ -362,7 +457,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                         className="h-7"
                     >
                         <RotateCcw className="h-3 w-3 mr-2" />
-                        Return to Latest
+                        {currentCommit && selectedBranchRef ? "Return to Branch Head" : "Return to Current Checkout"}
                     </Button>
                 </div>
             )}
@@ -445,7 +540,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                             <h2 className="text-2xl font-bold mb-6">Assets Portal</h2>
                             {projectId && (
                                 <Suspense fallback={<div className="text-sm text-muted-foreground">Loading assets...</div>}>
-                                    <AssetsPortal projectId={projectId} commit={currentCommit} />
+                                    <AssetsPortal projectId={projectId} commit={activeCommit} />
                                 </Suspense>
                             )}
                         </div>
@@ -456,7 +551,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                             <h2 className="text-2xl font-bold mb-6">Documentation</h2>
                             {projectId && (
                                 <Suspense fallback={<div className="text-sm text-muted-foreground">Loading documentation...</div>}>
-                                    <DocumentationBrowser projectId={projectId} commit={currentCommit} key={activeSection} />
+                                    <DocumentationBrowser projectId={projectId} commit={activeCommit} key={activeSection} />
                                 </Suspense>
                             )}
                         </div>
@@ -470,6 +565,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                                     <HistoryViewer
                                         key={refreshKey}
                                         projectId={projectId}
+                                        branchRef={selectedBranchRef}
                                         onViewCommit={handleViewCommit}
                                         canCompareDiffs={canMutateProject}
                                     />
@@ -489,7 +585,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                             <div className="flex-1 min-h-0">
                                 {projectId && (
                                     <Suspense fallback={<div className="text-sm text-muted-foreground">Loading visualizers...</div>}>
-                                        <Visualizer projectId={projectId} user={user} commit={currentCommit} />
+                                        <Visualizer projectId={projectId} user={user} commit={activeCommit} />
                                     </Suspense>
                                 )}
                             </div>


### PR DESCRIPTION
## Summary
- Add non-destructive project branch selection.
- Keep branch state scoped to the current browser URL; no repository checkout is changed.
- Scope history and project views to the selected ref.

Closes #47

## Validation
- Backend branch-viewing and commit-file tests
- Frontend lint and production build