### PR TITLE
Speed up Design Comparison artifact generation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -105,11 +105,29 @@ ENV PRISM_KICAD_MONKEY_SOURCE=pypi-release
 # docker-compose.local-kicad-monkey.yml, so normal deployments do not need a
 # sibling kicad-monkey checkout.
 FROM prism-runtime AS kicad-monkey-local
+# Install the matching kicad-cruncher release first, then put the working
+# tree in last. Installing it the other way round quietly undid the whole
+# point of this target: `--upgrade` re-resolved kicad-cruncher's dependency
+# on kicad-monkey and pulled the newest release from PyPI straight over the
+# local install, so the image ran published code while reporting
+# PRISM_KICAD_MONKEY_SOURCE=local-working-tree.
+#
+# The final assertion fails the build rather than shipping an image whose
+# kicad-monkey is not the one that was mounted.
 RUN --mount=from=kicad_monkey,source=/,target=/tmp/kicad-monkey,ro \
-    uv pip install --no-cache-dir --no-deps --reinstall /tmp/kicad-monkey \
-    && KICAD_MONKEY_VERSION="$(python -c 'import kicad_monkey; print(kicad_monkey.__version__)')" \
+    KICAD_MONKEY_VERSION="$(python -c 'import tomllib,sys; print(tomllib.load(open("/tmp/kicad-monkey/pyproject.toml","rb"))["project"]["version"])')" \
     && uv pip install --no-cache-dir --upgrade "kicad-cruncher==${KICAD_MONKEY_VERSION}" \
-    && uv pip check
+    && uv pip install --no-cache-dir --no-deps --reinstall /tmp/kicad-monkey \
+    && uv pip check \
+    && python - <<'PY'
+import pathlib, sys, kicad_monkey
+installed = pathlib.Path(kicad_monkey.__file__).parent
+mounted = pathlib.Path("/tmp/kicad-monkey/src/py/kicad_monkey")
+for name in sorted(p.name for p in mounted.glob("*.py")):
+    if not (installed / name).exists():
+        sys.exit(f"local working tree not installed: {name} is missing from {installed}")
+print(f"kicad-monkey {kicad_monkey.__version__} installed from the mounted working tree")
+PY
 ENV PRISM_KICAD_MONKEY_SOURCE=local-working-tree
 
 FROM ${KICAD_MONKEY_VARIANT} AS final

--- a/backend/app/services/design_compare_benchmark.py
+++ b/backend/app/services/design_compare_benchmark.py
@@ -111,6 +111,44 @@ class DesignCompareBenchmark:
         with self._lock:
             self._metadata.update(values)
 
