### PR TITLE
Add gated validation for dev changes

### DIFF
--- a/.github/workflows/dev-quality-gate.yml
+++ b/.github/workflows/dev-quality-gate.yml
@@ -1,0 +1,184 @@
+name: Dev quality gate
+
+on:
+  pull_request:
+    branches:
+      - dev
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dev-quality-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build application
+        run: npm run build
+
+      - name: Build Remote Symbol Provider panel
+        run: npm run build:panel
+
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: kicad_prism_test
+          POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d kicad_prism_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    defaults:
+      run:
+        working-directory: backend
+
+    env:
+      AUTH_ENABLED: "false"
+      DEV_GUEST_ROLE: admin
+      KICAD_PROJECTS_ROOT: ${{ github.workspace }}/.ci-data/projects
+      PRISM_DATABASE_URL: postgresql://postgres@127.0.0.1:5432/kicad_prism_test
+      TEST_POSTGRES_URL: postgresql://postgres@127.0.0.1:5432/kicad_prism_test
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Compile Python sources
+        run: python -m compileall -q app
+
+      - name: Run backend tests
+        run: python -m unittest discover -s tests -p "test_*.py"
+
+  semantic-viewer:
+    name: Semantic viewer
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: kicad-prism-viewer
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: kicad-prism-viewer/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test glTF conversion
+        run: npm run test:gltf
+
+      - name: Test viewer
+        run: npm run test:viewer
+
+      - name: Build viewer bundles
+        run: npm run build
+
+  deployment-config:
+    name: Deployment configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Validate default Compose configuration
+        run: docker compose --env-file .env.example -f docker-compose.yml config --quiet
+
+      - name: Validate reverse-proxy Compose configuration
+        run: docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.proxy.yml config --quiet
+
+      - name: Prepare load-test configuration
+        run: touch loadtest/.env.loadtest
+
+      - name: Validate load-test Compose configuration
+        run: docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.loadtest.yml config --quiet
+
+      - name: Validate local kicad-monkey Compose configuration
+        run: docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.local-kicad-monkey.yml config --quiet
+
+  quality-gate:
+    name: Quality gate
+    if: ${{ always() }}
+    needs:
+      - frontend
+      - backend
+      - semantic-viewer
+      - deployment-config
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Require every quality job
+        env:
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+          BACKEND_RESULT: ${{ needs.backend.result }}
+          VIEWER_RESULT: ${{ needs.semantic-viewer.result }}
+          DEPLOYMENT_RESULT: ${{ needs.deployment-config.result }}
+        run: |
+          test "$FRONTEND_RESULT" = "success"
+          test "$BACKEND_RESULT" = "success"
+          test "$VIEWER_RESULT" = "success"
+          test "$DEPLOYMENT_RESULT" = "success"


### PR DESCRIPTION
## Summary

- run frontend lint, tests, application build, and Remote Symbol Provider panel build
- run the complete backend test suite against PostgreSQL 17
- test and build the semantic viewer
- validate the supported Docker Compose configurations
- expose one stable `Quality gate` result for branch protection

## Why

The dev branch previously had no pull-request checks and accepted a TypeScript regression that only surfaced during a Docker build. This workflow makes the existing project checks mandatory and cancellable on superseding commits.

## Local validation

- frontend lint: passed
- frontend tests: 93 passed
- frontend application and panel builds: passed
- backend tests: 367 passed, 27 skipped without the optional local PostgreSQL integration environment
- semantic viewer tests: 16 passed
- semantic viewer build: passed
- default, proxy, and local kicad-monkey Compose validation: passed
- workflow YAML parse and whitespace validation: passed