### PR TITLE
Fix comparison event listener test types

### DIFF
--- a/frontend/src/components/design-comparison/comparison-presentation-shell.test.tsx
+++ b/frontend/src/components/design-comparison/comparison-presentation-shell.test.tsx
@@ -102,10 +102,10 @@ class FakeEcadViewer extends HTMLElement {
 
     override addEventListener(
         type: string,
-        listener: EventListenerOrEventListenerObject | null,
+        listener: EventListenerOrEventListenerObject,
         options?: boolean | AddEventListenerOptions,
     ): void {
-        if (type === "camerachange" && listener) {
+        if (type === "camerachange") {
             this.cameraListenerCount += 1;
         }
         super.addEventListener(type, listener, options);
@@ -113,10 +113,10 @@ class FakeEcadViewer extends HTMLElement {
 
     override removeEventListener(
         type: string,
-        listener: EventListenerOrEventListenerObject | null,
+        listener: EventListenerOrEventListenerObject,
         options?: boolean | EventListenerOptions,
     ): void {
-        if (type === "camerachange" && listener) {
+        if (type === "camerachange") {
             this.cameraListenerCount -= 1;
         }
         super.removeEventListener(type, listener, options);


### PR DESCRIPTION
## Summary

- align the fake ECAD viewer listener overrides with the DOM event listener contract
- remove redundant nullable-listener guards
- restore clean TypeScript and Docker frontend builds

## Root cause

The test double accepted `null` listeners and then passed that nullable value to the HTMLElement overloads, which TypeScript correctly rejected during a clean build.

## Validation

- `npm test -- src/components/design-comparison/comparison-presentation-shell.test.tsx` (15 tests)
- `npm run build`