### PR TITLE
fix: advertise HTTPS origins for Remote Symbols behind proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,14 @@ SESSION_COOKIE_SECURE=false
 # Keep this explicit; do not use "*" with session cookies.
 CORS_ORIGINS_STR=http://127.0.0.1:5173,http://localhost:5173,http://127.0.0.1:8080,http://localhost:8080
 
+# Canonical public origin for Remote Symbols / OAuth absolute URLs behind a
+# reverse proxy (example: https://prism.example.com). Leave empty to derive
+# from X-Forwarded-* headers or the incoming request.
+PUBLIC_BASE_URL=
+
+# Optional comments-only override (wins over PUBLIC_BASE_URL for comments helpers).
+COMMENTS_API_BASE_URL=
+
 # Local OAuth2 service-client tokens for PLM/MRP integrations
 OAUTH_SERVICE_TOKEN_TTL_SECONDS=3600
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -62,6 +62,14 @@ SESSION_COOKIE_SECURE=false
 # Keep this explicit; do not use "*" with session cookies.
 CORS_ORIGINS_STR=http://127.0.0.1:5173,http://localhost:5173,http://127.0.0.1:8080,http://localhost:8080
 
+# Canonical public origin for Remote Symbols / OAuth absolute URLs behind a
+# reverse proxy (example: https://prism.example.com). Leave empty to derive
+# from X-Forwarded-* headers or the incoming request.
+PUBLIC_BASE_URL=
+
+# Optional comments-only override (wins over PUBLIC_BASE_URL for comments helpers).
+COMMENTS_API_BASE_URL=
+
 # Local OAuth2 service-client tokens for PLM/MRP integrations
 OAUTH_SERVICE_TOKEN_TTL_SECONDS=3600
 

--- a/backend/app/api/provider_oauth.py
+++ b/backend/app/api/provider_oauth.py
@@ -9,12 +9,13 @@ from app.core.config import settings
 from app.core.session import create_session_token, set_session_cookie
 from app.core.security import get_current_user
 from app.services import provider_auth_service
+from app.services.public_url_service import resolve_public_base_url
 
 router = APIRouter()
 
 
 def _base_url(request: Request) -> str:
-    return str(request.base_url).rstrip("/")
+    return resolve_public_base_url(request)
 
 
 def _require_provider_auth() -> None:

--- a/backend/app/api/remote_provider.py
+++ b/backend/app/api/remote_provider.py
@@ -9,6 +9,7 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from app.core.security import AuthenticatedUser, require_remote_symbol_reader
 from app.services import provider_auth_service
 from app.services.component_catalog_service import catalog_service
+from app.services.public_url_service import resolve_public_base_url
 
 router = APIRouter()
 
@@ -16,7 +17,7 @@ STATIC_DIR = Path(__file__).resolve().parent.parent / "static" / "remote_provide
 
 
 def _provider_origin(request: Request) -> str:
-    return str(request.base_url).rstrip("/")
+    return resolve_public_base_url(request)
 
 
 def _component_payload(component: dict, request: Request) -> dict:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -192,7 +192,17 @@ class Settings(BaseSettings):
         description=(
             "Default base URL used to generate KiCad comments REST URLs "
             "for project import and visualizer helpers. "
-            "If empty, URL helpers derive host from the incoming request."
+            "If empty, URL helpers derive host from PUBLIC_BASE_URL or the incoming request."
+        ),
+    )
+
+    PUBLIC_BASE_URL: str = Field(
+        default="",
+        description=(
+            "Canonical public origin for absolute URLs (Remote Symbols metadata, OAuth, "
+            "and other request-derived links) when Prism sits behind a reverse proxy. "
+            "Example: https://prism.example.com. If empty, helpers use forwarded headers "
+            "or request.base_url."
         ),
     )
 

--- a/backend/app/services/comments_url_service.py
+++ b/backend/app/services/comments_url_service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from fastapi import Request
 
 from app.core.config import settings
+from app.services.public_url_service import resolve_public_base_url
 
 
 def _normalize_base_url(base_url: str | None) -> str:
