### PR TITLE
Treat blank SESSION_COOKIE_SECURE as unset

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,7 +7,7 @@ Configuration can be set via:
 
 See .env.example for available configuration options.
 """
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 from typing import List
 import os
@@ -183,6 +183,20 @@ class Settings(BaseSettings):
             "for any deployment whose PUBLIC_BASE_URL is HTTPS."
         ),
     )
+
+    @field_validator("SESSION_COOKIE_SECURE_OVERRIDE", mode="before")
+    @classmethod
+    def _blank_cookie_secure_is_unset(cls, value: object) -> object:
+        """Treat an empty value as unset so the PUBLIC_BASE_URL default applies.
+
+        docker-compose.yml passes `SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-}`,
+        so an operator who follows .env.example and leaves the setting commented out
+        still gets the variable in the container environment, as "". Without this,
+        pydantic rejects "" as a bool and the backend cannot start at all.
+        """
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
     AUTH_LOGIN_RATE_LIMIT: int = Field(
         default=10,

--- a/backend/tests/test_auth_hardening.py
+++ b/backend/tests/test_auth_hardening.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -78,6 +79,23 @@ class AuthConfigurationFailClosedTests(unittest.TestCase):
         self.assertTrue(
             self._settings(PUBLIC_BASE_URL="http://127.0.0.1:8080", SESSION_COOKIE_SECURE=True).SESSION_COOKIE_SECURE
         )
+
+    def test_blank_cookie_secure_falls_back_to_public_base_url(self) -> None:
+        # docker-compose.yml sends SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-},
+        # so leaving it commented out in .env delivers "" rather than nothing at all.
+        # That used to raise a pydantic bool_parsing error at import time and the
+        # backend never started.
+        self.assertTrue(
+            self._settings(PUBLIC_BASE_URL="https://prism.example.com", SESSION_COOKIE_SECURE="").SESSION_COOKIE_SECURE
+        )
+        self.assertFalse(
+            self._settings(PUBLIC_BASE_URL="http://127.0.0.1:8080", SESSION_COOKIE_SECURE="   ").SESSION_COOKIE_SECURE
+        )
+
+    def test_unparseable_cookie_secure_is_still_rejected(self) -> None:
+        # Only blank is treated as unset. A typo must not quietly become False.
+        with self.assertRaises(ValidationError):
+            self._settings(SESSION_COOKIE_SECURE="ture")
 
     def test_disabled_authentication_reports_no_errors(self) -> None:
         self.assertEqual(Settings(_env_file=None, AUTH_ENABLED=False).auth_configuration_errors(), [])


### PR DESCRIPTION
## Problem

A source-path deployment fails to start the backend, with a bare traceback and no actionable message:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
SESSION_COOKIE_SECURE
  Input should be a valid boolean, unable to interpret input
  [type=bool_parsing, input_value='', input_type=str]
```

The container reports `unhealthy` and `docker compose up --wait` fails.

## Cause

Three pieces disagree:

- `docker-compose.yml:73` passes `SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-}`, so the variable is **always** present in the container environment — as `""` when the operator has not set it.
- `.env.example:70` documents leaving it commented out (`# SESSION_COOKIE_SECURE=true`).
- `config.py:178` declares `SESSION_COOKIE_SECURE_OVERRIDE: bool | None = Field(default=None, ...)` for precisely that case.

Pydantic rejects `""` as a bool before `default=None` can apply, so the documented configuration is the one that crashes. `Settings()` is instantiated at module import (`config.py:658`), so this happens during uvicorn's app import — before `validate_auth_configuration()` gets a chance to print its banner.

`SESSION_COOKIE_SECURE_OVERRIDE` is the only non-string optional setting in `Settings`, so it is the only field affected by the `:-}` pattern; the other 20-odd occurrences land in `str` fields where `""` is valid. `deploy/release/compose.yml` never sets the variable, which is why this reproduces only on the source path.

## Fix

A `mode="before"` validator normalizes blank to `None`, restoring the documented fallback.

| `SESSION_COOKIE_SECURE` | `PUBLIC_BASE_URL` | Result |
| --- | --- | --- |
| `""` | https | `True` (derived) |
| `""` | http | `False` (derived) |
| `true` | http | `True` (explicit wins) |
| `false` | https | `False` (explicit wins) |
| `ture` | any | `ValidationError` |

Only blank is treated as unset. A typo still fails loudly rather than silently becoming `False`, which would ship session cookies without the `Secure` flag.

## Tests

Two regression tests added to `AuthConfigurationFailClosedTests`. Full module passes (24 tests).

## Alternative considered

Changing the Compose line to omit the variable when empty. Rejected: it would leave the same trap for anyone setting the variable to `""` by other means, and the validator fixes the source path and the release path identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)