### PR TITLE
Add .gitattributes to force LF checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,44 @@
+# Normalize line endings.
+#
+# Everything in this repository is consumed by Linux containers: scripts are
+# COPY'd into images and executed, and Compose reads .env verbatim. A CRLF
+# checkout breaks the image build with
+#   env: 'bash\r': No such file or directory
+# so the working tree is LF on every platform, including Windows.
+
+* text=auto eol=lf
+
+# Executed inside containers. Never CRLF.
+*.sh text eol=lf
+Dockerfile text eol=lf
+Dockerfile.* text eol=lf
+*.dockerignore text eol=lf
+
+# Read by Compose, Caddy, and nginx at runtime.
+*.yml text eol=lf
+*.yaml text eol=lf
+*.env text eol=lf
+.env.example text eol=lf
+*.conf text eol=lf
+*.conf.example text eol=lf
+Caddyfile text eol=lf
+Caddyfile.* text eol=lf
+
+# Windows-native tooling keeps CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary assets: never touch.
+*.png binary
+*.gif binary
+*.ico binary
+*.wasm binary
+*.dylib binary
+*.so binary
+*.dll binary
+*.woff binary
+*.woff2 binary
+*.pdf binary
+*.zip binary
+*.gz binary


### PR DESCRIPTION
## Problem

`docker compose up -d --build` fails on a Windows workstation at `backend/Dockerfile:83`:

```
env: 'bash\r': No such file or directory
env: use -[v]S to pass options in shebang lines
...did not complete successfully: exit code: 127
```

The repository has no `.gitattributes`, so Git for Windows applies its install default of `core.autocrlf=true` and rewrites `scripts/*.sh` to CRLF on checkout. `backend/Dockerfile:82` COPYs `scripts/build-prism-clipper2.sh` into the image and `:83` executes it, so the shebang arrives as `#!/usr/bin/env bash\r` and `env` looks for a program literally named `bash\r`.

This is not specific to that one script. `backend/Dockerfile:91` copies all of `scripts/`, and `loadtest/Dockerfile` uses `loadtest/entrypoint.sh` as its ENTRYPOINT, so any Windows checkout is affected.

## Fix

Pin the working tree to LF on every platform. Everything tracked here is consumed by Linux containers, so there is no case for CRLF in the checkout.

Also covered:

- `.env.example` and `*.env` — Compose reads `.env` verbatim, and a trailing `\r` silently corrupts `PUBLIC_BASE_URL` and breaks OIDC redirect-URI matching with no diagnostic pointing at line endings.
- `Dockerfile*`, `*.yml`, `Caddyfile*`, `*.conf` — read at build or runtime by Linux tooling.
- `*.bat` / `*.cmd` / `*.ps1` keep CRLF for Windows-native tooling.
- Known binary assets (`*.wasm`, `*.dylib`, `*.png`, ...) are marked `binary` so normalization cannot corrupt them. The tree tracks 5 `.wasm` and 1 `.dylib`.

## Risk

`git add --renormalize .` produces an empty diff — every tracked file is already LF, so this commit changes no file content. It only affects how future checkouts materialize.

## Verification

Existing Windows working trees are not repaired by pulling this, since Git sees the files as unmodified. A renormalized checkout is required:

```
git config core.autocrlf false && git rm --cached -r . && git reset --hard
```

Then `grep -c $'\r' scripts/build-prism-clipper2.sh` returns nothing and the image build proceeds past `Dockerfile:83`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)