@@ -29,18 +30,14 @@ def resolve_comments_base_url(
     Precedence:
     1. Explicit endpoint query override.
     2. COMMENTS_API_BASE_URL from environment.
-    3. Incoming request host/protocol (works for LAN IP access).
+    3. PUBLIC_BASE_URL / forwarded headers / request.base_url
+       (via resolve_public_base_url).
     """
     normalized = _normalize_base_url(explicit_base_url)
     if normalized:
         return normalized
 
-    forwarded_proto = request.headers.get("x-forwarded-proto")
-    forwarded_host = request.headers.get("x-forwarded-host")
-    if forwarded_proto and forwarded_host:
-        return f"{forwarded_proto}://{forwarded_host}".rstrip("/")
-
-    return str(request.base_url).rstrip("/")
+    return resolve_public_base_url(request)
 
 
 def build_comments_source_urls(project_id: str, base_url: str | None = None) -> dict:

--- a/backend/app/services/public_url_service.py
+++ b/backend/app/services/public_url_service.py
@@ -1,0 +1,58 @@
+"""
+Shared helpers for resolving Prism's public base URL behind reverse proxies.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from app.core.config import settings
+
+
+def _normalize_base_url(base_url: str | None) -> str:
+    """Return normalized base URL (no trailing slash)."""
+    return (base_url or "").strip().rstrip("/")
+
+
+def _first_forwarded_value(header_value: str | None) -> str:
+    """Return the left-most value from a possibly comma-separated forwarded header."""
+    if not header_value:
+        return ""
+    return header_value.split(",", 1)[0].strip()
+
+
+def resolve_public_base_url(
+    request: Request,
+    explicit: str | None = None,
+) -> str:
+    """
+    Resolve the externally visible origin for absolute URLs.
+
+    Precedence:
+    1. Explicit override argument
+    2. PUBLIC_BASE_URL from environment
+    3. X-Forwarded-Proto + (X-Forwarded-Host or Host)
+    4. request.base_url, with scheme rewritten from X-Forwarded-Proto when present
+    """
+    normalized = _normalize_base_url(explicit)
+    if normalized:
+        return normalized
+
+    normalized = _normalize_base_url(settings.PUBLIC_BASE_URL)
+    if normalized:
+        return normalized
+
+    forwarded_proto = _first_forwarded_value(request.headers.get("x-forwarded-proto")).lower()
+    forwarded_host = _first_forwarded_value(
+        request.headers.get("x-forwarded-host") or request.headers.get("host")
+    )
+
+    if forwarded_proto in {"http", "https"} and forwarded_host:
+        return f"{forwarded_proto}://{forwarded_host}".rstrip("/")
+
+    base = str(request.base_url).rstrip("/")
+    if forwarded_proto in {"http", "https"} and "://" in base:
+        _, remainder = base.split("://", 1)
+        return f"{forwarded_proto}://{remainder}"
+
+    return base

--- a/backend/tests/test_public_url_service.py
+++ b/backend/tests/test_public_url_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.comments_url_service import resolve_comments_base_url  # noqa: E402
+from app.services.public_url_service import resolve_public_base_url  # noqa: E402
+
+
+def _request(
+    *,
+    base_url: str = "http://backend:8000/",
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    request = MagicMock()
+    request.base_url = base_url
+    request.headers = headers or {}
+    return request
+
+
+class PublicUrlServiceTests(unittest.TestCase):
+    def test_explicit_override_wins(self) -> None:
+        request = _request(
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "proxy.example.com",
+            }
+        )
+        with patch("app.services.public_url_service.settings") as settings:
+            settings.PUBLIC_BASE_URL = "https://env.example.com"
+            self.assertEqual(
+                resolve_public_base_url(request, explicit="https://explicit.example.com/"),
+                "https://explicit.example.com",
+            )
+
+    def test_public_base_url_env_wins_over_headers(self) -> None:
+        request = _request(
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "proxy.example.com",
+            }
+        )
+        with patch("app.services.public_url_service.settings") as settings:
+            settings.PUBLIC_BASE_URL = "https://prism.example.com/"
+            self.assertEqual(
+                resolve_public_base_url(request),
+                "https://prism.example.com",
+            )
+
+    def test_forwarded_proto_and_host(self) -> None:
+        request = _request(
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "prism.example.com",
+            }
+        )
+        with patch("app.services.public_url_service.settings") as settings:
+            settings.PUBLIC_BASE_URL = ""
+            self.assertEqual(
+                resolve_public_base_url(request),
+                "https://prism.example.com",
+            )
+
+    def test_forwarded_proto_falls_back_to_host_header(self) -> None:
+        request = _request(
+            headers={
+                "x-forwarded-proto": "https",
+                "host": "prism.example.com",
+            }
+        )
+        with patch("app.services.public_url_service.settings") as settings:
+            settings.PUBLIC_BASE_URL = ""
+            self.assertEqual(
+                resolve_public_base_url(request),
+                "https://prism.example.com",
+            )
+
+    def test_comma_separated_forwarded_proto_uses_leftmost(self) -> None:
+        request = _request(
+            headers={
+                "x-forwarded-proto": "https, http",
+                "x-forwarded-host": "prism.example.com, internal",
+            }
+        )
+        with patch("app.services.public_url_service.settings") as settings:
+            settings.PUBLIC_BASE_URL = ""
+            self.assertEqual(
+                resolve_public_base_url(request),
+                "https://prism.example.com",
+            )
+
+    def test_forwarded_proto_rewrites_request_base_url_scheme(self) -> None:
+        request = _request(
+            base_url="http://prism.example.com/",
+            headers={"x-forwarded-proto": "https"},
+        )
+        with patch("app.services.public_url_service.settings") as settings:
+            settings.PUBLIC_BASE_URL = ""
+            # No Host / X-Forwarded-Host → rewrite scheme on request.base_url.
+            self.assertEqual(
+                resolve_public_base_url(request),
+                "https://prism.example.com",
+            )
+
+    def test_no_headers_uses_request_base_url(self) -> None:
+        request = _request(base_url="http://127.0.0.1:8000/")
+        with patch("app.services.public_url_service.settings") as settings:
+            settings.PUBLIC_BASE_URL = ""
+            self.assertEqual(
+                resolve_public_base_url(request),
+                "http://127.0.0.1:8000",
+            )
+
+
+class CommentsUrlOriginTests(unittest.TestCase):
+    def test_comments_api_base_url_wins_over_public_base_url(self) -> None:
+        request = _request(
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "proxy.example.com",
+            }
+        )
+        with (
+            patch("app.services.comments_url_service.settings") as comments_settings,
+            patch("app.services.public_url_service.settings") as public_settings,
+        ):
+            comments_settings.COMMENTS_API_BASE_URL = "https://comments.example.com"
+            public_settings.PUBLIC_BASE_URL = "https://prism.example.com"
+            self.assertEqual(
+                resolve_comments_base_url(request),
+                "https://comments.example.com",
+            )
+
+    def test_comments_falls_back_to_shared_public_resolver(self) -> None:
+        request = _request(
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "prism.example.com",
+            }
+        )
+        with (
+            patch("app.services.comments_url_service.settings") as comments_settings,
+            patch("app.services.public_url_service.settings") as public_settings,
+        ):
+            comments_settings.COMMENTS_API_BASE_URL = ""
+            public_settings.PUBLIC_BASE_URL = ""
+            self.assertEqual(
+                resolve_comments_base_url(request),
+                "https://prism.example.com",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - SESSION_TTL_HOURS=${SESSION_TTL_HOURS:-12}
       - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-false}
       - CORS_ORIGINS_STR=${CORS_ORIGINS_STR:-http://127.0.0.1:5173,http://localhost:5173,http://127.0.0.1:8080,http://localhost:8080}
+      - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-}
+      - COMMENTS_API_BASE_URL=${COMMENTS_API_BASE_URL:-}
       # Set to false to disable authentication entirely
       - AUTH_ENABLED=${AUTH_ENABLED:-true}
       # Development mode (set to false for production/bundling)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -228,7 +228,12 @@ If your production deployment is HTTPS, also set:
 
 ```env
 SESSION_COOKIE_SECURE=true
+PUBLIC_BASE_URL=https://your-domain.example
 ```