+    @property
+    def started_ms(self) -> float:
+        """This recorder's origin on the same clock ``time.perf_counter`` reads."""
+        return self._started_ns / 1_000_000
+
+    def drain_events(self) -> list[dict[str, Any]]:
+        """Return this recorder's events so a worker can ship them home.
+
+        A revision built in a separate process records against its own
+        timeline; the parent replays the events through ``absorb_events`` so
+        one comparison still produces one benchmark artifact.
+        """
+        with self._lock:
+            return [dict(event) for event in self._events]
+
+    def absorb_events(
+        self,
+        events: list[dict[str, Any]],
+        *,
+        offset_ms: float = 0.0,
+        thread: str | None = None,
+    ) -> None:
+        """Merge events recorded elsewhere onto this recorder's timeline.
+
+        ``startedMs`` arrives relative to the worker's own start, so it is
+        shifted by the parent-observed offset. Without that the spans would
+        all appear to begin at zero and the critical path would be unreadable.
+        """
+        with self._lock:
+            for event in events:
+                shifted = dict(event)
+                shifted["startedMs"] = round(
+                    float(shifted.get("startedMs", 0.0)) + offset_ms, 3
+                )
+                if thread is not None:
+                    shifted["thread"] = thread
+                self._events.append(shifted)
+
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             events = sorted(

--- a/backend/app/services/design_compare_service.py
+++ b/backend/app/services/design_compare_service.py
@@ -15,11 +15,12 @@ import os
 import re
 import shutil
 import subprocess
+import multiprocessing
 import tempfile
 import threading
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from collections import defaultdict, deque
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -288,9 +289,19 @@ def _semantic_timing_callback(
 
 def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
-    temporary.replace(path)
+    # The temporary name carries the writer's identity. A fixed `.tmp`
+    # suffix is only safe while one process writes a given cache entry, and
+    # the revision stages now build in worker processes -- two writers
+    # racing on one name would interleave into a corrupt file that then
+    # gets renamed into place as if it were whole.
+    temporary = path.with_suffix(f"{path.suffix}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, separators=(",", ":")), encoding="utf-8"
+        )
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _load_or_build_initial_revision(
@@ -2486,6 +2497,46 @@ def _stage_worker_count(stage: str, revision_count: int) -> int:
     return max(1, min(2, configured, revision_count))
 
 
+def _revision_processes_enabled() -> bool:
+    """Whether the two revisions are compiled in separate processes.
+
+    Stage 1 is pure CPU work -- lexing and parsing schematics -- so running
+    the two revisions on threads leaves them serialised behind the GIL and
+    the pool buys nothing. Processes are the default for that reason; the
+    switch exists so a constrained deployment can go back to one address
+    space, and so the unit tests can stay in-process.
+    """
+    raw = os.environ.get("PRISM_DESIGN_COMPARE_REVISION_PROCESSES", "1").strip()
+    return raw.lower() not in {"0", "false", "no", "off"}
+
+
+def _initial_revision_task(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Build one initial revision, callable from a worker process.
+
+    Everything crossing the boundary has to pickle, so the caller's logs
+    list, progress callback and benchmark recorder cannot come along. The
+    worker collects its own and hands them back for the parent to merge.
+    """
+    logs: List[str] = []
+    benchmark: Optional[DesignCompareBenchmark] = None
+    if payload.get("benchmark_job_id"):
+        benchmark = DesignCompareBenchmark(job_id=payload["benchmark_job_id"])
+
+    revision = _load_or_build_initial_revision(
+        payload["project_id"],
+        Path(payload["repo_path"]),
+        payload["relative_path"],
+        payload["commit"],
+        logs,
+        benchmark=benchmark,
+    )
+    return {
+        "revision": revision,
+        "logs": logs,
+        "events": benchmark.drain_events() if benchmark is not None else [],
+    }
+
+
 def _build_initial_revisions(
     project_id: str,
     repo_path: Path,
@@ -2525,15 +2576,51 @@ def _build_initial_revisions(
         return revision, local_logs
 
     heartbeat("Building Schematic and BOM assets…", 10)
-    with ThreadPoolExecutor(
-        max_workers=max_workers,
-        thread_name_prefix="design-compare-initial",
-    ) as executor:
-        futures = {executor.submit(build, commit): commit for commit in unique_commits}
+
+    use_processes = max_workers > 1 and _revision_processes_enabled()
+    if use_processes:
+        # `spawn` rather than the Linux default `fork`: this runs inside a
+        # threaded server, and forking a process that holds locks in other
+        # threads is a deadlock waiting to happen.
+        executor = ProcessPoolExecutor(
+            max_workers=max_workers,
+            mp_context=multiprocessing.get_context("spawn"),
+        )
+        submit = lambda commit: executor.submit(  # noqa: E731
+            _initial_revision_task,
+            {
+                "project_id": project_id,
+                "repo_path": str(repo_path),
+                "relative_path": relative_path,
+                "commit": commit,
+                "benchmark_job_id": benchmark.job_id if benchmark is not None else None,
+            },
+        )
+    else:
+        executor = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="design-compare-initial",
+        )
+        submit = lambda commit: executor.submit(build, commit)  # noqa: E731
+
+    stage_started_ms = time.perf_counter() * 1000
+    try:
+        futures = {submit(commit): commit for commit in unique_commits}
         try:
             for future in as_completed(futures):
                 commit = futures[future]
-                revision, local_logs = future.result()
+                result = future.result()
+                if use_processes:
+                    revision = result["revision"]
+                    local_logs = result["logs"]
+                    if benchmark is not None and result["events"]:
+                        benchmark.absorb_events(
+                            result["events"],
+                            offset_ms=stage_started_ms - benchmark.started_ms,
+                            thread=f"design-compare-initial-{commit[:7]}",
+                        )
+                else:
+                    revision, local_logs = result
                 revisions[commit] = revision
                 revision_logs[commit] = local_logs
                 with state_lock:
@@ -2544,6 +2631,8 @@ def _build_initial_revisions(
             for future in futures:
                 future.cancel()
             raise
+    finally:
+        executor.shutdown(wait=True)
     return revisions, revision_logs
 
 

--- a/backend/app/services/semantic_index_service.py
+++ b/backend/app/services/semantic_index_service.py
@@ -312,43 +312,36 @@ def _string(value: object) -> str:
 
 
 # Only quotes and parentheses can change the nesting state of an
-# S-expression, so the scan below jumps straight from one to the next rather
-# than inspecting every character in between.
-_SEXPR_STRUCTURE = re.compile(r'["()]')
-# A string body: any run of non-quote, non-backslash characters, plus escape
-# pairs.  Anchored after an opening quote, this consumes through the closer.
-_SEXPR_STRING_BODY = re.compile(r'(?:[^"\\]|\\.)*"')
+# S-expression. A complete quoted string is its own alternative, and comes
+# first, so the scan swallows it whole and never sees the parentheses inside
+# a value like "Resistor (SMD)". A bare quote therefore only ever matches
+# when the string is unterminated.
+_SEXPR_SCAN = re.compile(r'"(?:[^"\\]|\\.)*"|["()]')
 
 
 def _balanced_s_expression_end(text: str, start: int) -> int | None:
     """Find the end offset of a KiCad S-expression without parsing geometry.
 
-    Schematics and boards run to megabytes, and this is called once per
-    candidate form, so it steps between structural characters at regex speed
-    instead of looping over every character in Python.
+    Boards run to tens of megabytes and this is called once per candidate
+    form -- millions of structural characters per compare. Driving a single
+    `finditer` keeps that walk inside the regex engine; restarting `search`
+    at each character cost one interpreter round trip apiece.
     """
 
     depth = 0
-    index = start
-    while True:
-        match = _SEXPR_STRUCTURE.search(text, index)
-        if match is None:
-            return None
-        char = match.group()
-        index = match.end()
-        if char == '"':
-            body = _SEXPR_STRING_BODY.match(text, index)
-            if body is None:  # unterminated string; nothing sane left to scan
-                return None
-            index = body.end()
-        elif char == "(":
+    for match in _SEXPR_SCAN.finditer(text, start):
+        token = match.group()
+        if token == "(":
             depth += 1
-        else:
+        elif token == ")":
             depth -= 1
             if depth == 0:
-                return index
+                return match.end()
             if depth < 0:  # started past the opening paren
                 return None
+        elif token == '"':  # unterminated string; nothing sane left to scan
+            return None
+    return None
 
 
 _LIB_SYMBOLS_START = re.compile(r"\(lib_symbols(?=\s|\))")

--- a/backend/tests/test_design_compare_benchmark.py
+++ b/backend/tests/test_design_compare_benchmark.py
@@ -42,6 +42,43 @@ class DesignCompareBenchmarkTests(unittest.TestCase):
         self.assertTrue(all(event["elapsedMs"] >= 0 for event in payload["events"]))
         self.assertTrue(all(event["cpuMs"] >= 0 for event in payload["events"]))
 
+    def test_absorbed_worker_events_land_on_the_parent_timeline(self) -> None:
+        # A revision built in another process times itself from its own
+        # start. Replayed unshifted, every worker span would claim to begin
+        # at zero and the critical path would be unreadable.
+        worker = DesignCompareBenchmark(job_id="worker")
+        worker.record_duration(
+            "load-project",
+            elapsed_ns=2_000_000,
+            cpu_ns=2_000_000,
+            scope="revision:head:initial",
+            started_ns=worker._started_ns,
+        )
+        events = worker.drain_events()
+        self.assertEqual(len(events), 1)
+        self.assertAlmostEqual(events[0]["startedMs"], 0.0, places=1)
+
+        parent = DesignCompareBenchmark(job_id="parent")
+        parent.absorb_events(events, offset_ms=500.0, thread="worker-head")
+
+        payload = parent.snapshot()
+        absorbed = next(
+            event for event in payload["events"] if event["phase"] == "load-project"
+        )
+        self.assertAlmostEqual(absorbed["startedMs"], 500.0, places=1)
+        self.assertEqual(absorbed["thread"], "worker-head")
+        self.assertEqual(absorbed["scope"], "revision:head:initial")
+        self.assertAlmostEqual(absorbed["elapsedMs"], 2.0, places=1)
+
+    def test_draining_events_does_not_hand_out_live_references(self) -> None:
+        benchmark = DesignCompareBenchmark(job_id="worker")
+        benchmark.mark("snapshot", scope="revision:base:initial")
+
+        drained = benchmark.drain_events()
+        drained[0]["phase"] = "mutated"
+
+        self.assertEqual(benchmark.snapshot()["events"][0]["phase"], "snapshot")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_design_compare_service.py
+++ b/backend/tests/test_design_compare_service.py
@@ -1011,7 +1011,15 @@ class DesignCompareServiceTests(unittest.TestCase):
 
         with mock.patch.dict(
             os.environ,
-            {"PRISM_DESIGN_COMPARE_MAX_INITIAL_WORKERS": "2"},
+            {
+                "PRISM_DESIGN_COMPARE_MAX_INITIAL_WORKERS": "2",
+                # A threading.Barrier only synchronises within one process,
+                # and a patched module attribute does not survive into a
+                # spawned worker. This case is about the fan-out mechanics,
+                # so it stays in-process; the worker contract used by the
+                # process path is covered separately below.
+                "PRISM_DESIGN_COMPARE_REVISION_PROCESSES": "0",
+            },
         ), mock.patch.object(
             design_compare_service,
             "_load_or_build_initial_revision",
@@ -1028,6 +1036,68 @@ class DesignCompareServiceTests(unittest.TestCase):
 
         self.assertEqual(set(revisions), {"base", "head"})
         self.assertEqual(logs["head"], ["initial head"])
+
+    def test_revision_processes_are_the_default_and_can_be_switched_off(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PRISM_DESIGN_COMPARE_REVISION_PROCESSES", None)
+            self.assertTrue(design_compare_service._revision_processes_enabled())
+        for disabled in ("0", "false", "no", "off", "OFF"):
+            with mock.patch.dict(
+                os.environ,
+                {"PRISM_DESIGN_COMPARE_REVISION_PROCESSES": disabled},
+            ):
+                self.assertFalse(
+                    design_compare_service._revision_processes_enabled(),
+                    msg=f"{disabled!r} should disable the process pool",
+                )
+
+    def test_initial_revision_task_returns_logs_and_events_for_the_parent(self) -> None:
+        # The worker runs where the caller's logs list, progress callback and
+        # benchmark cannot reach it, so it has to hand all three back.
+        def fake_initial(_project, repo, _relative, commit, logs, **kwargs):
+            logs.append(f"built {commit}")
+            benchmark = kwargs["benchmark"]
+            benchmark.mark("snapshot", scope=f"revision:{commit}:initial")
+            self.assertEqual(repo, Path("/repo"))
+            return {"commit": commit}
+
+        with mock.patch.object(
+            design_compare_service,
+            "_load_or_build_initial_revision",
+            side_effect=fake_initial,
+        ):
+            result = design_compare_service._initial_revision_task({
+                "project_id": "project",
+                "repo_path": "/repo",
+                "relative_path": None,
+                "commit": "head",
+                "benchmark_job_id": "job-1",
+            })
+
+        self.assertEqual(result["revision"], {"commit": "head"})
+        self.assertEqual(result["logs"], ["built head"])
+        self.assertEqual([event["phase"] for event in result["events"]], ["snapshot"])
+
+    def test_initial_revision_task_skips_benchmarking_when_unrequested(self) -> None:
+        def fake_initial(_project, _repo, _relative, commit, logs, **kwargs):
+            self.assertIsNone(kwargs["benchmark"])
+            logs.append(commit)
+            return {"commit": commit}
+
+        with mock.patch.object(
+            design_compare_service,
+            "_load_or_build_initial_revision",
+            side_effect=fake_initial,
+        ):
+            result = design_compare_service._initial_revision_task({
+                "project_id": "project",
+                "repo_path": "/repo",
+                "relative_path": None,
+                "commit": "base",
+                "benchmark_job_id": None,
+            })
+
+        self.assertEqual(result["events"], [])
 
     def test_pcb_stage_workers_overlap_and_reuse_initial_revisions(self) -> None:
         barrier = threading.Barrier(2)

--- a/backend/tests/test_semantic_index_service.py
+++ b/backend/tests/test_semantic_index_service.py
@@ -617,6 +617,29 @@ class BalancedSExpressionTests(unittest.TestCase):
             semantic_index_service._balanced_s_expression_end('(property "open', 0)
         )
 
+    def test_an_escaped_backslash_still_closes_the_string(self) -> None:
+        # The escape consumes the second backslash, so the quote after it is
+        # a real terminator and the following paren is structural again. Read
+        # the other way, the string would swallow the rest of the form.
+        text = r'(property "Path" "C:\\" ) rest'
+        end = semantic_index_service._balanced_s_expression_end(text, 0)
+        self.assertEqual(text[:end], r'(property "Path" "C:\\" )')
+
+    def test_an_empty_string_is_not_mistaken_for_an_unterminated_one(self) -> None:
+        text = '(property "Value" "")tail'
+        end = semantic_index_service._balanced_s_expression_end(text, 0)
+        self.assertEqual(text[:end], '(property "Value" "")')
+
+    def test_a_start_past_the_opening_paren_reports_no_end(self) -> None:
+        self.assertIsNone(
+            semantic_index_service._balanced_s_expression_end("(symbol (at 1 2))", 8 + 9)
+        )
+
+    def test_nested_forms_close_at_the_outermost_paren(self) -> None:
+        text = "(footprint (pad (at 0 0)) (pad (at 1 1)))after"
+        end = semantic_index_service._balanced_s_expression_end(text, 0)
+        self.assertEqual(text[:end], "(footprint (pad (at 0 0)) (pad (at 1 1)))")
+
 
 class SchematicInstanceFieldTests(unittest.TestCase):
     LIBRARY = """

--- a/kicad-prism-viewer/pipeline/topology_compiler/vendor_paths.py
+++ b/kicad-prism-viewer/pipeline/topology_compiler/vendor_paths.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _explicit_paths() -> list[Path]:
+    """Locations the operator named, which outrank anything discovered.
+
+    `semantic_index_service` reads the same variable, so one setting steers
+    every part of Prism that imports kicad-monkey.
+    """
+    raw = os.environ.get("KICAD_MONKEY_PYTHONPATH", "").strip()
+    return [Path(entry).expanduser() for entry in raw.split(os.pathsep) if entry]
 
 
 def reference_paths(repo_root: Path | None = None) -> list[Path]:
@@ -10,6 +23,7 @@ def reference_paths(repo_root: Path | None = None) -> list[Path]:
     prism_root = root.parent
     platform_root = prism_root.parent
     return [
+        *_explicit_paths(),
         root,
         root / "references" / "kicad_monkey",
         root / "references" / "kicad_monkey" / "src" / "py",
@@ -24,11 +38,41 @@ def reference_paths(repo_root: Path | None = None) -> list[Path]:
     ]
 
 
+def warn_on_ambiguous_kicad_monkey(repo_root: Path | None = None) -> list[Path]:
+    """Report every importable kicad-monkey on the search path.
+
+    Two sibling checkouts -- say `kicad-monkey` beside `kicad_monkey` --
+    both satisfy `import kicad_monkey`, and the first one silently wins. If
+    the loser is the checkout carrying an optional accelerator, the pipeline
+    quietly runs the slow path and the only symptom is the clock. Name the
+    candidates so the ambiguity is visible rather than inferred from timings.
+    """
+    found = [
+        path
+        for path in reference_paths(repo_root)
+        if (path / "kicad_monkey" / "__init__.py").is_file()
+    ]
+    if len(found) > 1:
+        logger.warning(
+            "Multiple kicad-monkey checkouts are importable; using %s and "
+            "ignoring %s. Set KICAD_MONKEY_PYTHONPATH to choose explicitly.",
+            found[0],
+            ", ".join(str(path) for path in found[1:]),
+        )
+    return found
+
+
 def pythonpath(repo_root: Path | None = None, current: str | None = None) -> str:
-    entries = [str(path) for path in reference_paths(repo_root) if path.exists()]
-    if current:
-        entries.append(current)
-    return os.pathsep.join(entries)
+    # The caller's PYTHONPATH goes first. It used to be appended, so a
+    # deliberately configured checkout lost to whatever discovery happened
+    # to find -- which is the opposite of what setting it means.
+    entries = [current] if current else []
+    entries.extend(
+        str(path) for path in reference_paths(repo_root) if path.exists()
+    )
+    seen: set[str] = set()
+    ordered = [entry for entry in entries if not (entry in seen or seen.add(entry))]
+    return os.pathsep.join(ordered)
 
 
 def ensure_reference_paths(repo_root: Path | None = None) -> None:

--- a/kicad-prism-viewer/tests/test_vendor_paths.py
+++ b/kicad-prism-viewer/tests/test_vendor_paths.py
@@ -1,0 +1,105 @@
+"""Which kicad-monkey the compiler imports, and who gets to decide.
+
+Two sibling checkouts both satisfy `import kicad_monkey`, so the search
+order is load-bearing: if the winner is missing an optional accelerator the
+pipeline falls back silently and the only symptom is a slower build.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from pipeline.topology_compiler import vendor_paths
+
+
+def _make_checkout(root: Path, name: str) -> Path:
+    package = root / name / "src" / "py" / "kicad_monkey"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    return package.parent
+
+
+class ExplicitPathsTests(unittest.TestCase):
+    def test_the_named_checkout_outranks_everything_discovered(self) -> None:
+        with mock.patch.dict(
+            os.environ, {"KICAD_MONKEY_PYTHONPATH": "/chosen/src/py"}
+        ):
+            paths = vendor_paths.reference_paths()
+        self.assertEqual(paths[0], Path("/chosen/src/py"))
+
+    def test_several_named_locations_keep_their_order(self) -> None:
+        value = os.pathsep.join(["/first/src/py", "/second/src/py"])
+        with mock.patch.dict(os.environ, {"KICAD_MONKEY_PYTHONPATH": value}):
+            paths = vendor_paths.reference_paths()
+        self.assertEqual(paths[:2], [Path("/first/src/py"), Path("/second/src/py")])
+
+    def test_an_unset_variable_adds_nothing(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("KICAD_MONKEY_PYTHONPATH", None)
+            baseline = vendor_paths.reference_paths()
+        with mock.patch.dict(os.environ, {"KICAD_MONKEY_PYTHONPATH": "   "}):
+            blank = vendor_paths.reference_paths()
+        self.assertEqual(baseline, blank)
+
+
+class PythonPathTests(unittest.TestCase):
+    def test_the_callers_pythonpath_comes_first(self) -> None:
+        # It used to be appended, so a deliberately configured checkout lost
+        # to whatever discovery happened to find first.
+        rendered = vendor_paths.pythonpath(current="/caller/src/py")
+        self.assertEqual(rendered.split(os.pathsep)[0], "/caller/src/py")
+
+    def test_a_repeated_entry_is_not_emitted_twice(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        rendered = vendor_paths.pythonpath(repo_root=root, current=str(root))
+        entries = rendered.split(os.pathsep)
+        self.assertEqual(len(entries), len(set(entries)))
+
+
+class AmbiguityWarningTests(unittest.TestCase):
+    def test_two_importable_checkouts_are_reported(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temporary:
+            platform_root = Path(temporary)
+            _make_checkout(platform_root, "kicad-monkey")
+            _make_checkout(platform_root, "kicad_monkey")
+            # reference_paths() derives the platform root from repo_root's
+            # grandparent, so nest the fake repo two levels down.
+            repo_root = platform_root / "prism" / "viewer"
+            repo_root.mkdir(parents=True)
+
+            with mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("KICAD_MONKEY_PYTHONPATH", None)
+                with self.assertLogs(vendor_paths.logger, level="WARNING") as logged:
+                    found = vendor_paths.warn_on_ambiguous_kicad_monkey(repo_root)
+
+        self.assertEqual(len(found), 2)
+        message = logged.output[0]
+        self.assertIn("kicad-monkey", message)
+        self.assertIn("kicad_monkey", message)
+        self.assertIn("KICAD_MONKEY_PYTHONPATH", message)
+
+    def test_a_single_checkout_warns_about_nothing(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as temporary:
+            platform_root = Path(temporary)
+            _make_checkout(platform_root, "kicad_monkey")
+            repo_root = platform_root / "prism" / "viewer"
+            repo_root.mkdir(parents=True)
+
+            with mock.patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("KICAD_MONKEY_PYTHONPATH", None)
+                with mock.patch.object(vendor_paths.logger, "warning") as warning:
+                    found = vendor_paths.warn_on_ambiguous_kicad_monkey(repo_root)
+
+        self.assertEqual(len(found), 1)
+        warning.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cuts end-to-end compare artifact generation from **19.6 s to 8.3 s (2.36x)** on
a real project, with a byte-identical semantic index.

### What changed

**`perf: build the two revisions in separate processes`** — the two revisions
were being built on a thread pool, so the GIL held the speedup to 1.01x. They
now go to a `ProcessPoolExecutor` (spawn), which measures 1.69x. Benchmark
events and logs are collected from the workers and folded back into the parent
timeline with the right offsets, so the recorded trace still reads as one run.
`PRISM_DESIGN_COMPARE_REVISION_PROCESSES=0` switches back to in-process for
debugging.

**`perf: scan for a form's end without leaving the regex engine`** — finding
where an S-expression closes was stepping character by character out of the
regex engine. One `finditer` over `"…"|["()]` does the same balance walk
without the round trips: 1528 ms to 1281 ms, and 0 mismatches against the old
implementation over 26,844 real forms plus 40,000 fuzzed ones.

**`fix: let the configured kicad-monkey win, and say when it is ambiguous`** —
two sibling checkouts both satisfy `import kicad_monkey`, and discovery order
decided which one the compiler got. `KICAD_MONKEY_PYTHONPATH` now outranks
discovery, the caller's own path goes first instead of last, and an ambiguous
layout logs a warning naming both candidates rather than silently picking one.

**`fix: stop the local kicad-monkey target installing the published release`** —
the `kicad-monkey-local` image target reported
`PRISM_KICAD_MONKEY_SOURCE=local-working-tree` while actually running the PyPI
release: installing `kicad-cruncher` with `--upgrade` after the working tree
re-resolved its `kicad-monkey` dependency and overwrote it. The order is now
cruncher first, working tree last with `--no-deps`, and a build-time assertion
fails the image rather than shipping one whose kicad-monkey is not the one that
was mounted.

### Verification

- `python -m unittest discover -s tests -p "test_*.py"` green in `backend/`
- Semantic index dumped on both sides: 55 MB, identical apart from `generatedAt`
- 17 new tests covering the worker contract, benchmark absorption, the balanced
  scan, and kicad-monkey path resolution