### PR TITLE
fix(webgpu): restore staged board/components visibility during 3D jobs

### DIFF
--- a/backend/app/services/job_service.py
+++ b/backend/app/services/job_service.py
@@ -1235,6 +1235,26 @@ class JobService:
             return None
         return _loads(row["status_payload"], {})
 
+    def upsert_webgpu_ready_status(
+        self,
+        *,
+        job_id: str,
+        fence: int,
+        details: Mapping[str, Any],
+    ) -> None:
+        """Publish staged or completed WebGPU readiness for O(1) status reads."""
+
+        self.initialize()
+        with self._connect() as conn:
+            conn.execute("SET search_path TO workspace, public")
+            self._upsert_webgpu_ready(
+                conn,
+                job_id=job_id,
+                fence=fence,
+                details=details,
+            )
+            conn.commit()
+
     def find_webgpu_ready_by_commit_prefix(
         self,
         project_id: str,

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -389,16 +389,31 @@ def get_job_status(job_id: str):
     v3_job = v3_jobs.get(job_id)
     if v3_job:
         metadata = dict(v3_job.get("result_metadata") or {})
+        payload_compat = dict(v3_job.get("payload") or {})
+        staged_keys = (
+            "bundle_url",
+            "readiness",
+            "readiness_stage",
+            "sourceRevisionKey",
+            "source_fingerprint",
+            "status_selector",
+            "commit",
+        )
+        staged_fields = {
+            key: payload_compat[key]
+            for key in staged_keys
+            if key in payload_compat and payload_compat[key] is not None
+        }
+        logs = payload_compat.get("logs")
+        if not isinstance(logs, list):
+            logs = []
         return {
             **metadata,
-            # Result metadata may describe an artifact with its own lifecycle
-            # (for example WebGPU's "ready" status).  The compatibility job
-            # endpoint must keep the authoritative queue status so pollers can
-            # observe terminal "completed"/"failed"/"cancelled" states.
+            **staged_fields,
             **v3_job,
             "type": v3_job.get("kind"),
             "error": v3_job.get("error_message") or None,
-            "logs": [],
+            "logs": logs,
         }
     return workspace.get_job(job_id)
 
@@ -561,6 +576,9 @@ def run_webgpu_3d_job_v3(context: JobContext) -> JobResult:
     commit = payload.get("commit")
     force = bool(payload.get("force"))
     artifact_key = str(payload["artifact_key"])
+    status_selector = (
+        f"commit:{commit}" if commit else f"workspace:{row.get('last_modified') or ''}"
+    )
     state: dict[str, Any] = {
         "job_id": context.job_id,
         "status": "running",
@@ -568,10 +586,14 @@ def run_webgpu_3d_job_v3(context: JobContext) -> JobResult:
         "message": "Generating WebGPU 3D assets...",
         "percent": 0,
         "project_id": project_id,
+        "status_selector": status_selector,
         "logs": [],
         "performance": [],
     }
+    if commit:
+        state["commit"] = commit
     emitted_logs = 0
+    last_readiness_stage: dict[str, str | None] = {"value": None}
 
     def persist() -> None:
         nonlocal emitted_logs
@@ -579,10 +601,41 @@ def run_webgpu_3d_job_v3(context: JobContext) -> JobResult:
         for line in logs[emitted_logs:]:
             print(str(line), flush=True)
         emitted_logs = len(logs)
+        readiness_stage = state.get("readiness_stage")
+        milestone = (
+            isinstance(readiness_stage, str)
+            and readiness_stage
+            and readiness_stage != last_readiness_stage["value"]
+        )
+        if milestone:
+            last_readiness_stage["value"] = str(readiness_stage)
+        payload_updates: dict[str, Any] = {}
+        for key in (
+            "bundle_url",
+            "readiness",
+            "readiness_stage",
+            "sourceRevisionKey",
+            "source_fingerprint",
+            "status_selector",
+            "commit",
+        ):
+            if key in state and state[key] is not None:
+                payload_updates[key] = state[key]
+        if logs:
+            payload_updates["logs"] = logs[-80:]
+        if state.get("bundle_url") and state.get("readiness"):
+            semantic_visualizer_service.sync_staged_webgpu_status(
+                job_id=context.job_id,
+                fence=context.fence,
+                project=project,
+                state=state,
+            )
         context.progress(
             stage=str(state.get("stage") or "building"),
             message=str(state.get("message") or "Generating WebGPU 3D assets..."),
             percent=float(state.get("percent") or 0),
+            payload_updates=payload_updates or None,
+            force=bool(milestone),
         )
 
     context.check_cancelled()

--- a/backend/app/services/semantic_visualizer_service.py
+++ b/backend/app/services/semantic_visualizer_service.py
@@ -11,7 +11,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Mapping, Optional
 
 from app.core.config import settings
 from app.services import path_config_service
@@ -349,9 +349,8 @@ def get_status_for_source(
             payload["readiness"] = readiness
             semantic_ready = readiness.get("stage") == "semantic-ready"
             payload["status"] = "ready" if semantic_ready else "building"
-            if not semantic_ready:
-                payload["available"] = False
-                payload["bundle_url"] = None
+            payload["available"] = True
+            payload["bundle_url"] = bundle_url(project.id, source_hash)
             payload["generated_at"] = bundle.get("generated_at")
             payload["capabilities"] = bundle.get("capabilities", {})
             _validate_bundle_assets(current_bundle.parent, bundle)
@@ -758,6 +757,8 @@ def _publish_partial_bundle(
     job["stage"] = stage
     job["readiness_stage"] = stage
     job["readiness"] = readiness
+    job["sourceRevisionKey"] = source_hash
+    job["source_fingerprint"] = source_hash
     job["bundle_url"] = bundle_url(project.id, source_hash)
     job["percent"] = readiness["progress"]
     job["message"] = (
@@ -769,6 +770,49 @@ def _publish_partial_bundle(
         f"Published staged bundle: {stage} ({', '.join(available_assets)})"
     )
     persist()
+
+
+def sync_staged_webgpu_status(
+    *,
+    job_id: str,
+    fence: int,
+    project: Any,
+    state: Mapping[str, Any],
+) -> None:
+    """Mirror an in-flight partial bundle into ws_webgpu_ready for fast status reads."""
+
+    bundle_url_value = str(state.get("bundle_url") or "")
+    readiness = state.get("readiness")
+    source_hash = str(
+        state.get("sourceRevisionKey") or state.get("source_fingerprint") or ""
+    )
+    selector_key = str(state.get("status_selector") or "")
+    if not bundle_url_value or not isinstance(readiness, dict) or not source_hash or not selector_key:
+        return
+    stage = str(readiness.get("stage") or "")
+    semantic_ready = stage == "semantic-ready"
+    details: Dict[str, Any] = {
+        "schema": "prism.webgpu_3d_status_a0",
+        "project_id": str(project.id),
+        "source_fingerprint": source_hash,
+        "sourceRevisionKey": source_hash,
+        "build_fingerprint": BUILD_FINGERPRINT,
+        "generator": {
+            "name": GENERATOR_NAME,
+            "version": GENERATOR_VERSION,
+            "build": BUILD_FINGERPRINT,
+        },
+        "artifactScope": "3d-semantic",
+        "status": "ready" if semantic_ready else "building",
+        "available": True,
+        "bundle_url": bundle_url_value,
+        "readiness": readiness,
+        "status_selector": selector_key,
+    }
+    commit = state.get("commit")
+    if commit:
+        details["commit"] = commit
+    jobs.upsert_webgpu_ready_status(job_id=job_id, fence=fence, details=details)
 
 
 def _write_bundle(project: Any, output_dir: Path, source_hash: str) -> None:

--- a/backend/tests/test_job_service_postgres.py
+++ b/backend/tests/test_job_service_postgres.py
@@ -512,6 +512,46 @@ class JobServicePostgresTests(unittest.TestCase):
         )
         self.assertEqual(prefixed["commit"], "a" * 40)
 
+    def test_webgpu_staged_upsert_exposes_building_status_via_fast_read(self) -> None:
+        selector = f"workspace:staged-{self.suffix}"
+        project_id = f"project-staged-{self.suffix}"
+        queued = self.service.enqueue(
+            "webgpu_3d",
+            {"test": True},
+            worker_pool=self.pool,
+            artifact_key=f"webgpu-staged-{self.suffix}",
+        )
+        self.job_ids.append(str(queued["job_id"]))
+        claim = self.service.claim("worker-a", worker_pool=self.pool)
+        readiness = {
+            "schema": "prism.visualizer_readiness.a0",
+            "stage": "board-ready",
+            "progress": 35,
+            "available_assets": ["board"],
+            "revision": "rev-partial",
+        }
+        self.service.upsert_webgpu_ready_status(
+            job_id=str(queued["job_id"]),
+            fence=int(claim["fence"]),
+            details={
+                "schema": "prism.webgpu_3d_status_a0",
+                "project_id": project_id,
+                "status_selector": selector,
+                "source_fingerprint": "source-partial",
+                "sourceRevisionKey": "source-partial",
+                "build_fingerprint": "build-a",
+                "bundle_url": "/partial/bundle.json",
+                "status": "building",
+                "available": True,
+                "readiness": readiness,
+            },
+        )
+        ready = self.service.get_webgpu_ready(project_id, selector, "build-a")
+        self.assertIsNotNone(ready)
+        self.assertEqual(ready["status"], "building")
+        self.assertTrue(ready["available"])
+        self.assertEqual(ready["readiness"]["stage"], "board-ready")
+
     def test_webgpu_ready_upsert_respects_invalidation_and_recency(self) -> None:
         selector = f"commit:webgpu-race-{self.suffix}"
         project_id = f"project-race-{self.suffix}"

--- a/backend/tests/test_project_service_v3_jobs.py
+++ b/backend/tests/test_project_service_v3_jobs.py
@@ -35,6 +35,36 @@ class ProjectServiceV3JobTests(unittest.TestCase):
         self.assertEqual(status["schema"], "prism.webgpu_3d_status_a0")
         self.assertTrue(status["available"])
 
+    def test_job_status_merges_staged_payload_for_pollers(self) -> None:
+        with mock.patch.object(
+            project_service.v3_jobs,
+            "get",
+            return_value={
+                "job_id": "job-webgpu",
+                "kind": "webgpu_3d",
+                "status": "running",
+                "stage": "compile-assets",
+                "payload": {
+                    "bundle_url": "/api/projects/p1/webgpu-3d/manifest/source/build",
+                    "readiness_stage": "board-ready",
+                    "readiness": {
+                        "stage": "board-ready",
+                        "progress": 35,
+                        "revision": "rev-1",
+                    },
+                    "logs": ["Published staged bundle: board-ready (board)"],
+                },
+                "result_metadata": {},
+                "error_message": "",
+            },
+        ):
+            status = project_service.get_job_status("job-webgpu")
+
+        self.assertEqual(status["status"], "running")
+        self.assertEqual(status["readiness_stage"], "board-ready")
+        self.assertIn("bundle_url", status)
+        self.assertEqual(len(status["logs"]), 1)
+
     def test_thumbnail_url_is_content_versioned_when_digest_is_available(self) -> None:
         self.assertEqual(
             project_service.thumbnail_url_for_row(
@@ -240,6 +270,7 @@ class ProjectServiceV3JobTests(unittest.TestCase):
             staging_dir = Path(temporary)
             context = SimpleNamespace(
                 job_id="job-webgpu",
+                fence=1,
                 payload={
                     "project_id": "project-1",
                     "commit": "abc123",
@@ -267,6 +298,17 @@ class ProjectServiceV3JobTests(unittest.TestCase):
                 state["stage"] = "compile-assets"
                 state["message"] = "Compiling"
                 state["percent"] = 55
+                state["bundle_url"] = "/api/projects/project-1/webgpu-3d/manifest/source/build"
+                state["readiness"] = {
+                    "schema": "prism.visualizer_readiness.a0",
+                    "stage": "board-ready",
+                    "progress": 35,
+                    "available_assets": ["board"],
+                    "revision": "rev-board",
+                }
+                state["readiness_stage"] = "board-ready"
+                state["sourceRevisionKey"] = "source"
+                state["source_fingerprint"] = "source"
                 assert callable(persist)
                 persist()
                 return {
@@ -289,7 +331,7 @@ class ProjectServiceV3JobTests(unittest.TestCase):
                 mock.patch.object(
                     project_service.workspace,
                     "get_project_by_id",
-                    return_value={"id": "project-1"},
+                    return_value={"id": "project-1", "last_modified": "rev-1"},
                 ),
                 mock.patch.object(
                     project_service,
@@ -311,8 +353,18 @@ class ProjectServiceV3JobTests(unittest.TestCase):
                     "prepare_file",
                     return_value=prepared,
                 ),
+                mock.patch.object(
+                    semantic_visualizer_service,
+                    "sync_staged_webgpu_status",
+                    mock.Mock(),
+                ) as sync_staged,
             ):
                 result = project_service.run_webgpu_3d_job_v3(context)
+
+        sync_staged.assert_called()
+        payload_update = progress_updates[-1].get("payload_updates") or {}
+        self.assertIn("bundle_url", payload_update)
+        self.assertEqual(payload_update.get("readiness_stage"), "board-ready")
 
         self.assertEqual(
             result.details["performance"],

--- a/backend/tests/test_semantic_index_service.py
+++ b/backend/tests/test_semantic_index_service.py
@@ -115,10 +115,10 @@ class SemanticIndexServiceTests(unittest.TestCase):
             self.assertEqual(bundle["readiness"]["stage"], "board-ready")
             self.assertEqual(semantic["assets"], {"base_board_glb": "geometry/base_board.glb"})
             self.assertEqual(job["readiness_stage"], "board-ready")
-            self.assertEqual(
-                semantic_visualizer_service.get_status_for_source(project, source_hash)["status"],
-                "building",
-            )
+            source_status = semantic_visualizer_service.get_status_for_source(project, source_hash)
+            self.assertEqual(source_status["status"], "building")
+            self.assertTrue(source_status["available"])
+            self.assertIsNotNone(source_status["bundle_url"])
 
             (geometry / "components.glb").write_bytes(b"components")
             semantic_visualizer_service._publish_partial_bundle(

--- a/frontend/src/components/webgpu-3d-tab.tsx
+++ b/frontend/src/components/webgpu-3d-tab.tsx
@@ -62,6 +62,7 @@ interface WorkflowJob {
     readiness_stage?: string;
     readiness?: WebGpu3dReadiness;
     bundle_url?: string;
+    sourceRevisionKey?: string;
 }
 
 interface GenerateResponse {
@@ -184,6 +185,7 @@ export function WebGpu3dTab({
                     && nextReadinessRevision !== readinessRevisionRef.current
                 ) {
                     readinessRevisionRef.current = nextReadinessRevision;
+                    setViewerRevision((revision) => revision + 1);
                     await refreshStatus();
                 }
                 if (next.status === "completed") {
@@ -314,7 +316,7 @@ export function WebGpu3dTab({
         };
     }, [onClearSelection, onSelection, projectId, status?.sourceRevisionKey, viewerElement]);
 
-    const readiness = status?.readiness;
+    const readiness = job?.readiness ?? status?.readiness;
     const readinessStage = readiness?.stage || (status?.status === "ready" ? "semantic-ready" : "generating");
     const readinessProgress = job?.readiness?.progress ?? readiness?.progress ?? job?.percent ?? 0;
     const stageLabel = {
@@ -323,8 +325,18 @@ export function WebGpu3dTab({
         "semantic-ready": "Semantic scene ready",
         generating: "Generating 3D assets",
     }[readinessStage] || readinessStage;
-    const bundleUrl = status?.bundle_url
-        ? `${status.bundle_url}${status.bundle_url.includes("?") ? "&" : "?"}viewer=${encodeURIComponent(readiness?.revision || status.generated_at || status.sourceRevisionKey)}`
+    const resolvedBundleUrl = status?.bundle_url ?? job?.bundle_url;
+    const canShowViewer = Boolean(
+        resolvedBundleUrl
+        && (
+            status?.available
+            || status?.status === "building"
+            || status?.status === "ready"
+            || Boolean(job?.bundle_url && job?.readiness)
+        ),
+    );
+    const bundleUrl = resolvedBundleUrl
+        ? `${resolvedBundleUrl}${resolvedBundleUrl.includes("?") ? "&" : "?"}viewer=${encodeURIComponent(readiness?.revision || status?.generated_at || status?.sourceRevisionKey || "staged")}`
         : undefined;
 
     if (loading && !status) {
@@ -338,7 +350,7 @@ export function WebGpu3dTab({
         );
     }
 
-    if (!status?.available || !status.bundle_url) {
+    if (!canShowViewer) {
         return (
             <div className="flex h-full items-center justify-center bg-muted/20 p-6">
                 <Card className="w-full max-w-2xl" size="sm">
@@ -411,7 +423,7 @@ export function WebGpu3dTab({
     return (
         <div className="relative h-full min-h-0 overflow-hidden bg-muted/20">
             <prism-semantic-viewer
-                key={`${status.sourceRevisionKey}-${status.generator.build}-${readiness?.revision || viewerRevision}`}
+                key={`${status?.sourceRevisionKey ?? job?.sourceRevisionKey ?? projectId}-${status?.generator?.build ?? "build"}-${readiness?.revision || viewerRevision}`}
                 ref={attachViewer}
                 bundle-url={bundleUrl}
                 workspace={workspace}
@@ -453,7 +465,7 @@ export function WebGpu3dTab({
                     </Button>
                 )}
             </div>
-            {(jobId || status.status === "building") && (
+            {(jobId || status?.status === "building") && (
                 <div className="pointer-events-none absolute bottom-3 left-3 right-3 mx-auto max-w-xl border bg-background/95 p-3 shadow-sm backdrop-blur-sm">
                     <div className="mb-2 flex items-center justify-between gap-3 text-xs">
                         <span className="font-medium text-foreground">{job?.message || stageLabel}</span>


### PR DESCRIPTION
Reconnect V3 job progress and ws_webgpu_ready upserts to partial bundles so the 3D tab can mount before semantic GLTF finishes.