+
+`PUBLIC_BASE_URL` is the hard override for absolute URLs advertised to KiCad (Remote Symbols
+metadata and OAuth endpoints). Prefer it whenever Prism sits behind a reverse proxy. See
+[HTTPS and TLS](HTTPS_AND_TLS.md).
 
 ## Reverse Proxy for Office/VPN Hosting
 
@@ -237,8 +242,8 @@ database and `.kicad-prism/components` asset directory on the workstation's loca
 place either path on NFS/SMB/network storage; SQLite WAL mode is designed for local filesystems.
 
 If the external reverse proxy points at the frontend container, the bundled frontend Nginx config
-already forwards KiCad/API paths to the backend. If the external reverse proxy routes directly to
-individual containers, use these path rules:
+already forwards KiCad/API paths to the backend and preserves outer `X-Forwarded-Proto` when present.
+If the external reverse proxy routes directly to individual containers, use these path rules:
 
 - `/` to the frontend container
 - `/api/*` to the backend container
@@ -253,11 +258,17 @@ CORS_ORIGINS_STR=http://kicad-prism.example.internal
 SESSION_COOKIE_SECURE=false
 ```
 
-For HTTPS, use the HTTPS origin and set `SESSION_COOKIE_SECURE=true`.
+For HTTPS:
 
-The proxy must preserve the original `Host` header so provider metadata advertises the public
-office/VPN URL instead of the backend container name. Enable gzip or Brotli compression at the
-proxy for JSON responses and static panel assets.
+```env
+CORS_ORIGINS_STR=https://kicad-prism.example.internal
+SESSION_COOKIE_SECURE=true
+PUBLIC_BASE_URL=https://kicad-prism.example.internal
+```
+
+The proxy must preserve the original `Host` header and set `X-Forwarded-Proto: https` so provider
+metadata advertises the public office/VPN URL instead of the backend container name. Enable gzip or
+Brotli compression at the proxy for JSON responses and static panel assets.
 
 ## Private Repository Access
 

--- a/docs/HTTPS_AND_TLS.md
+++ b/docs/HTTPS_AND_TLS.md
@@ -1,0 +1,82 @@
+# HTTPS and TLS for KiCAD Prism
+
+This guide covers reverse-proxy HTTPS for Prism, focusing on Remote Symbols metadata that must
+advertise `https://` absolute URLs to KiCad.
+
+For general Docker hosting, see [DEPLOYMENT.md](DEPLOYMENT.md). For provider setup, see
+[REMOTE_SYMBOL_PROVIDER.md](REMOTE_SYMBOL_PROVIDER.md).
+
+## Why this matters
+
+KiCad discovers Prism at:
+
+```text
+https://<your-host>/.well-known/kicad-remote-provider
+```
+
+That document advertises absolute URLs for `api_base_url`, `panel_url`, OAuth metadata, and asset
+downloads. If Prism thinks the request was plain HTTP (common behind TLS terminators), KiCad
+rejects the provider with errors such as:
+
+```text
+'api_base_url' must use HTTPS unless allow_insecure_localhost is set for loopback URLs
+```
+
+## Recommended environment
+
+```env
+AUTH_ENABLED=true
+DEV_MODE=false
+SESSION_SECRET=<long-random-value>
+SESSION_COOKIE_SECURE=true
+CORS_ORIGINS_STR=https://prism.example.com
+PUBLIC_BASE_URL=https://prism.example.com
+```
+
+`PUBLIC_BASE_URL` is the hard override for absolute URLs. Prefer it for any multi-hop proxy
+(ALB → Kong → Compose, outer nginx → frontend nginx → backend, etc.).
+
+Comments helpers still honor `COMMENTS_API_BASE_URL` as a comments-only override that wins over
+`PUBLIC_BASE_URL`.
+
+## Proxy path map
+
+Point the public hostname at the **frontend** container (recommended). Frontend Nginx proxies:
+
+| Path | Upstream |
+|------|----------|
+| `/` | frontend static SPA |
+| `/api/*` | backend |
+| `/oauth/*` | backend |
+| `/.well-known/kicad-remote-provider` | backend |
+| `/remote-provider/*` | backend |
+
+Outer TLS proxy requirements:
+
+- Preserve public `Host`
+- Set `X-Forwarded-Proto: https`
+- Optionally set `X-Forwarded-Host` to the public host
+
+Frontend Nginx preserves an incoming `X-Forwarded-Proto` (falls back to `$scheme` for direct HTTP)
+and forwards `X-Forwarded-Host`.
+
+## Verify
+
+```bash
+curl -fsS https://prism.example.com/.well-known/kicad-remote-provider | jq '{api_base_url, panel_url, auth}'
+curl -fsS https://prism.example.com/oauth/.well-known/oauth-authorization-server | jq '{issuer, authorization_endpoint, token_endpoint}'
+```
+
+Every advertised URL must start with `https://prism.example.com`.
+
+## Common failure: metadata shows `http://`
+
+Cause: outer proxy missing `X-Forwarded-Proto: https`, overwriting `Host`, or an older frontend
+nginx that rewrote forwarded proto to the internal `http` hop.
+
+Fix:
+
+1. Set `PUBLIC_BASE_URL=https://<public-host>`
+2. Preserve public `Host` and force `X-Forwarded-Proto: https` on the outer proxy
+3. Rebuild/restart so frontend nginx proto passthrough is active
+4. Re-fetch metadata and confirm every URL is `https://<public-host>/...`

