### PR TITLE
Document the ACME DNS-01 deployment path

### DIFF
--- a/deploy/Caddyfile.dns-01
+++ b/deploy/Caddyfile.dns-01
@@ -1,0 +1,54 @@
+# KiCAD Prism reverse proxy (public ACME, DNS-01 challenge)
+
+# Use this when Prism must be reachable over publicly trusted HTTPS but the
+# host must not accept inbound connections from the internet. DNS-01 proves
+# domain control by publishing a TXT record, so:
+#
+# - ports 80 and 443 never need to be reachable from outside your network;
+# - the A record may resolve to a private address in internal DNS only;
+# - no root CA has to be distributed to KiCad workstations.
+#
+# Requires a Caddy binary with your DNS provider module compiled in. The stock
+# caddy:2 image will not work. See deploy/Dockerfile.caddy-dns.
+#
+# Replace prism.example.com and the provider directive below.
+#
+# See docs/DEPLOYMENT.md.
+
+prism.example.com {
+	tls {
+		# Cloudflare shown as an example. Each caddy-dns module documents its
+		# own directive and arguments; substitute yours. Read credentials from
+		# the environment so they stay out of this file and out of Git.
+		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+
+		# Caddy confirms the TXT record is visible before asking the CA to
+		# validate. Name resolvers that can see the public zone: a split-horizon
+		# corporate resolver may never return the public answer. On a network
+		# that intercepts outbound DNS, these must be resolvers the network
+		# permits, or the propagation check times out.
+		resolvers 1.1.1.1 8.8.8.8
+
+		# Rehearse against the staging CA first. Staging issues untrusted
+		# certificates but has far higher rate limits than production, which
+		# allows only 5 failed validations per hostname per hour.
+		# acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+	}
+
+	encode gzip zstd
+
+	# Large catalog imports and long-running semantic generation
+	request_body {
+		max_size 2GB
+	}
+
+	reverse_proxy frontend:80 {
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+
+		transport http {
+			read_timeout 300s
+			write_timeout 300s
+		}
+	}
+}

--- a/deploy/Dockerfile.caddy-dns
+++ b/deploy/Dockerfile.caddy-dns
@@ -1,0 +1,34 @@
+# Caddy with an ACME DNS-01 provider module compiled in.
+#
+# The official caddy:2 image cannot solve DNS-01 challenges. Caddy's DNS
+# providers are Go modules linked into the binary, not plugins loaded at
+# runtime, so the provider must be chosen at build time.
+#
+#   docker build -f deploy/Dockerfile.caddy-dns \
+#     --build-arg DNS_PROVIDER_MODULE=github.com/caddy-dns/cloudflare \
+#     -t kicad-prism-caddy-dns:2 .
+#
+# Providers live at https://github.com/caddy-dns. Common ones:
+#
+#   Cloudflare    github.com/caddy-dns/cloudflare
+#   Route 53      github.com/caddy-dns/route53
+#   Azure DNS     github.com/caddy-dns/azure
+#   Google Cloud  github.com/caddy-dns/googleclouddns
+#   DigitalOcean  github.com/caddy-dns/digitalocean
+#   deSEC         github.com/caddy-dns/desec
+#
+# Verify the module is present before deploying. An empty result means the
+# build did not link it, and issuance will fail with an unhelpful error:
+#
+#   docker run --rm kicad-prism-caddy-dns:2 caddy list-modules | grep dns.providers
+#
+# See docs/DEPLOYMENT.md.
+
+ARG CADDY_VERSION=2
+
+FROM caddy:${CADDY_VERSION}-builder AS builder
+ARG DNS_PROVIDER_MODULE=github.com/caddy-dns/cloudflare
+RUN xcaddy build --with "${DNS_PROVIDER_MODULE}"
+
+FROM caddy:${CADDY_VERSION}
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/deploy/certs/README.md
+++ b/deploy/certs/README.md
@@ -2,7 +2,8 @@
 
 Tracked examples live one directory up:
 
-- `../Caddyfile` — public ACME / Let's Encrypt
+- `../Caddyfile` — public ACME / Let's Encrypt over HTTP-01
+- `../Caddyfile.dns-01` — public ACME over DNS-01, no inbound exposure needed
 - `../Caddyfile.internal` — custom certificates (reads `/certs/...` in the container)
 - `../nginx-tls.conf.example` — Nginx TLS terminator sketch
 

--- a/deploy/release/Caddyfile.dns-01
+++ b/deploy/release/Caddyfile.dns-01
@@ -1,0 +1,54 @@
+# KiCAD Prism reverse proxy (public ACME, DNS-01 challenge)
+
+# Use this when Prism must be reachable over publicly trusted HTTPS but the
+# host must not accept inbound connections from the internet. DNS-01 proves
+# domain control by publishing a TXT record, so:
+#
+# - ports 80 and 443 never need to be reachable from outside your network;
+# - the A record may resolve to a private address in internal DNS only;
+# - no root CA has to be distributed to KiCad workstations.
+#
+# Requires a Caddy binary with your DNS provider module compiled in. The stock
+# caddy:2 image will not work. See Dockerfile.caddy-dns.
+#
+# Replace prism.example.com and the provider directive below.
+#
+# See the Deployment guide.
+
+prism.example.com {
+	tls {
+		# Cloudflare shown as an example. Each caddy-dns module documents its
+		# own directive and arguments; substitute yours. Read credentials from
+		# the environment so they stay out of this file and out of Git.
+		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+
+		# Caddy confirms the TXT record is visible before asking the CA to
+		# validate. Name resolvers that can see the public zone: a split-horizon
+		# corporate resolver may never return the public answer. On a network
+		# that intercepts outbound DNS, these must be resolvers the network
+		# permits, or the propagation check times out.
+		resolvers 1.1.1.1 8.8.8.8
+
+		# Rehearse against the staging CA first. Staging issues untrusted
+		# certificates but has far higher rate limits than production, which
+		# allows only 5 failed validations per hostname per hour.
+		# acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+	}
+
+	encode gzip zstd
+
+	# Large catalog imports and long-running semantic generation
+	request_body {
+		max_size 2GB
+	}
+
+	reverse_proxy frontend:80 {
+		header_up Host {host}
+		header_up X-Real-IP {remote_host}
+
+		transport http {
+			read_timeout 300s
+			write_timeout 300s
+		}
+	}
+}

--- a/deploy/release/Dockerfile.caddy-dns
+++ b/deploy/release/Dockerfile.caddy-dns
@@ -1,0 +1,34 @@
+# Caddy with an ACME DNS-01 provider module compiled in.
+#
+# The official caddy:2 image cannot solve DNS-01 challenges. Caddy's DNS
+# providers are Go modules linked into the binary, not plugins loaded at
+# runtime, so the provider must be chosen at build time.
+#
+#   docker build -f Dockerfile.caddy-dns \
+#     --build-arg DNS_PROVIDER_MODULE=github.com/caddy-dns/cloudflare \
+#     -t kicad-prism-caddy-dns:2 .
+#
+# Providers live at https://github.com/caddy-dns. Common ones:
+#
+#   Cloudflare    github.com/caddy-dns/cloudflare
+#   Route 53      github.com/caddy-dns/route53
+#   Azure DNS     github.com/caddy-dns/azure
+#   Google Cloud  github.com/caddy-dns/googleclouddns
+#   DigitalOcean  github.com/caddy-dns/digitalocean
+#   deSEC         github.com/caddy-dns/desec
+#
+# Verify the module is present before deploying. An empty result means the
+# build did not link it, and issuance will fail with an unhelpful error:
+#
+#   docker run --rm kicad-prism-caddy-dns:2 caddy list-modules | grep dns.providers
+#
+# See the Deployment guide.
+
+ARG CADDY_VERSION=2
+
+FROM caddy:${CADDY_VERSION}-builder AS builder
+ARG DNS_PROVIDER_MODULE=github.com/caddy-dns/cloudflare
+RUN xcaddy build --with "${DNS_PROVIDER_MODULE}"
+
+FROM caddy:${CADDY_VERSION}
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/deploy/release/README.md
+++ b/deploy/release/README.md
@@ -57,6 +57,11 @@ docker compose --profile proxy up -d --wait
 For an internal CA or custom certificate, replace `Caddyfile` with
 `Caddyfile.internal` and place `prism.crt` and `prism.key` in `certs/`.
 
+For a publicly trusted certificate on a host that must not accept inbound
+connections from the internet, replace `Caddyfile` with `Caddyfile.dns-01`,
+build a proxy image from `Dockerfile.caddy-dns`, and set `PRISM_CADDY_IMAGE`.
+Ports 80 and 443 then stay closed to the internet. See the Deployment guide.
+
 ## Verify
 
 ```bash

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -18,6 +18,8 @@ kicad-prism-vX.Y.Z-linux-amd64.tar.gz
 ├── .env.example
 ├── Caddyfile
 ├── Caddyfile.internal
+├── Caddyfile.dns-01
+├── Dockerfile.caddy-dns
 ├── README.md
 ├── VERSION
 └── SHA256SUMS
@@ -170,6 +172,112 @@ For a private CA or custom certificate:
 2. place `prism.crt` and `prism.key` in `certs/`;
 3. distribute the issuing root CA to browsers and KiCad workstations;
 4. start the same `proxy` profile.
+
+### Public certificates without inbound exposure (ACME DNS-01)
+
+Use this when Prism must present a publicly trusted certificate but the host
+must not accept inbound connections from the internet. The HTTP-01 challenge
+above requires the CA to reach port 80 from outside. DNS-01 instead proves
+domain control by publishing a TXT record, so ports 80 and 443 stay closed to
+the internet, the A record may exist only in internal DNS and resolve to a
+private address, and no root CA has to be distributed to KiCad workstations.
+
+The cost is a DNS credential on the deployment host and a custom proxy image.
+
+#### 1. Build a Caddy image with a DNS provider
+
+The stock `caddy:2` image cannot solve DNS-01. Providers are Go modules linked
+into the binary, not runtime plugins:
+
+```bash
+docker build -f deploy/Dockerfile.caddy-dns \
+  --build-arg DNS_PROVIDER_MODULE=github.com/caddy-dns/cloudflare \
+  -t kicad-prism-caddy-dns:2 .
+docker run --rm kicad-prism-caddy-dns:2 caddy list-modules | grep dns.providers
+```
+
+The `grep` must return a line. Providers are listed at
+<https://github.com/caddy-dns>.
+
+#### 2. Obtain a scoped DNS credential
+
+Request the narrowest credential the provider supports. For Cloudflare that is
+an API token — not the Global API Key — with `Zone / DNS / Edit` on the single
+zone, and IP filtering restricted to the host's egress address.
+
+That credential can still rewrite any record in the zone, including MX and SPF.
+Where the DNS team will not accept that, delegate only the challenge record:
+
+```text
+_acme-challenge.prism.example.com.  CNAME  prism.acme-delegation.example.
+```
+
+The target lives in a separate zone whose credentials are held only by this
+deployment. ACME follows the CNAME, so Caddy needs no access to the main zone.
+This is one static record, created once.
+
+#### 3. Configure and start
+
+Copy `deploy/Caddyfile.dns-01` over `Caddyfile`, set the hostname and provider
+directive, and leave the `acme_ca` staging line commented in for the first run.
+
+Set `PRISM_CADDY_IMAGE=kicad-prism-caddy-dns:2` in `.env`, and pass the
+provider credential to the proxy with a Compose override so the shipped file
+stays untouched:
+
+```yaml
+# docker-compose.dns-01.yml
+services:
+  caddy:
+    environment:
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN in .env}
+```
+
+Check the configuration before starting anything. This resolves the provider
+module and the credential, so it catches a missing module, an unset variable,
+and a malformed token in one step:
+
+```bash
+docker run --rm -e CLOUDFLARE_API_TOKEN \
+  -v "$PWD/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  kicad-prism-caddy-dns:2 caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+```
+
+```bash
+docker compose -f compose.yml -f docker-compose.dns-01.yml --profile proxy up -d --wait
+docker compose -f compose.yml -f docker-compose.dns-01.yml logs -f caddy
+```
+
+Confirm the challenge succeeds against staging, then remove the `acme_ca` line,
+delete the `caddy-data` volume to discard the staging account, and restart. The
+certificate is issued when `/data/caddy/certificates` appears.
+
+#### Operational notes
+
+Egress must reach the ACME directory and the DNS provider API. Both are
+frequently miscategorised by filtering appliances, and the resulting failure is
+misleading: the ACME client reports a TLS verification error against
+`acme-v02.api.letsencrypt.org` rather than a block. Confirm from inside the
+container, not from the host, because container DNS often resolves through a
+different path:
+
+```bash
+docker compose exec caddy nslookup acme-v02.api.letsencrypt.org
+```
+
+An address outside the CA's published ranges means DNS interception. Pinning
+`dns:` on the proxy service works around it; exempting the hostnames from
+filtering is the durable fix, because a pinned resolver breaks silently when
+the host's network changes and the failure only surfaces at renewal.
+
+Every issued certificate is published to Certificate Transparency logs, so the
+hostname becomes publicly enumerable within minutes even though the service is
+internal. Treat that as a decision to record, not a surprise. A wildcard
+certificate hides the label at the cost of concentrating risk in one key.
+
+Renewal is automatic at roughly 30 days remaining and needs no scheduled task,
+but it depends on the DNS credential still being valid. Track the credential's
+expiry alongside the certificate's.
 
 ### Existing reverse proxy
 

--- a/scripts/release_bundle.py
+++ b/scripts/release_bundle.py
@@ -26,6 +26,8 @@ TEMPLATE_FILES = (
     ".env.example",
     "Caddyfile",
     "Caddyfile.internal",
+    "Caddyfile.dns-01",
+    "Dockerfile.caddy-dns",
     "README.md",
 )
 


### PR DESCRIPTION
## Problem

`docs/DEPLOYMENT.md` documented two HTTPS options:

- **Public ACME over HTTP-01** — requires the CA to reach port 80 from the internet.
- **Internal CA** — requires distributing a root certificate to every browser and KiCad workstation.

A deployment that can accept neither (internal-only service, but no appetite for CA distribution) had no documented path, even though Caddy supports one.

## What DNS-01 buys

Domain control is proven by publishing a TXT record instead of serving a file, so:

- ports 80 and 443 never need to be reachable from outside the network;
- the A record can exist only in internal DNS and resolve to a private address;
- browsers trust the certificate with no CA distribution.

## The blocking detail

**The stock `caddy:2` image cannot solve DNS-01.** Caddy links DNS providers into the binary via `xcaddy`; they are not runtime plugins. Nothing in the previous docs hinted at this, and the failure mode is opaque — `caddy validate` reports `module not registered: dns.providers.cloudflare` only if you happen to run it.

## Changes

| File | Purpose |
| --- | --- |
| `deploy/Dockerfile.caddy-dns` | `xcaddy` build parameterised by `DNS_PROVIDER_MODULE`, so any `caddy-dns` provider works |
| `deploy/Caddyfile.dns-01` | DNS-01 site config, Cloudflare as the worked example |
| `deploy/release/*` | Same two files in the release bundle |
| `scripts/release_bundle.py` | Adds both to `TEMPLATE_FILES` |
| `docs/DEPLOYMENT.md` | New subsection under *Configure HTTPS* |
| `deploy/release/README.md`, `deploy/certs/README.md` | Cross-references |

Cloudflare is the example because it is what was deployed against, but the provider is a build argument and the Caddyfile comments point at the provider list.

## Operational notes included

These are the failure modes that were slow to diagnose in practice:

- **Filtering appliances miscategorise the ACME directory and the provider API.** The error surfaces as a TLS verification failure against `acme-v02.api.letsencrypt.org`, which reads as a certificate problem rather than a block. Container DNS frequently resolves through a different path than the host, so testing from the host passes while the container fails — the doc says to test from inside the container.
- **Split-horizon or intercepted resolvers** break Caddy's TXT propagation self-check; hence the explicit `resolvers` directive and a comment explaining when to change it.
- **Certificate Transparency** makes an internal-only hostname publicly enumerable within minutes. Flagged as a decision to record.
- **A zone-wide API token can rewrite MX and SPF**, so CNAME delegation of `_acme-challenge` is documented as the least-privilege alternative.
- **Staging first**, because production allows only 5 failed validations per hostname per hour.

## Verification

- `docker build -f deploy/Dockerfile.caddy-dns --build-arg DNS_PROVIDER_MODULE=github.com/caddy-dns/cloudflare` succeeds.
- `caddy list-modules | grep dns.providers` returns `dns.providers.cloudflare`.
- Both `Caddyfile.dns-01` copies return `Valid configuration` from `caddy validate` against that image.
- `python3 -m unittest scripts.test_release_bundle` passes.

Docs-and-templates only; no runtime code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)