### PR TITLE
Fix remote panel back from component detail

### DIFF
--- a/frontend/src/panel/PanelApp.tsx
+++ b/frontend/src/panel/PanelApp.tsx
@@ -11,20 +11,34 @@ import {
 } from "@/panel/lib/kicad-bridge";
 import { getCategories, isAuthError, setApiToken } from "@/panel/lib/panel-api";
 import type { PanelComponent } from "@/panel/lib/panel-api";
+import type { FinderViewState } from "@/panel/lib/view-state";
 
 import { PanelLoginScreen } from "@/panel/screens/PanelLoginScreen";
 import { SymbolFinderScreen } from "@/panel/screens/SymbolFinderScreen";
 import { CategoryListScreen } from "@/panel/screens/CategoryListScreen";
 import { PartDetailScreen } from "@/panel/screens/PartDetailScreen";
 
+type DetailReturnTarget =
+  | { kind: "finder" }
+  | { kind: "category"; name: string };
+
 type Screen =
   | { kind: "login" }
   | { kind: "finder" }
   | { kind: "category"; name: string }
-  | { kind: "detail"; componentId: string; prefetched: PanelComponent | null };
+  | {
+      kind: "detail";
+      componentId: string;
+      prefetched: PanelComponent | null;
+      returnTo: DetailReturnTarget;
+    };
 
 export function PanelApp() {
   const [screen, setScreen] = useState<Screen>({ kind: "login" });
+  const [finderView, setFinderView] = useState<FinderViewState>({
+    query: "",
+    searchResults: [],
+  });
   const [logEntries, setLogEntries] = useState<string[]>([]);
   const [sessionReady, setSessionReady] = useState(false);
   const [loginLoading, setLoginLoading] = useState(false);
@@ -146,11 +160,38 @@ export function PanelApp() {
     []
   );
 
-  const goToDetail = useCallback(
-    (comp: PanelComponent) =>
-      setScreen({ kind: "detail", componentId: comp.id, prefetched: comp }),
-    []
+  const goToDetailFromFinder = useCallback((comp: PanelComponent) => {
+    setScreen({
+      kind: "detail",
+      componentId: comp.id,
+      prefetched: comp,
+      returnTo: { kind: "finder" },
+    });
+  }, []);
+
+  const goToDetailFromCategory = useCallback(
+    (comp: PanelComponent) => {
+      if (screen.kind !== "category") return;
+      setScreen({
+        kind: "detail",
+        componentId: comp.id,
+        prefetched: comp,
+        returnTo: { kind: "category", name: screen.name },
+      });
+    },
+    [screen]
   );
+
+  const goBackFromDetail = useCallback(() => {
+    setScreen((current) => {
+      if (current.kind !== "detail") return current;
+      const { returnTo } = current;
+      if (returnTo.kind === "category") {
+        return { kind: "category", name: returnTo.name };
+      }
+      return { kind: "finder" };
+    });
+  }, []);
 
   // ─── Render ─────────────────────────────────────────────────────
 
@@ -169,8 +210,10 @@ export function PanelApp() {
 
         {screen.kind === "finder" && (
           <SymbolFinderScreen
+            viewState={finderView}
+            onViewStateChange={setFinderView}
             onSelectCategory={goToCategory}
-            onSelectComponent={goToDetail}
+            onSelectComponent={goToDetailFromFinder}
             onAuthRequired={goToLogin}
             appendLog={appendLog}
           />
@@ -180,7 +223,7 @@ export function PanelApp() {
           <CategoryListScreen
             category={screen.name}
             onBack={goToFinder}
-            onSelectComponent={goToDetail}
+            onSelectComponent={goToDetailFromCategory}
             onAuthRequired={goToLogin}
             appendLog={appendLog}
           />
@@ -190,7 +233,7 @@ export function PanelApp() {
           <PartDetailScreen
             componentId={screen.componentId}
             prefetched={screen.prefetched}
-            onBack={goToFinder}
+            onBack={goBackFromDetail}
             appendLog={appendLog}
           />
         )}

--- a/frontend/src/panel/lib/view-state.ts
+++ b/frontend/src/panel/lib/view-state.ts
@@ -1,0 +1,6 @@
+import type { PanelComponent } from "@/panel/lib/panel-api";
+
+export type FinderViewState = {
+  query: string;
+  searchResults: PanelComponent[];
+};

--- a/frontend/src/panel/screens/SymbolFinderScreen.tsx
+++ b/frontend/src/panel/screens/SymbolFinderScreen.tsx
@@ -12,7 +12,11 @@ import {
   isAuthError,
 } from "@/panel/lib/panel-api";
 
+import type { FinderViewState } from "@/panel/lib/view-state";
+
 interface SymbolFinderScreenProps {
+  viewState: FinderViewState;
+  onViewStateChange: React.Dispatch<React.SetStateAction<FinderViewState>>;
   onSelectCategory: (category: string) => void;
   onSelectComponent: (component: PanelComponent) => void;
   onAuthRequired: () => void;
@@ -36,15 +40,20 @@ function categoryIcon(name: string): string {
 }
 
 export function SymbolFinderScreen({
+  viewState,
+  onViewStateChange,
   onSelectCategory,
   onSelectComponent,
   onAuthRequired,
   appendLog,
 }: SymbolFinderScreenProps) {
+  const { query, searchResults } = viewState;
+  const setQuery = (value: string) =>
+    onViewStateChange((prev) => ({ ...prev, query: value }));
+  const setSearchResults = (items: PanelComponent[]) =>
+    onViewStateChange((prev) => ({ ...prev, searchResults: items }));
   const [categories, setCategories] = useState<PanelCategory[]>([]);
   const [loadingCategories, setLoadingCategories] = useState(true);
-  const [query, setQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<PanelComponent[]>([]);
   const [searching, setSearching] = useState(false);
   const searchAbortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);


### PR DESCRIPTION
## Summary
- Detail back returns to search results (query + results preserved) instead of the finder category home.
- Detail remembers whether it was opened from search or a category list and restores that screen.
- Finder search state is lifted to `PanelApp` so it survives detail navigation.

## Test plan
- [ ] Open Remote Symbol panel, search for a part, open detail, press back — same query and results list.
- [ ] Browse a category, open a part, press back — returns to that category list.
- [ ] Clear search and confirm category grid still shows as before.