--- a/docs/REMOTE_SYMBOL_PROVIDER.md
+++ b/docs/REMOTE_SYMBOL_PROVIDER.md
@@ -38,6 +38,34 @@ Search is backed by SQLite FTS5 when the runtime SQLite build supports it. FTS i
 database triggers on component revisions. If FTS5 is unavailable, Prism logs a warning and falls
 back to `LIKE` search so the provider remains functional.
 
+## HTTPS and public origin
+
+For any non-loopback deployment used by desktop KiCad, serve Prism over HTTPS. Metadata, panel,
+OAuth, and asset URLs are absolute and must match the public origin.
+
+When Prism sits behind a reverse proxy, set:
+
+```env
+PUBLIC_BASE_URL=https://prism.example.com
+SESSION_COOKIE_SECURE=true
+CORS_ORIGINS_STR=https://prism.example.com
+```
+
+`PUBLIC_BASE_URL` overrides request-derived origins for Remote Symbols discovery and OAuth
+metadata. If unset, Prism uses `X-Forwarded-Proto` / `X-Forwarded-Host` (or `Host`) and finally
+`request.base_url`.
+
+Verify before opening KiCad:
+
+```bash
+curl -fsS https://prism.example.com/.well-known/kicad-remote-provider | jq '{api_base_url, panel_url, auth}'
+curl -fsS https://prism.example.com/oauth/.well-known/oauth-authorization-server | jq '{issuer, authorization_endpoint, token_endpoint}'
+```
+
+Every advertised URL must start with `https://prism.example.com`.
+
+Full reverse-proxy notes: [HTTPS and TLS](HTTPS_AND_TLS.md) and [Deployment](DEPLOYMENT.md).
+
 ## Running locally
 
 1. Start the Prism backend.

--- a/docs/discussion-39-remote-symbols-https-reply.md
+++ b/docs/discussion-39-remote-symbols-https-reply.md
@@ -1,0 +1,60 @@
+# Discussion #39 reply (Remote Symbols HTTPS)
+
+Paste into: https://github.com/krishna-swaroop/KiCAD-Prism/discussions/39#discussioncomment-17692631
+
+---
+
+@aidanbrzezinski You’re hitting a real gap that showed up for several reverse-proxy HTTPS deploys. Short version: behind TLS termination, Prism’s Remote Symbols metadata often advertised `http://…`, and KiCad rejects that.
+
+**1. Diagnose which failure you have**
+
+```bash
+curl -fsS https://YOUR_HOST/.well-known/kicad-remote-provider | head
+curl -fsS https://YOUR_HOST/.well-known/kicad-remote-provider | jq '{api_base_url, panel_url, auth}'
+```
+
+- Response starts with `<` / HTML → proxy is returning the SPA (`index.html`) instead of backend JSON.
+- JSON with `"api_base_url": "http://…"` → origin/proto bug (your case if you’re past invalid JSON).
+- JSON with all `https://YOUR_HOST/…` URLs → different issue (TLS trust / OIDC redirects).
+
+**2. Temporary fix for HTML / invalid JSON**
+
+Ensure these paths hit the backend (not SPA fallback), either in the bundled frontend nginx or your outer nginx:
+
+- `/.well-known/kicad-remote-provider`
+- `/remote-provider/`
+- `/oauth/`
+- `/api/`
+
+Current main already proxies these in `frontend/nginx.conf`; rebuild/pull a recent image if you’re on an older build.
+
+**3. Temporary workarounds until you upgrade**
+
+**Option A:** set an explicit public origin and rebuild:
+
+```env
+PUBLIC_BASE_URL=https://YOUR_HOST
+SESSION_COOKIE_SECURE=true
+CORS_ORIGINS_STR=https://YOUR_HOST
+```
+
+(Available once the linked PR is merged; until then you can patch `_provider_origin` / `_base_url` as TriOda described.)
+
+**Option B (proxy-only):** have the outer TLS nginx proxy `.well-known`, `/oauth`, `/remote-provider`, and `/api` **directly to backend:8000** with:
+
+```nginx
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto https;
+proxy_set_header X-Forwarded-Host $host;
+```
+
+**4. Verify before opening KiCad**
+
+```bash
+curl -fsS https://YOUR_HOST/.well-known/kicad-remote-provider | jq '{api_base_url, panel_url, auth}'
+curl -fsS https://YOUR_HOST/oauth/.well-known/oauth-authorization-server | jq '{issuer, authorization_endpoint, token_endpoint}'
+```
+
+Every advertised URL must be `https://YOUR_HOST/...`.
+
+**Permanent fix:** Remote Symbols now uses the same public-origin resolution pattern as the comments helpers (`PUBLIC_BASE_URL` + forwarded headers), and frontend nginx no longer overwrites outer `X-Forwarded-Proto` with the internal HTTP `$scheme`. See the linked PR / `docs/HTTPS_AND_TLS.md`.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,10 @@ FROM nginx:alpine
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Copy custom nginx config for SPA routing and API proxy
+# Copy custom nginx config for SPA routing and API proxy.
+# Map lives in a separate conf.d file (http context) so $prism_forwarded_proto
+# can prefer the outer X-Forwarded-Proto over the internal HTTP $scheme.
+COPY nginx-forwarded-map.conf /etc/nginx/conf.d/00-forwarded-map.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port 80

--- a/frontend/nginx-forwarded-map.conf
+++ b/frontend/nginx-forwarded-map.conf
@@ -1,0 +1,6 @@
+# Forwarded-header helpers for the frontend reverse proxy.
+# Included from http context via conf.d (alpine nginx image).
+map $http_x_forwarded_proto $prism_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,7 +19,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        # Prefer outer TLS proto; fall back to $scheme for direct HTTP access.
+        proxy_set_header X-Forwarded-Proto $prism_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_cache_bypass $http_upgrade;
     }
 
@@ -30,7 +32,8 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $prism_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $host;
     }
 
     location /oauth/ {
@@ -41,7 +44,8 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $prism_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_cache_bypass $http_upgrade;
     }
 
@@ -53,7 +57,8 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $prism_forwarded_proto;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_cache_bypass $http_upgrade;
     }
 


### PR DESCRIPTION
## Summary
- Remote Symbols / OAuth absolute URLs now resolve via shared `resolve_public_base_url()` with `PUBLIC_BASE_URL` override and forwarded-header support (same pattern as comments helpers).
- Frontend nginx preserves outer `X-Forwarded-Proto` instead of overwriting it with the internal HTTP `$scheme`, and forwards `X-Forwarded-Host`.
- Docs and env examples cover the reverse-proxy HTTPS failure mode from Discussion #39; unit tests cover origin precedence.
## Test plan
- [ ] `cd backend && python -m unittest tests.test_public_url_service -v`
- [ ] Behind HTTPS reverse proxy: metadata URLs are all `https://HOST/...`
- [ ] With `PUBLIC_BASE_URL=https://HOST`, metadata stays correct even if forwarded headers are incomplete
- [ ] Local HTTP Docker still works for loopback