### PR TITLE
Stop pinning kicad-cruncher to the local kicad-monkey version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -105,18 +105,23 @@ ENV PRISM_KICAD_MONKEY_SOURCE=pypi-release
 # docker-compose.local-kicad-monkey.yml, so normal deployments do not need a
 # sibling kicad-monkey checkout.
 FROM prism-runtime AS kicad-monkey-local
-# Install the matching kicad-cruncher release first, then put the working
-# tree in last. Installing it the other way round quietly undid the whole
-# point of this target: `--upgrade` re-resolved kicad-cruncher's dependency
-# on kicad-monkey and pulled the newest release from PyPI straight over the
-# local install, so the image ran published code while reporting
+# Install kicad-cruncher first, then put the working tree in last. Installing
+# it the other way round quietly undid the whole point of this target:
+# `--upgrade` re-resolved kicad-cruncher's dependency on kicad-monkey and
+# pulled the newest release from PyPI straight over the local install, so the
+# image ran published code while reporting
 # PRISM_KICAD_MONKEY_SOURCE=local-working-tree.
+#
+# kicad-cruncher is deliberately unpinned. The two packages share a date-based
+# scheme but not a release cadence — kicad-monkey 2026.7.28 shipped with no
+# matching cruncher — so asking for the working tree's own version resolves to
+# nothing and fails the build. cruncher depends on `kicad-monkey>=`, and the
+# `uv pip check` below is what actually proves the mounted tree satisfies it.
 #
 # The final assertion fails the build rather than shipping an image whose
 # kicad-monkey is not the one that was mounted.
 RUN --mount=from=kicad_monkey,source=/,target=/tmp/kicad-monkey,ro \
-    KICAD_MONKEY_VERSION="$(python -c 'import tomllib,sys; print(tomllib.load(open("/tmp/kicad-monkey/pyproject.toml","rb"))["project"]["version"])')" \
-    && uv pip install --no-cache-dir --upgrade "kicad-cruncher==${KICAD_MONKEY_VERSION}" \
+    uv pip install --no-cache-dir --upgrade kicad-cruncher \
     && uv pip install --no-cache-dir --no-deps --reinstall /tmp/kicad-monkey \
     && uv pip check \
     && python - <<'PY'

--- a/docs/PUBLIC_DEMO_PLAN.md
+++ b/docs/PUBLIC_DEMO_PLAN.md
@@ -1,0 +1,681 @@
+# Public Demo Plan (demo.<your-domain>)
+
+Plan for hosting a public, no-login KiCAD Prism instance showing a curated corpus
+of open-source KiCad projects.
+
+Audience: someone who has never deployed a public site before. Every command is
+meant to be run in order.
+
+---
+
+## 0. Reality check on the hosting constraint
+
+You asked for "cheap compute that charges by usage/traffic rather than time".
+For most web apps that means serverless (Cloudflare Workers, Vercel functions,
+AWS Lambda). **Prism cannot run there**, and it is worth being explicit about why
+before picking a host:
+
+| Prism requirement | Why serverless fails |
+|---|---|
+| Backend image is ~3 GB (built **on top of** the `kicad/kicad` image, which ships the full KiCad binary + libraries) | Lambda caps at 10 GB but cold-starts badly; Workers cap at a few MB |
+| Invokes `kicad-cli` as a subprocess | No arbitrary native binaries in most serverless runtimes |
+| PostgreSQL 17 with four schemas (`workspace`, `comments`, `catalog`, `operations`) | Needs a persistent database, billed separately |
+| Cloned Git repos + generated artifacts on a **read-write filesystem** under `/app/projects` | Serverless filesystems are ephemeral; Prism expects durable disk |
+| Long-running background jobs (`prism-worker`, `catalog-worker`) | Request-scoped execution model, hard timeouts |
+
+So the honest options are: **a small always-on VM** (charges by time, but the
+absolute number is tiny), or **a scale-to-zero container host** (charges closer
+to per-use, but with caveats). Recommendation and comparison in §2.
+
+### The single most important cost decision
+
+Prism's expensive work is *artifact generation*: the semantic index, WebGPU 3D
+assets, iBOM, thumbnails, and design-comparison caches. For a **read-only
+demo, none of that has to happen on the server.**
+
+Generate everything locally on your Mac, then ship the finished `data/` directory
+to the server. The public host then only serves pre-computed files, which means:
+
+- no `prism-worker` / `catalog-worker` containers in production
+- ~2 vCPU / 4 GB instead of the 24 GB of memory limits the dev compose file allows
+- visitors physically cannot trigger a compute bill
+
+This is the difference between a ~$6/mo demo and a ~$50/mo demo. Everything
+below assumes this "pre-baked corpus" model.
+
+---
+
+## 1. Corpus: open-source KiCad projects
+
+Selection criteria: genuinely KiCad-native (not an Altium export), complex enough
+to show off hierarchical schematics and dense layout, permissively licensed, and
+exercising a *different* Prism feature from the others.
+
+### Tier 1 — the core demo set
+
+| Project | Source | Size | Why it earns its slot |
+|---|---|---|---|
+| **USB-PD Trigger Board** | `github.com/krishna-swaroop/USB-PD-Trigger-Board` | 41 MB | Yours. Already has a release tag (`A.1.0.0`), hierarchical subsheets, a 3D model, and iBOM committed. Best "guided tour" project because you can explain every design decision. |
+| **Antmicro Jetson Orin Nano Baseboard** | `github.com/antmicro/jetson-orin-baseboard` | 1.28 GB | The showpiece. High-speed SoM carrier, very dense, deep sheet hierarchy. Antmicro maintains it *in* KiCad, Apache-licensed. |
+| **Antmicro Kria K26 Devboard** | `github.com/antmicro/kria-k26-devboard` | 521 MB | Xilinx UltraScale+ SoM carrier. Second flavour of the same class, good for showing the component catalog finding shared parts across projects. |
+| **MNT Reform** | `source.mnt.re/reform/reform` | large | **A true monorepo: 7 separate PCBs** (motherboard, keyboard, OLED, trackball, trackball sensor, trackpad, battery). This is the one project that demonstrates Prism's multi-board monorepo import, which nothing else here does. Also a GitLab remote, proving Prism isn't GitHub-only. |
+| **Glasgow Interface Explorer** | `github.com/GlasgowEmbedded/glasgow` | 55 MB | 2.1k stars, 0BSD, genuinely famous in this community, and *small*. Best cost-to-credibility ratio in the list. |
+
+### Tier 2 — add if you want more breadth
+
+| Project | Source | Size | Note |
+|---|---|---|---|
+| Antmicro CM4 Baseboard | `github.com/antmicro/cm4-baseboard` | 429 MB | KiCad 9.x, clean modern project |
+| Antmicro COM Express 7 Baseboard | `github.com/antmicro/com-express-7-baseboard` | 577 MB | Dense, lots of high-speed differential routing |
+| Antmicro Jetson AGX Thor Baseboard | `github.com/antmicro/jetson-agx-thor-baseboard` | 153 MB | Newest silicon in the list; good "we're current" signal |
+| Cynthion | `github.com/greatscottgadgets/cynthion-hardware` | 38 MB | CERN-OHL-P, USB test instrument, compact |
+| System76 Launch Keyboard | `github.com/system76/launch` | 27 MB | GPL-3.0, commercially shipped product, very different design domain |
+| OrangeCrab | `github.com/orangecrab-fpga/orangecrab-hardware` | small | Greg Davill, ECP5 + DDR3L in a Feather footprint. Impressive density-per-square-inch. |
+| ThunderScope | `github.com/EEVengers/ThunderScope` | 1.17 GB | MIT, 4-channel PCIe scope. Analog + high-speed digital mix. Large — clone shallow if disk is tight. |
+| Olimex A64-OLinuXino | `github.com/OLIMEX/OLINUXINO` | large | Featured on kicad.org; note it's a big multi-product monorepo, so import only the `HARDWARE/A64-OLinuXino` subtree. |
+
+### On your two other suggestions
+
+- **Lukas Henkel / Open Visions Technology (Pi.MX8, Jet-SoM 8MP, the Linux
+  smartwatch).** These are excellent, ambitious designs and he is a great name to
+  associate with — but **the Pi.MX8 is designed in Altium Designer.** The
+  published files are Altium data with a KiCad import promised but, as far as I
+  can find, not delivered. Don't build the demo around this. If you want him
+  represented, email him first and ask whether a KiCad export exists; a native
+  KiCad version of that SiP/HDI work would be a fantastic addition precisely
+  because it's HDI, which almost nothing else open-source is.
+- **Wavenumber Engineering.** I could not find public open-source KiCad
+  repositories for them. The only concrete trace is a KiCon North America 2025
+  talk, "From Altium to KiCad and everything in between", about migrating a
+  professional workflow with 20+ years of legacy projects into KiCad. That's a
+  *relationship* worth having (they're exactly your target user) but not a corpus
+  source today. Worth reaching out to about the talk rather than scraping.
+
+### Deliberately excluded
+
+- `antmicro/hardware-components` — **14 GB.** It's a component library, not a
+  board project, and it would dominate your disk. You already have it cloned
+  locally; use it to seed the Library Manager if you want, but don't import it as
+  a project.
+- `opulo-inc/lumenpnp` — 3.7 GB, and most of that is mechanical CAD, not PCB.
+
+### Disk budget
+
+Tier 1 alone is roughly **2 GB of Git data**, and Prism's generated artifacts
+(semantic index, WebGPU 3D, previews, design-compare cache) will add on the order
+of 2–4× that. **Provision at least 80 GB and expect to use 20–40 GB.** Tier 1 +
+Tier 2 pushes toward 60–80 GB used, so size up to 160 GB if you take everything.
+
+### Licence hygiene
+
+Every project above is open-source, but "open" is not "do anything". Before
+publishing, add a `LICENSE`/attribution line to each project's demo landing
+copy. Specifically: CERN-OHL-S (Pi.MX8, if it ever lands) is *strongly*
+reciprocal, CERN-OHL-P (Cynthion) is permissive, GPL-3.0 (System76 Launch)
+covers the design files. You are only *displaying* them, which is fine, but
+crediting the designer by name next to their board is both correct and good
+manners — and it is the thing most likely to make those designers amplify your
+demo rather than resent it.
+
+---
+
+## 2. Where to host
+
+### Option A — Small x86 VM (recommended)
+
+**Hetzner Cloud CPX31**: 4 AMD vCPU, 8 GB RAM, 160 GB NVMe, ~20 TB/mo traffic
+included at EU locations. Roughly **€16–17/mo** — but note Hetzner adjusted
+prices in 2026 (a further adjustment took effect 15 June 2026), so **check
+current pricing before committing.**
+
+If the pre-baked model works as intended, the cheaper **CPX21** (3 vCPU, 4 GB,
+80 GB) at roughly €8/mo is likely sufficient for Tier 1. Start there; resizing up
+on Hetzner is a 2-minute reboot.
+
+Why this wins:
+- **Traffic is effectively free** at 20 TB. Your demo will use single-digit GB.
+  This satisfies the spirit of "charges by traffic" better than metered hosts do,
+  because the traffic bill is simply zero.
+- **x86 matters.** Your `.env` currently targets
+  `KICAD_BASE_IMAGE=kicad/kicad:10.0.4-arm64-local` — a base image you built
+  yourself on Apple Silicon, which does not exist in any registry. On an x86 host
+  you switch to the upstream multi-arch `kicad/kicad:10.0.0` and it just works.
+  On an ARM host you would have to recompile KiCad from source on the server
+  (see `kicad-docker/.kicad-native-arm64/`), which is a multi-hour build.
+- Everything you already have — `docker-compose.yml`, `deploy/Caddyfile` — runs
+  unchanged.
+
+Equivalent alternatives: DigitalOcean ($24/mo for 4 GB, 4 TB transfer), Vultr,
+Linode. All ~2–3× Hetzner for the same specs.
+
+### Option B — Scale-to-zero container host
+
+**Fly.io** with `auto_stop_machines`. Genuinely closest to "pay per traffic":
+compute stops when nobody is visiting, ~$0.0027/hr for the smallest shared-CPU
+machine.
+
+Caveats you must know before choosing this:
+- **Volumes bill even when the machine is stopped** — $0.15/GB/mo. A 40 GB volume
+  is $6/mo *before any compute*, which already matches a whole Hetzner box.
+- Fly's free tier ended in 2026.
+- Cold start on a 3 GB image is not 1–3 seconds; expect **20–60 s** for the first
+  visitor after idle. For a demo you're linking from a talk or a README, the
+  first person to click gets a blank page. That's a bad first impression.
+- Still needs managed Postgres (Fly Postgres, or Neon/Supabase free tier).
+
+**Google Cloud Run** is the other real option here (per-request billing, up to
+32 GB RAM, scales to zero, and its startup-CPU-boost helps). But Cloud Run has no
+persistent writable disk — you'd need GCS via FUSE or Filestore, which is a
+meaningful rearchitecture of how Prism stores `data/projects`. Not worth it for a
+demo.
+
+**Verdict:** Option B costs about the same as Option A, adds cold-start pain, and
+requires more work. Choose it only if traffic is genuinely spiky and rare.
+
+### Option C — Free
+
+**Oracle Cloud Always Free** ARM Ampere: 4 OCPU, 24 GB RAM, 200 GB, 10 TB/mo
+egress, free indefinitely. Tempting, and the specs are absurd for free.
+
+But: it's **ARM**, so you inherit the KiCad-from-source build problem above;
+capacity is frequently unavailable in popular regions; and Oracle reclaims idle
+free instances. Don't put a demo you're showing to industry people on it.
+
+### Recommendation
+
+**Hetzner CPX21 or CPX31 (x86, EU) + Cloudflare in front (free tier).**
+Cloudflare gives you DNS, caching, DDoS protection, and analytics at no cost, and
+caching matters here: the large static artifacts (3D assets, iBOM, images) get
+served from Cloudflare's edge rather than your origin, which keeps a small box
+responsive under a traffic spike from Hacker News or a conference talk.
+
+Budget: **~€8–17/mo server + ~$10/yr domain.**
+
+---
+
+## 3. Step-by-step: from nothing to a live demo
+
+### Step 1 — Buy the domain (~$10–12/yr)
+
+Registrar: **Cloudflare Registrar** (sells at wholesale cost, no markup, no
+upsells, free WHOIS privacy) or **Porkbun** (similar pricing, nicer UI, can
+register TLDs Cloudflare won't).
+
+Name suggestions, in order of preference:
+- `kicadprism.com` — clearest
+- `prism-ecad.com` / `prismecad.com` — safer if you ever want distance from the
+  KiCad trademark
+- `kicadprism.dev` — `.dev` is HSTS-preloaded, so browsers *force* HTTPS. Nice
+  security property, and cheap.
+
+> **Trademark note:** "KiCad" is a registered trademark of the KiCad project.
+> Using it in a domain for a third-party commercial product is the kind of thing
+> worth a short, friendly email to the KiCad team before you buy — they are
+> approachable, and you're already in that community via KiCon. Getting an
+> explicit "fine by us" costs you one email and removes a real future headache.
+
+You'll serve the demo from a subdomain: `demo.kicadprism.com`.
+
+### Step 2 — Point the domain at Cloudflare
+
+1. Create a free account at `cloudflare.com`.
+2. "Add a site", enter your domain.
+3. Cloudflare gives you two nameservers. If you bought at Cloudflare Registrar
+   this is already done. At Porkbun, paste them into the domain's nameserver
+   settings.
+4. Wait for propagation (minutes to a few hours). Cloudflare emails you.
+
+### Step 3 — Create the server
+
+1. Sign up at `hetzner.com/cloud`, create a project.
+2. **Add your SSH key first** (Security → SSH keys). On your Mac:
+   ```bash
+   ssh-keygen -t ed25519 -C "hetzner-prism-demo"
+   ```
+   Press Enter for the default path, set a passphrase. Then paste the contents of
+   `~/.ssh/id_ed25519.pub` into Hetzner.
+
+   > This is your *personal* key for logging into the server. It is unrelated to
+   > the Git deploy key Prism manages at `data/ssh/` — don't reuse it there.
+3. Create a server: Location **Nuremberg or Helsinki** (cheapest traffic),
+   Image **Ubuntu 24.04**, Type **CPX21** (shared vCPU / AMD), your SSH key,
+   and enable **Backups** (+20%, worth it).
+4. Note the public IPv4 address.
+
+### Step 4 — First login and basic hardening
+
+```bash
+ssh root@<SERVER_IP>
+```
+
+```bash
+apt update && apt upgrade -y
+adduser prism
+usermod -aG sudo prism
+rsync --archive --chown=prism:prism ~/.ssh /home/prism
+```
+
+Lock down SSH — edit `/etc/ssh/sshd_config` and set:
+
+```
+PermitRootLogin no
+PasswordAuthentication no
+```
+
+```bash
+systemctl restart ssh
+```
+
+Firewall — only SSH and HTTP(S):
+
+```bash
+ufw allow OpenSSH
+ufw allow 80
+ufw allow 443
+ufw --force enable
+```
+
+Unattended security updates:
+
+```bash
+apt install -y unattended-upgrades
+dpkg-reconfigure -plow unattended-upgrades
+```
+
+Now reconnect as the non-root user and confirm it works before closing the root
+session:
+
+```bash
+ssh prism@<SERVER_IP>
+```
+
+### Step 5 — Install Docker
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker prism
+```
+
+Log out and back in for the group change to apply, then verify:
+
+```bash
+docker run --rm hello-world
+```
+
+### Step 6 — DNS record
+
+In Cloudflare → your domain → DNS → Add record:
+
+- Type **A**, Name **demo**, IPv4 **<SERVER_IP>**
+- Proxy status: **Proxied** (orange cloud) — this is what gives you caching,
+  DDoS protection, and analytics
+
+Then SSL/TLS → Overview → set encryption mode to **Full (strict)**.
+
+> Ordering matters: Caddy needs to solve an ACME challenge to get its
+> certificate, and Cloudflare's proxy can interfere. Easiest path is to set the
+> record to **DNS only** (grey cloud) first, let Caddy issue the cert in Step 8,
+> confirm HTTPS works, *then* switch to Proxied.
+
+### Step 7 — Deploy the code
+
+```bash
+cd /opt
+sudo git clone https://github.com/krishna-swaroop/KiCAD-Prism.git prism
+sudo chown -R prism:prism prism
+cd prism
+cp .env.example .env
+```
+
+Edit `.env`. The demo-critical values (see §4 for the full rationale — **do not
+skip that section, the defaults are unsafe for public hosting**):
+
+```env
+# --- Platform: switch off the local ARM base image ---
+KICAD_BASE_IMAGE=kicad/kicad:10.0.0
+KICAD_BASE_PLATFORM=linux/amd64
+DOCKER_PLATFORM=linux/amd64
+
+# --- Public, no-login demo ---
+AUTH_ENABLED=false
+DEV_GUEST_ROLE=viewer          # CRITICAL: default is 'admin'
+DEV_MODE=false
+
+WORKSPACE_NAME=KiCAD Prism — Public Demo
+PUBLIC_BASE_URL=https://demo.kicadprism.com
+CORS_ORIGINS_STR=https://demo.kicadprism.com
+
+# --- Keep heavy features off; artifacts are pre-baked ---
+CATALOG_KLC_ENABLED=false
+CATALOG_RETENTION_ENABLED=true
+
+# --- Postgres ---
+POSTGRES_PASSWORD=<generate a long random string>
+
+# --- Not used in guest mode, but must not be a placeholder ---
+SESSION_SECRET=<generate with the command below>
+GITHUB_TOKEN=
+```
+
+Generate secrets:
+
+```bash
+python3 -c 'import secrets; print(secrets.token_urlsafe(48))'
+```
+
+### Step 8 — TLS via Caddy
+
+You already have `deploy/Caddyfile`. Point it at the real hostname:
+
+```
+demo.kicadprism.com {
+    reverse_proxy frontend:8080
+}
+```
+
+Caddy obtains and renews a Let's Encrypt certificate automatically. Bring the
+stack up with the proxy overlay:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d --build
+```
+
+The first build compiles the frontend and installs the Python environment on top
+of the KiCad image — **expect 15–30 minutes** on a shared-vCPU box. Watch it:
+
+```bash
+docker compose logs -f
+```
+
+Then confirm the origin is healthy and HTTPS is live:
+
+```bash
+curl -I https://demo.kicadprism.com
+```
+
+Once that returns `200`, go back to Cloudflare and flip the DNS record to
+**Proxied**.
+
+### Step 9 — Load the corpus
+
+Do the imports **locally on your Mac first**, where you have CPU to spare and an
+admin session, then copy the finished data up. Locally, with `DEV_GUEST_ROLE=admin`:
+
+1. Import each Tier 1 project through the UI.
+2. For each one, generate every artifact the demo needs: semantic index,
+   WebGPU 3D, thumbnail, iBOM.
+3. For MNT Reform, use the monorepo import path so all 7 boards appear.
+4. Pre-compute the diffs and design comparisons you plan to show, so the results
+   are already cached (see §4.3 — visitors won't be able to trigger these).
+5. Click through the whole demo yourself and confirm nothing shows a spinner that
+   never resolves.
+
+Then ship it:
+
+```bash
+# from your Mac, in KiCAD-Prism/
+docker compose stop
+tar -czf prism-demo-data.tar.gz data/projects
+rsync -avP prism-demo-data.tar.gz prism@<SERVER_IP>:/opt/prism/
+```
+
+```bash
+# on the server
+cd /opt/prism
+docker compose stop backend
+tar -xzf prism-demo-data.tar.gz
+docker compose up -d
+docker compose restart frontend   # refresh Nginx's DNS for the backend container
+```
+
+Also dump and restore Postgres, or the database won't know about the projects you
+just copied:
+
+```bash
+# Mac
+docker compose exec postgres pg_dump -U postgres kicad_prism > prism-demo.sql
+rsync -avP prism-demo.sql prism@<SERVER_IP>:/opt/prism/
+# server
+docker compose exec -T postgres psql -U postgres kicad_prism < prism-demo.sql
+```
+
+### Step 10 — Analytics
+
+**Cloudflare Web Analytics** (free) is the right default:
+- Dashboard → Analytics → Web Analytics → add your hostname
+- It gives you pageviews, visitors, referrers, countries, and Core Web Vitals
+- **No cookies, no client-side fingerprinting** → under GDPR you do not need a
+  consent banner, which matters because your audience is heavily European
+
+You also get request counts, bandwidth, cache hit ratio, and threat blocks for
+free in the main Cloudflare dashboard, with no code change at all.
+
+If you later want per-project funnel data ("which board do people open? do they
+reach the 3D view?"), self-host **Umami** or **Plausible** as one extra container
+— both are cookieless and roughly 200 MB of RAM. Skip until you actually need it.
+
+### Step 11 — Guard against surprise bills and abuse
+
+1. **Hetzner** → set a traffic alert. Traffic beyond the included 20 TB is billed
+   per TB, so know before it happens.
+2. **Cloudflare** → Security → WAF → add a rate limiting rule: more than
+   ~100 requests/minute from one IP to `/api/*` gets blocked. The free tier
+   includes one rate-limiting rule; this is the single highest-value use of it,
+   because it is your backstop for §4.3.
+3. **Cloudflare** → Caching → set a Cache Rule so the large immutable artifacts
+   (3D assets, iBOM HTML, preview images) are cached at the edge. This is what
+   keeps a €8 box alive during a traffic spike.
+4. **Uptime monitoring**: a free UptimeRobot or Better Stack check on
+   `https://demo.kicadprism.com` so you find out before your audience does.
+
+---
+
+## 4. Changes needed on Prism's side
+
+Prism already has a guest mode (`AUTH_ENABLED=false`), so this is *mostly*
+configuration. But the current defaults are actively unsafe for public hosting,
+and read-only mode breaks two headline features. Details below, roughly in
+priority order.
+
+### 4.1 CRITICAL: guest mode currently grants **admin**, not viewer
+
+`backend/app/core/config.py:219`:
+
+```python
+DEV_GUEST_ROLE: str = Field(
+    default="admin",
+    description="Role granted to the implicit guest user when AUTH_ENABLED is false."
+)
+```
+
+and `docker-compose.yml` passes it straight through:
+
+```yaml
+- DEV_GUEST_ROLE=${DEV_GUEST_ROLE:-admin}
+```
+
+So `AUTH_ENABLED=false` on a public host, with no other changes, gives **every
+anonymous visitor on the internet full admin rights.** Concretely, a visitor
+could:
+
+- `DELETE /api/projects/{id}` — delete any project
+- `POST /api/projects/import` — make your server clone arbitrary Git URLs
+- `POST /api/settings/ssh-key/generate` — destroy and regenerate the server's Git
+  deploy key (the whole `settings` router is admin-guarded via
+  `APIRouter(dependencies=[Depends(require_admin)])`, which is correct — but
+  "admin" is exactly what a guest is by default)
+- `GET /api/settings/access/users` — read every stored user email
+- `PUT /api/settings/access/users/{email}` — rewrite RBAC
+- `POST /api/projects/{id}/workflows` — run KiCad jobsets on your machine
+
+**Fix:** set `DEV_GUEST_ROLE=viewer` in `.env`. This is mandatory.
+
+**Recommended hardening beyond the demo**, because this is a footgun that will
+eventually catch someone: make the *safe* value the default. Change the default
+to `viewer`, and have `validate_auth_configuration()` in
+`backend/app/main.py` refuse to start when `AUTH_ENABLED=false` **and**
+`DEV_GUEST_ROLE` resolves to `admin` **and** the server is not bound to
+localhost. The codebase already has exactly this instinct elsewhere — incomplete
+OIDC config is a hard startup failure rather than a silent auth bypass
+(`config.py:563`), and there's already a loud warning banner at `main.py:166`.
+Anonymous-admin deserves the same treatment.
+
+### 4.2 `viewer` breaks two features you probably want in the demo
+
+Audited guards on the mutating endpoints:
+
+| Feature | Endpoint | Guard | Works as guest viewer? |
+|---|---|---|---|
+| Visual SCH/PCB/BOM diff | `POST /api/projects/{id}/diff` | `require_designer` | **No** |
+| Design comparison | `POST /api/projects/{id}/design-compare` | `require_viewer` | Yes |
+| Trigger jobset workflow | `POST /api/projects/{id}/workflows` | `require_designer` | No (good) |
+| Generate semantic index | `POST /api/projects/{id}/semantic-index/generate` | `require_designer` | No (good) |
+| Generate WebGPU 3D | `POST /api/projects/{id}/webgpu-3d/generate` | `require_designer` | No (good) |
+| Sync repo from remote | `POST /api/projects/{id}/sync` | `require_designer` | No (good) |
+| Create/reply comment | `POST /api/projects/{id}/comments` | `require_designer` | No |
+| Delete project | `DELETE /api/projects/{id}` | `require_designer` | No (good) |
+| Folder create/move/delete | `folders.py` | `require_designer` | No (good) |
+
+The problem: **visual diff is designer-gated**, and it's one of the most
+compelling things Prism does. Two ways to handle it:
+
+- **Simplest (do this first):** pre-compute diffs locally for a few interesting
+  commit pairs so the cached results render, and deep-link to them from your demo
+  landing copy. Your own USB-PD board already has a tag (`A.1.0.0`) and a commit
+  history to diff against.
+- **Better long-term:** introduce an explicit `PRISM_DEMO_MODE=true` flag that
+  relaxes *read-only-but-expensive* operations for viewers while keeping all
+  destructive operations designer-gated. Implement it as a dedicated dependency
+  (e.g. `require_designer_or_demo`) applied only to `POST .../diff`, so the
+  permission widening is visible at each call site rather than hidden in role
+  resolution. Do **not** solve this by promoting guests to `designer` — that
+  would hand them project deletion, repo import, and jobset execution.
+
+Comments being read-only is fine, and arguably desirable: the visualizer
+commenting UI isn't shipped in the current release anyway, and public write
+access to comments is a spam magnet.
+
+### 4.3 Endpoints that are viewer-guarded but expensive — the real abuse surface
+
+These are reachable by anonymous visitors once `DEV_GUEST_ROLE=viewer`, and they
+are the ones that can cost you money or take the box down:
+
+1. **`POST /api/projects/{id}/design-compare` (`require_viewer`)** — kicks off a
+   heavy multi-worker comparison job (`PRISM_DESIGN_COMPARE_MAX_*_WORKERS`).
+   Anonymous, unauthenticated, unrate-limited, and repeatable in a loop. This is
+   the most serious issue after §4.1. Mitigate by: pre-warming the revision cache
+   (`PRISM_DESIGN_COMPARE_CACHE`) for the pairs you demo, adding a demo-mode
+   check that serves only cached comparisons and returns `429`/`503` for
+   uncached requests, and the Cloudflare rate-limit rule from Step 11.
+
+2. **`POST /api/projects/{id}/design-compare/debug-log` (`require_viewer`)** —
+   accepts up to 128 KB per event and appends to a file on disk. It's a debugging
+   aid with rotation, but it is an anonymous write primitive. **Disable it
+   entirely when `PRISM_DEMO_MODE=true`.**
+
+3. **`POST /api/jobs/{job_id}/cancel` (`require_viewer`)** — any visitor can
+   cancel any other visitor's running job, since all guests share one identity.
+   Low severity but it will produce confusing demo behaviour. Scope cancellation
+   to jobs the caller started, or disable in demo mode.
+
+Note that Prism's existing `rate_limit_service` is wired into the *login* and
+*OAuth* paths only (`auth.py:104`, `oauth.py:26`) — not the job-creating
+endpoints. Extending it to cover design-compare is the natural fix, and reuses
+`rate_limit_service.client_fingerprint(request)` which already exists.
+
+### 4.4 Production compose overlay
+
+Add a `docker-compose.demo.yml` overlay that:
+
+- **omits `catalog-worker` and `prism-worker`** entirely (artifacts are pre-baked;
+  their default limits of 8 GB and 12 GB of memory are why you'd otherwise need a
+  much bigger server)
+- **removes the `ports:` mapping on `backend`** — right now `docker-compose.yml`
+  publishes `8000:8000`, which on a public host exposes the API directly,
+  bypassing the frontend proxy, Caddy, TLS, and Cloudflare. Only Caddy should be
+  reachable from outside. `ufw` in Step 4 blocks this at the firewall too, but
+  Docker has a habit of writing its own iptables rules — fix it in compose, don't
+  rely on the firewall.
+- mounts `./data/projects` **read-only** (`:ro`) if you can confirm nothing writes
+  at request time. Verify first: the design-compare cache and debug log both write
+  under this tree, so this depends on §4.3 being done.
+- sets `UVICORN_WORKERS=2` and modest `PRISM_BACKEND_CPU_LIMIT` /
+  `PRISM_BACKEND_MEMORY_LIMIT` to match the small box.
+
+### 4.5 Frontend touches
+
+- `frontend/src/App.tsx:246-254` already branches on `user.email === 'guest@local'`,
+  so the plumbing for a guest-specific UI exists. Extend it to hide the Settings
+  and access-control navigation for viewers, so guests don't click through to a
+  wall of `403`s.
+- Add a persistent demo banner: "Public read-only demo — [what Prism is] —
+  [request a trial]". This is your conversion path; don't ship the demo without
+  it.
+- Hide or disable "Import repository", "Sync", and "New folder" for viewers
+  rather than letting them fail. A greyed-out control with a tooltip ("disabled
+  in the public demo") reads as intentional; a `403` toast reads as broken.
+- Add a short per-project description and attribution line naming the original
+  designer and licence (see §1). Prism already supports project display names and
+  descriptions (`PUT /api/projects/{id}/description`), so this needs no new
+  backend work.
+
+### 4.6 Pre-launch checklist
+
+Run through this against the live public URL before sharing the link:
+
+```bash
+# All of these MUST return 403
+curl -X DELETE https://demo.kicadprism.com/api/projects/<some-id>
+curl -X POST https://demo.kicadprism.com/api/projects/import
+curl -X POST https://demo.kicadprism.com/api/settings/ssh-key/generate \
+     -H 'Content-Type: application/json' -d '{"email":"x@y.z"}'
+curl https://demo.kicadprism.com/api/settings/access/users
+curl -X POST https://demo.kicadprism.com/api/projects/<id>/workflows
+
+# This MUST fail to connect (backend not publicly exposed)
+curl --max-time 5 http://<SERVER_IP>:8000/api/projects
+```
+
+Also confirm: `GITHUB_TOKEN` is empty in the deployed `.env`; `data/ssh/` contains
+no private key you care about; `docker compose logs backend | head -40` shows the
+guest-mode warning with role `viewer`, not `admin`.
+
+---
+
+## 5. Ongoing cost and effort
+
+| Item | Cost |
+|---|---|
+| Hetzner CPX21 (3 vCPU, 4 GB, 80 GB) | ~€8/mo |
+| Hetzner backups | +20% (~€1.60/mo) |
+| Domain (.com via Cloudflare Registrar) | ~$10/yr |
+| Cloudflare (DNS, CDN, WAF, Web Analytics) | Free |
+| TLS (Let's Encrypt via Caddy) | Free |
+| **Total** | **~€10/mo + $10/yr** |
+
+Verify Hetzner's current pricing at checkout — there were adjustments during 2026.
+
+Maintenance: `unattended-upgrades` handles OS patches. Refreshing the corpus is a
+manual `git pull` + regenerate + re-ship cycle (Step 9); quarterly is plenty. If
+that becomes tedious, script it as a GitHub Action that rebuilds the data bundle
+and rsyncs it — you already have a self-hosted runner checked out in
+`../actions-runner/`.
+
+---
+
+## 6. Suggested order of work
+
+1. §4.1 — set `DEV_GUEST_ROLE=viewer`, and fix the unsafe default upstream
+2. §4.3 — neutralise the anonymous design-compare and debug-log endpoints
+3. §4.4 — write `docker-compose.demo.yml` (drop workers, unpublish port 8000)
+4. Test the whole thing **locally** with `DEV_GUEST_ROLE=viewer` and confirm the
+   demo is still compelling with everything a viewer can't do removed
+5. §4.5 — frontend banner, hidden admin nav, attributions
+6. Buy the domain, create the server, deploy (§3)
+7. Import Tier 1 locally, pre-bake artifacts, ship the bundle
+8. §4.6 — run the pre-launch checklist against the public URL
+9. Announce
+
+Step 4 is the one people skip. Do it before you spend money on a server: it's
+where you find out whether a read-only Prism is a good demo, and if it isn't,
+you'll want to know that before provisioning anything.

--- a/docs/ROADMAP_COMPETITIVE_ANALYSIS.md
+++ b/docs/ROADMAP_COMPETITIVE_ANALYSIS.md
@@ -1,0 +1,735 @@
+# Competitive analysis and feature roadmap
+
+Assessment of KiCAD Prism (`dev`, heading to V3.0.0 alpha) against the
+commercial ECAD collaboration stacks that hardware teams migrate away from,
+plus a proposed feature roadmap.
+
+Scope note: simulation workflows (SPICE, SI/PI, thermal, EMC) are deliberately
+excluded throughout. Rule checking (ERC/DRC/DFM) is *not* simulation and is
+treated as in-scope.
+
+Accuracy note: the Prism inventory below is read from this repository. The
+Altium and Siemens descriptions are from product knowledge and may lag current
+packaging and naming — verify specific SKU claims before using them in
+customer-facing material.
+
+---
+
+## 1. What Prism ships today
+
+Read from the `dev` branch, not from marketing copy.
+
+### Project workspace
+- Git-native import over SSH/HTTPS, including monorepos with multiple boards
+  (`project_import_service.py`, `POST /api/projects/analyze` → `/import`).
+- Queued sync, branch/commit pinning, folder tree organisation, project
+  properties, thumbnails, global project search.
+- Import hardening: host allow-lists, rejection of local paths, embedded
+  credentials, and dangerous remote-helper transports.
+
+### Review surface
+- Schematic, PCB, WebGPU 3D, engineering BOM, stackup, assembly, iBOM viewers.
+- Semantic index with cross-probing between schematic ↔ PCB ↔ BOM identities.
+- History browser, release tags, commit-pinned links.
+- **Design Comparison**: semantic diff over `components` and `nets` categories
+  with added/removed/changed classification, geometry-backed change markers,
+  side-by-side and synchronised presentation, camera sync, BOM delta panel,
+  stackup panel, PCB layer panel, and commit-pinned discussions
+  (`design_compare_service.py`, `frontend/src/components/design-comparison/`).
+- Comments with class, severity, resolution, replies, area/object markers,
+  stored mentions, and export to `.comments/comments.json`.
+
+### Component governance (Library Manager)
+- `open → in_progress → qa_review → done → released` lifecycle with archival.
+- Immutable revisions, content-hashed assets, manifest hashing, audit log with
+  a verification endpoint (`/components/{id}/audit/verify`).
+- Two-person rule: release requires an approver distinct from the revision
+  author.
+- Configurable metadata field registry, grid preferences, bulk edit, CSV
+  import/export, batch apply with field-level approval.
+- Import Center: folder-root discovery, project harvest, remediation grid,
+  bulk accept, proposal CSV round-trip.
+- KLC validation with `off` / `warn` / `block` release gates and durable report
+  artifacts.
+- Where-used (`/components/{id}/usage`), revision compare, review and release
+  history, previews.
+- KiCad DBL bundle export and the Remote Symbol Provider (OAuth2) for desktop
+  placement of released, place-ready parts.
+- CSV stock sync (`/stock/sync-csv`).
+
+### Platform
+- FastAPI backend, two worker pools, PostgreSQL, React frontend.
+- Durable job system with events, logs, artifacts, cancellation, artifact-key
+  caching, and benchmark metrics.
+- OIDC SSO, server-side sessions, session revocation, five roles, scoped
+  service clients, rate limiting on auth paths, security headers.
+- Job kinds: `design_compare`, `webgpu_3d`, `kicad_workflow`, `semantic_index`,
+  `project_analyze`, `project_import`, `project_sync`, `project_thumbnail`,
+  plus catalog jobs.
+
+### Stated boundaries (from `docs/OVERVIEW.md`)
+Single workspace; one role per user; project-scoped standard comments; mentions
+stored but not delivered; no webhooks or PR status integration; fixed workflow
+types (`design`, `manufacturing`, `render`, `webgpu_3d`) rather than arbitrary
+workflows; no real-time co-editing; no in-product approved/changes-requested
+state.
+
+---
+
+## 2. Parity assessment
+
+Legend: **Ahead** — Prism is better than the commercial tools. **Parity** —
+close enough that a migrating team will not feel a loss. **Partial** — the
+capability exists but is materially thinner. **Missing** — not present.
+
+### 2.1 Versus Altium (Designer + Altium 365 / Enterprise Server)
+
+| Capability | Altium | Prism | Verdict |
+|---|---|---|---|
+| Version control of design source | Git/SVN bolted into the client; the vault is the real system of record | Git *is* the system of record; server-managed checkouts, branch/commit pinning | **Ahead** |
+| Web viewer for schematic/PCB/3D | Altium 365 Web Viewer | Full viewer set + WebGPU 3D | **Parity** |
+| Design comparison | Basic project/document compare; historical revision compare in the workspace | Semantic component/net diff with geometry markers, BOM delta, stackup delta, synchronised views | **Ahead** |
+| Comments and markup on the web | Comments, @mentions, task assignment, notifications | Comments with severity/class/markers; mentions stored but **not delivered** | **Partial** |
+| Managed components with lifecycle | Item/revision model, lifecycle states, HRID, parameter templates | Immutable revisions, 5-stage lifecycle, metadata field registry, two-person release, KLC gates, audit verification | **Parity** (Prism arguably ahead on audit rigour) |
+| Component supply-chain data | ActiveBOM + Octopart/Nexar: live price, stock, lifecycle, alternates, BOM risk | CSV stock sync only | **Missing** |
+| Where-used / impact analysis | Yes, workspace-wide | `/components/{id}/usage` | **Partial** |
+| Design release / item revision | Formal release of an item revision with packaged fab/assembly data and lifecycle transition | Assets from jobsets; no release record, no binding of package to approval | **Missing** |
+| ECO / change management | Lifecycle transitions + workspace approvals | None | **Missing** |
+| Assembly variants | Variant manager, variant-aware BOM/outputs | None | **Missing** |
+| ERC / DRC as review evidence | In-client, plus rule sets in the workspace | None — no `kicad-cli sch erc` / `pcb drc` anywhere in the codebase | **Missing** |
+| Manufacturing handoff | Manufacturing Portal, shareable package links to fabs/CMs | Assets portal, internal only | **Missing** |
+| MCAD collaboration | CoDesign with SolidWorks/Inventor/Creo/Fusion | None | **Missing** |
+| Requirements traceability | Requirements & Systems Portal | None | **Missing** |
+| Multi-board / harness | Multi-board projects, harness design | Monorepo import; no inter-board connectivity model | **Partial** |
+| Draftsman-style drawings | Draftsman documents | Whatever the jobset emits | **Partial** |
+| PLM connectors | Arena, Duro, OpenBOM, others | Scoped read-only service clients (build-your-own) | **Partial** |
+| SSO, roles, audit | Enterprise SSO, granular workspace permissions | OIDC, 5 non-composable roles | **Partial** |
+| Self-hosting | Enterprise Server, expensive | Apache-2.0, self-hosted by default | **Ahead** |
+
+### 2.2 Versus Siemens Xpedition Enterprise (+ Teamcenter, Valor)
+
+| Capability | Xpedition stack | Prism | Verdict |
+|---|---|---|---|
+| Constraint management | **Constraint Manager** — hierarchical, schematic-driven constraints (net classes, diff pairs, topology, impedance, length matching) cross-probed into layout. The single biggest thing Xpedition users lose | None | **Missing** |
+| Library management | Library Manager + central part database, partitions, approval flows | Library Manager with lifecycle, KLC, audit | **Parity** on governance, behind on scale tooling |
+| DFM analysis | **Valor NPI** — DFF/DFA/DFT rule decks, fab capability decks, ODB++ | None | **Missing** |
+| Design data management | Teamcenter: item/revision, ECR/ECO workflow, approvals, BOM release | Git + catalog lifecycle; no ECO | **Partial** |
+| Design reuse blocks | Reuse blocks — schematic + placed/routed layout + constraints as one governed object | None (KiCad 9/10 has native design blocks; Prism does not govern them) | **Missing** |
+| Concurrent team layout | Multiple designers on one board simultaneously | Explicitly out of scope | **Missing** (accept) |
+| Web design review with markup | DesignRev / ODB++ viewer, largely desktop | Better, browser-native | **Ahead** |
+| Variant manager | Yes | None | **Missing** |
+| Multi-board systems | Multi-board connectivity, Capital for harness | Monorepo only | **Partial** |
+| Test/DFT analysis | Test point coverage, ICT analysis | None | **Missing** |
+| Cost of ownership | Very high; seat- and module-licensed | Apache-2.0 | **Ahead** |
+
+### 2.3 The honest summary
+
+Prism is **already ahead** on the things it chose to be about: Git as the source
+of truth, browser-native semantic design review, and auditable component
+governance. Its design comparison is better than what either commercial stack
+gives a reviewer in a browser.
+
+The parity gaps that will actually stop a professional team from migrating,
+ranked by how often they will be raised in an evaluation:
+
+1. **No change control.** No approved/changes-requested state, no release
+   record, no ECO. Every regulated or ISO-audited team asks this in the first
+   meeting. This is gap #1 by a wide margin.
+2. **No rule-check evidence.** ERC and DRC results are not captured, not
+   diffed, not gated. Reviewers currently have no machine-checked evidence at
+   all.
+3. **No supply-chain intelligence.** ActiveBOM is the feature Altium users cite
+   most when asked what they would miss. Startups feel this immediately because
+   they are the ones getting burned by allocation and EOL.
+4. **No notifications.** Mentions are stored and dropped. This makes the
+   collaboration story feel unfinished regardless of how good the viewers are.
+5. **No variants.** Any team shipping more than one SKU from one board is
+   blocked.
+6. **No constraint governance.** Specifically an Xpedition-migration blocker.
+7. **Non-composable roles.** A person cannot be both `designer` and
+   `component_designer`. This will be hit on day one of any real rollout, and
+   it blocks several features proposed below.
+
+Everything else is differentiation rather than parity.
+
+---
+
+## 3. Workflow A — Git forge identity, issues, and project management
+
+The strategic argument is right: reuse GitHub/GitLab/Jira rather than
+reimplement a worse tracker. The refinement worth making is that **pull-request
+integration is higher value than issue integration**, because it puts Prism
+inside the daily loop rather than making it a place engineers have to remember
+to visit.
+
+### A1. Identity and authentication
+
+Today: generic OIDC (`OIDC_ISSUER_URL`, etc.) with a single deployment-level
+Git credential — an SSH deploy key or `GITHUB_TOKEN`.
+
+Proposed:
+
+- **First-class forge providers** alongside generic OIDC: GitHub, GitLab
+  (SaaS and self-hosted), Google, and later Bitbucket/Gitea/Forgejo. Login page
+  shows provider buttons; `AuthConfig` gains a provider list.
+- **Per-user forge tokens.** The important architectural shift: capture and
+  store (encrypted at rest, refresh-aware, minimum scope) an OAuth token per
+  linked account so Prism can act *as the user*. Consequences:
+  - Import authorisation derives from the user's real repository access instead
+    of a shared deploy key. A user can only import what they can already read.
+    This is a genuine security improvement over the current model.
+  - Issues and PR comments are attributed to the human, not to a bot account —
+    which is what makes forge-side workflows feel native.
+  - Keep the deploy key path for unattended server-side sync; per-user tokens
+    are for interactive and attribution operations. Do not make background sync
+    depend on a human's token expiring.
+- **Explicit account linking, never email matching.** A Google login whose
+  email matches a GitHub account is not proof of control. Require an OAuth
+  link per forge, stored in an identity table (`user_id`, `provider`,
+  `provider_user_id`, `handle`, `avatar`, `scopes`, `token_ref`). Support
+  multiple linked accounts per user, and unlinking.
+- **Self-hosted forges** need per-deployment app registration; support dynamic
+  provider config in `.env` plus admin UI, and document the callback URL.
+
+Risks to plan for: token storage is now a high-value target — use envelope
+encryption with a KMS-or-file master key, never log tokens, support forced
+re-auth and admin-side revocation, and surface granted scopes in the user's
+settings page so a security reviewer can audit them.
+
+### A2. Comments as issues
+
+The mechanism: a Prism discussion can be **promoted** to a forge issue, or
+auto-promoted by policy (for example, `severity >= major` on a project with an
+issue-sync policy configured).
+
+What makes this good rather than merely wired-up:
+
+- The issue body carries a **rendered crop of the marker region** — the
+  schematic area or PCB footprint the comment is anchored to — plus the
+  refdes/net identity from the semantic index, plus a commit-pinned deep link
+  back into the Prism viewer with the exact camera and selection restored.
+  Someone reading the issue on GitHub understands it without opening Prism.
+  Prism already has the geometry, the semantic identity, and the renderers to
+  do this; it is mostly plumbing.
+- Structured footer with machine-readable identity
+  (`prism-comment-id`, `project`, `commit`, `object-uuid`) so the reconciler can
+  recover links even if the local row is lost.
+- Labels derived from Prism metadata: severity, class, board name, sheet.
+
+Sync design:
+
+- **Ship one-way first (Prism → forge) with read-back of state.** Two-way
+  comment mirroring is the single highest-maintenance surface in this entire
+  document. V1: create the issue, then poll/webhook only for `state` and
+  `assignee` so Prism can show "closed on GitHub" and offer to resolve the
+  discussion. V2: mirror comment bodies both ways.
+- Everything goes through the **existing job system**. A forge outage must
+  never block someone leaving a comment on a board. Queue, retry with backoff,
+  surface a "sync pending / sync failed" badge on the discussion.
+- **Loop prevention** is mandatory: tag Prism-authored forge comments and
+  ignore them on inbound webhooks; use the forge's node/global ID for
+  idempotency; store `last_synced_etag`.
+- A **reconciliation job** that periodically re-reads linked issues, because
+  webhooks are lossy and self-hosted GitLab instances drop them.
+
+### A3. Pull-request integration — the highest-value piece
+
+When a PR/MR opens or updates against a repository Prism has imported:
+
+1. Webhook fires → Prism enqueues a `design_compare` for `base...head`.
+2. Prism posts a **check run / commit status**: `prism/design-review`.
+3. The check summary is the review the human would otherwise have to assemble
+   by hand:
+   - components added / removed / changed, with the notable refdes list
+   - nets added / removed / changed
+   - BOM delta with line-item and cost implications
+   - stackup or layer-count change (flagged loudly — it changes fab cost)
+   - board outline / mounting-hole change (flagged for mechanical review)
+   - new ERC/DRC violations relative to base (see §5.2)
+   - unresolved major/critical Prism discussions on this branch
+4. A single link into the prepared comparison, already warm.
+5. Optional **required check** so branch protection can block a merge on
+   unresolved critical discussions or new DRC violations.
+
+This is the feature that changes Prism from a review site into infrastructure.
+It is also the best demo you will ever have: open a PR, get an automatic
+hardware-aware review summary that GitHub cannot produce on its own.
+
+### A4. Dashboard / "My work"
+
+Landing view aggregating, per user:
+
+- Forge issues assigned to me across all linked projects
+- PRs awaiting my review that touch imported hardware projects
+- Prism discussions where I am mentioned, or that I authored and are unresolved
+- Catalog items waiting on my QA (already queryable via the release queue)
+- Failed or long-running jobs I started
+- Board bring-up units awaiting my sign-off (see §4)
+- Component EOL/stock alerts affecting projects I own (see §5.4)
+
+Implementation note: fan-out to forge search APIs is rate-limited and slow.
+Cache aggressively with a short TTL, refresh in the background, and render
+local data (discussions, jobs, catalog, bring-up) immediately rather than
+blocking on the network round-trip.
+
+### A5. Jira, Linear, and the tracker abstraction
+
+Do not special-case each tracker. Define a `TrackerProvider` interface:
+
+```
+create_issue(project_ref, title, body, labels, assignee) -> external_ref
+update_issue(external_ref, ...) -> None
+read_issue(external_ref) -> IssueState
+search_assigned(user_ref) -> list[IssueState]
+verify_webhook(headers, body) -> Event | None
+issue_url(external_ref) -> str
+```
+
+Ship GitHub → GitLab → Jira in that order. Jira specifics that will bite:
+Atlassian OAuth 2.0 (3LO) with rotating refresh tokens; project and issue-type
+mapping must be configurable per Prism project; the Prism deep link should go
+in a dedicated custom field, not buried in the description; webhooks are
+admin-scoped and differ between Cloud and Data Center.
+
+For kanban boards and timelines: **do not rebuild them.** Deep-link out, and at
+most embed a read-only summary (counts by status, sprint burndown thumbnail).
+The whole point of this workflow is to not maintain a worse tracker.
+
+### A6. Releases
+
+Link Prism release tags to forge releases, and attach the manufacturing package
+(§5.9) as release assets so the fabrication data for a given revision is
+retrievable from the forge even if Prism is offline.
+
+---
+
+## 4. Workflow B — Board bring-up, units, rework, and failures
+
+This is the strongest idea in the brief, and it deserves to be built.
+
+Neither Altium nor Xpedition covers this well. Altium has essentially nothing
+between "design released" and "product in the field". Teamcenter and full QMS
+suites cover it at a cost and complexity no startup will accept. What every
+hardware team actually does today is a spreadsheet of serial numbers, a
+Slack thread, and a photo of a board with bodge wires. **This is a genuine
+frontier feature, not a parity feature**, and it is the natural extension of
+Prism's existing claim: Git holds the design, Prism holds everything around it.
+
+### B1. Data model
+
+**Build (manufacturing lot)** — the anchor object. Binds physical hardware to
+an immutable design revision:
+
+```
+build:
+  id, project_id, name            # "EVT", "DVT-2", "Rev B pilot"
+  design_ref:
+    commit_sha                    # immutable
+    tag                           # optional, e.g. A.1.0.0
+    manufacturing_artifact_digest # the exact package sent to the fab
+  variant_id                      # optional, see §5.5
+  fab, assembler, po_number, quote_ref
+  quantity_ordered, quantity_received
+  ordered_at, received_at
+  notes, attachments              # quote, DFM feedback, AOI report
+```
+
+The `manufacturing_artifact_digest` is the important field. It answers "what
+exactly did we send?" — a question that is currently unanswerable in Prism and
+that causes real money to be lost.
+
+**Unit (serial)**:
+
+```
+unit:
+  serial                          # unique within workspace
+  build_id
+  status                          # received | in_bringup | passing | failing
+                                  # | deployed | rma | scrapped
+  owner, location                 # who has it, which bench/site
+  variant_id                      # if it differs from the build default
+  created_at, updated_at
+```
+
+Serial handling matters more than it sounds:
+- Configurable serial scheme per project (prefix, date code, sequence width).
+- Allocate a block of serials for a build up front.
+- Generate printable label sheets (Code128 / DataMatrix) with a QR encoding
+  `https://prism.example/u/<serial>`.
+- `/u/<serial>` resolves to a **mobile-friendly unit page**. Bring-up happens
+  at a bench with a scope and a phone, not at a desk with two monitors. If this
+  view is not good on a phone, the feature will not get used.
+
+**Bring-up procedure** — versioned in Git, results in PostgreSQL. This respects
+the sources-of-truth split already stated in `OVERVIEW.md`:
+
+- Procedure lives in the project repo (`docs/bringup/*.md` with front-matter,
+  or `.prism-bringup.yaml`), so it is reviewed, versioned, and diffable through
+  the existing document-diff service and the normal PR flow.
+- Prism parses it into structured steps with typed expectations:
+
+```yaml
+steps:
+  - id: PWR-01
+    title: 3V3 rail voltage
+    type: measurement
+    unit: V
+    min: 3.20
+    max: 3.40
+    refdes: U3          # links into the semantic index
+    net: +3V3
+  - id: PWR-02
+    title: Inrush waveform
+    type: attachment
+    accepts: [image, csv]
+  - id: FW-01
+    title: Bootloader enumerates over USB
+    type: pass_fail
+```
+
+- `refdes` / `net` fields cross-probe into the schematic and PCB viewers. A
+  failing step can highlight the exact component on the board. This reuses
+  machinery Prism already has.
+
+**Test run**:
+
+```
+test_run:
+  unit_serial, procedure_version (git blob sha), operator, started_at, ended_at
+  environment                     # temperature, equipment IDs, cal-due dates
+  results: [ {step_id, value, pass, notes, attachments[]} ]
+  overall: pass | fail | partial
+```
+
+**Automated ingest is non-negotiable.** Engineers will not hand-type forty
+measurements. Expose `POST /api/units/{serial}/test-runs` authenticated by the
+**existing scoped service-client mechanism**, accepting JSON, JUnit XML, or
+CSV. A pytest/LabVIEW/Python bench harness posts results directly. Provide a
+tiny reference client. The manual web form is the fallback, not the primary
+path.
+
+**Failure / defect**:
+
+```
+failure:
+  unit_serial, discovered_in (test_run_id | field | manual)
+  symptom, severity
+  affected_refdes[], affected_nets[]    # semantic-index linked
+  category    # design | assembly | component | process | esd | firmware | unknown
+  root_cause, disposition
+  linked_issue (external_ref)           # §A2
+  fixed_by_commit / fixed_in_build
+```
+
+Two links here are where the value compounds:
+
+- **Failure → component.** A failure attributed to a refdes rolls up to the
+  catalog component and its MPN. Over time: *"this MPN has 4 field failures
+  across 3 projects."* No ECAD tool offers component reliability history
+  grounded in your own build data. This alone justifies the module.
+- **Failure → design change.** Link a failure to the issue and to the commit
+  that fixed it. Closes the loop from bench observation to schematic change to
+  next build.
+
+**Rework** — two objects, deliberately separated:
+
+```
+rework_instruction:            # the recipe, reviewed and approved once
+  id, project_id, title
+  description                  # "Add 10k from TP4 to U3 pin 12"
+  affected_refdes[], affected_nets[]
+  annotated_images[]           # marked-up schematic/PCB crops
+  approved_by, approved_at
+  roll_into_design: bool       # must this become an ECO?
+  resolved_by_commit           # set when the design change lands
+  applies_to_builds[]
+
+rework_application:            # per-unit record
+  rework_instruction_id, unit_serial
+  applied_by, applied_at, verified_by
+  photo_evidence[], notes
+```
+
+The payoff query: **effective configuration per unit** = base build + applied
+reworks, rendered as a stack:
+
+```
+SN-0042   Rev B (a3f19c2)  + R-001  + R-003        [2 of 4 recommended]
+                                     ⚠ missing R-002, R-004
+```
+
+You can now answer "which boards actually have the fix?" and "is this unit's
+result comparable to that one's?" — questions that currently get answered by
+memory and are frequently answered wrong. Neither Altium nor Xpedition has
+anything here.
+
+`roll_into_design` plus `resolved_by_commit` prevents the classic failure mode:
+twelve boards fixed with bodge wires and nobody updates the schematic.
+
+### B2. Analytics
+
+- **First-pass yield** per build, trended across builds.
+- **Failure Pareto** by step, by refdes, by category.
+- **Failure heatmap on the PCB.** Overlay failure counts per refdes onto the
+  existing PCB viewer using the semantic index geometry. Prism already has the
+  geometry and the identity mapping — this is nearly free to build and is the
+  single most compelling screenshot the product could produce.
+- **Measurement distributions** per step against spec limits, with Cpk. Catches
+  the rail that is passing at 3.21 V against a 3.20 V limit before it becomes a
+  field return.
+- Cross-build comparison: did Rev B actually fix the Rev A failure mode?
+
+### B3. UI and roles
+
+- New **Bring-up** section in `ProjectDetailPage` alongside Overview, History,
+  Visualizers, Workflows, Assets, Documentation. Sub-views: Builds, Units,
+  Procedures, Failures, Reworks, Analytics.
+- A workspace-level **Fleet** view spanning projects, for the person who owns
+  hardware logistics.
+- **This forces the role model fix.** A test technician must be able to record
+  results and apply reworks without being able to modify designs or import
+  repositories. The current single-role model cannot express that. Adding
+  `test_operator` as composable permissions is a prerequisite — which is fine,
+  because non-composable roles is already a known boundary that needs fixing
+  regardless.
+
+### B4. Unit birth certificate
+
+Per-unit PDF export: design revision and commit, build and fab, full test
+record with measurements, all applied reworks with evidence, sign-offs, and
+timestamps.
+
+This is what you hand a customer, an auditor, or a certification body. For
+teams in medical, aerospace, industrial, or automotive markets, this is an
+AS9100 / ISO 13485-adjacent artifact that they would otherwise buy a QMS to
+produce. It is an instant credibility feature and a strong commercial hook.
+
+---
+
+## 5. Proposed roadmap beyond the two named workflows
+
+Ordered roughly by value-to-effort, with the parity blockers first.
+
+### 5.1 Design review state, release records, and ECO — *parity blocker #1*
+
+- First-class project review state: `draft → in_review → changes_requested →
+  approved`, bound to a commit, with a configurable review checklist.
+- **Release record**: an immutable object binding {commit, jobset outputs and
+  their digests, ERC/DRC evidence, BOM snapshot, approver signatures, release
+  notes}. This is what Altium's item-revision release and Teamcenter's ECO
+  give you, and it is the thing Prism most conspicuously lacks.
+- Attributable sign-off (re-authentication at signing time, immutable audit
+  entry). Not full 21 CFR Part 11, but close enough to matter.
+- ECO objects that link {reason, failures from §4, affected units, approvals,
+  the commit that implements it, the build it first ships in}.
+
+Nothing else on this list changes an evaluation outcome as much as this.
+
+### 5.2 ERC / DRC gates — *parity blocker #2, cheapest high-value item here*
+
+There is currently no DRC or ERC anywhere in the backend. Meanwhile the job
+infrastructure, artifact storage, and comparison machinery already exist.
+
+- Run `kicad-cli sch erc` and `kicad-cli pcb drc` (JSON output) as job kinds.
+- Normalise violations into a stable schema with stable IDs so they can be
+  **diffed against the base commit**: "this change introduces 3 new DRC
+  violations, resolves 7."
+- Render violations as markers in the existing PCB/schematic viewers, using the
+  same overlay path as comments.
+- **Waiver workflow**: a violation can be waived with a justification, an
+  approver, and an expiry date. Waivers are reviewable objects that expire —
+  which is better than what the commercial tools offer, where suppressions rot
+  silently.
+- Surface as a required check on PRs (§A3).
+
+This is rule checking, not simulation, and it is the single best
+effort-to-credibility ratio on this list.
+
+### 5.3 Notifications and inbox — *parity blocker, unblocks everything else*
+
+Mentions are stored and dropped today. Deliver them: in-product inbox, email,
+and outbound webhooks (Slack/Teams/Discord via incoming webhooks rather than
+bespoke integrations). Per-user preferences and digest mode. Every feature in
+this document is less useful without it.
+
+### 5.4 BOM and supply-chain intelligence — *parity blocker #3*
+
+The ActiveBOM equivalent. This is what startups feel first.
+
+- Pluggable `SupplyProvider` interface — Nexar/Octopart, Mouser, DigiKey,
+  Arrow, plus a **manual/CSV provider** so air-gapped self-hosted deployments
+  still work. Prism is self-hosted; do not assume outbound internet.
+- Per-catalog-part **AVL**: approved manufacturers and distributors, alternates
+  and second sources with an approval state of their own.
+- **BOM risk scoring**: single-source, NRND/EOL, lifecycle status, lead time,
+  stock versus planned build quantity, minimum order quantity, price break
+  analysis.
+- "Can I build 50 of these today, and for how much?" — a single answer on the
+  BOM page.
+- **EOL and PCN watch** across the whole catalog with blast-radius analysis:
+  which projects, which builds, which units are affected. Feeds §5.3.
+- BOM snapshot frozen into the release record (§5.1) so the BOM that was
+  released is recoverable years later.
+
+### 5.5 Assembly variants
+
+Variant definitions (fitted/not-fitted, alternate values, alternate MPNs) as
+first-class, versioned objects. Variant-aware BOM, CPL, assembly drawing, and
+design comparison. Variant-aware builds and units in §4. Any team shipping more
+than one SKU from one PCB is blocked without this.
+
+### 5.6 DFM and fabrication capability profiles
+
+The Valor NPI gap, addressed proportionately:
+
+- **Vendor capability profiles**: min trace/space, min drill, annular ring,
+  aspect ratio, min silkscreen width, mask sliver, panel dimensions, layer
+  count, controlled-impedance offerings, surface finishes. Ship profiles for
+  the common low-cost fabs and let teams add their own.
+- Check the design against the selected vendor and produce a stoplight report
+  *before* the Gerbers are sent.
+- Assembly-side checks: courtyard overlaps, fiducial presence and placement,
+  tooling holes, part height clearances, paste aperture sanity, CPL/pick-place
+  consistency against the BOM.
+- Cost estimation driven by the profile (layer count, area, finish, quantity).
+- Panelisation validation.
+
+### 5.7 Constraint and design-intent registry — *the Xpedition migration answer*
+
+Prism cannot be a constraint editor — that is KiCad's job. But it can own
+constraint *governance*, which is what Constraint Manager users actually value:
+
+- Declare design intent as a versioned, reviewable, in-repo document: net
+  classes, differential pairs with target impedance and tolerance, length
+  matching groups and tolerances, layer assignments, keepouts, high-voltage
+  spacing.
+- A checker verifies that the KiCad project's actual net classes and custom
+  DRC rules match the declared intent, and reports drift.
+- Diff constraints across commits as a first-class comparison domain, alongside
+  components and nets. "Someone changed the USB differential pair impedance
+  target from 90Ω to 100Ω" is exactly the kind of change that currently escapes
+  review entirely.
+
+### 5.8 Managed design blocks and reuse — *strong differentiator*
+
+KiCad 9/10 has native design blocks. Nobody governs them yet.
+
+Apply the existing catalog lifecycle machinery to a **design block**: a
+hierarchical schematic sheet, its matching layout snippet, its constraints, its
+validated BOM subset, and its bring-up procedure fragment — versioned,
+QA-approved, released, and placeable. "We designed this buck converter once,
+qualified it once, and it is now a released, traceable, reusable object" is a
+message that lands hard with both startups and enterprises, and Prism already
+has essentially all the machinery.
+
+### 5.9 Manufacturing handoff portal
+
+An externally shareable, scoped, expiring, optionally watermarked view of a
+release package for a fab or CM, without giving them repository access:
+
+- Immutable package tied to a release record (§5.1).
+- Vendor Q&A thread that routes back into Prism discussions and forge issues.
+- A record of exactly which package version each vendor received and when.
+- Vendor-uploaded artifacts back into Prism: DFM feedback, AOI reports, X-ray
+  images, first-article inspection — which then attach to the build in §4.
+
+This replaces a genuinely awful email-and-Dropbox process, and it closes the
+loop into the bring-up module.
+
+### 5.10 Requirements traceability
+
+Lightweight, in-repo requirements (YAML/Markdown, versioned, diffable) linked
+to design elements (nets, blocks, components) and to bring-up test steps (§4).
+Generates a traceability matrix: requirement → design implementation →
+verification evidence → the specific units it was verified on.
+
+This is what Altium charges enterprise money for, it is mandatory in regulated
+markets, and in Prism it is mostly a linking layer over things §4 and §5.8
+already create.
+
+### 5.11 Multi-board system view
+
+Prism already imports monorepos with multiple boards — nobody else is well
+positioned for this.
+
+Declare inter-board connectivity (this connector on board A mates with that
+connector on board B, via this cable), then check pin-to-pin consistency across
+boards, flag mismatches, and generate a system-level interconnect diagram.
+Catches the most expensive class of bug in multi-board products: the one you do
+not find until both boards are back from fab.
+
+### 5.12 Mechanical / MCAD review loop
+
+Not full CoDesign. Instead: detect and highlight changes to board outline,
+mounting hole positions, connector placement, and keepouts; export STEP and
+diff it; and provide an explicit mechanical sign-off gate on a release. Route
+mechanical change requests through the same discussion and issue machinery.
+
+### 5.13 Field and fleet tracking
+
+The natural extension of §4 past deployment: units in the field, RMA intake
+(scan the serial, see its entire history), failure-rate-by-revision analytics,
+and firmware-version-to-hardware-revision compatibility tracking. Turns Prism
+into a hardware lifecycle system rather than a design review tool.
+
+### 5.14 Platform: outbound webhooks and events
+
+Publish Prism events (job completed, comparison ready, component released,
+test run recorded, unit failed, DRC regressed) so teams can build their own
+automation. A self-hosted tool that cannot be automated will be worked around.
+
+### 5.15 AI-assisted review — *frontier, position carefully*
+
+Grounded on the semantic index and diff data that already exist:
+
+- Natural-language change summaries on a PR: "moves the feedback divider,
+  changes R12 from 10k to 12k, adds a 100nF near U3, no net topology change."
+- Natural-language search across designs, catalog, and bring-up history: "which
+  boards used this regulator and had a thermal failure?"
+- Review checklist suggestions based on what changed.
+- Bring-up failure triage: "3 units failed PWR-01, all from build DVT-2, all
+  with C14 from the same reel."
+
+Position this as an assistant layered on top of deterministic analysis, never
+as authority. The deterministic diff and rule checks are the product; the
+summarisation is convenience. Say so explicitly in the UI — hardware engineers
+are, correctly, sceptical.
+
+---
+
+## 6. Suggested release sequencing
+
+**R1 — Close the credibility gaps.** Composable permissions; notifications and
+inbox; ERC/DRC job kinds with baseline diffing and waivers; design review state
+and release records with sign-off.
+*Rationale: these are the questions asked in the first evaluation meeting, and
+several later features depend on them.*
+
+**R2 — The two named workflows.** Forge identity and per-user tokens; PR check
+runs with automatic design comparison; comments → issues (one-way + state
+read-back); user dashboard. Bring-up module v1: builds, units, serials,
+procedures, test runs with API ingest, failures, reworks, effective
+configuration.
+*Rationale: R1's release records and permissions are prerequisites for doing
+these properly.*
+
+**R3 — Professional depth.** Supply-chain intelligence and AVL; assembly
+variants; DFM and fab capability profiles; manufacturing handoff portal;
+bring-up analytics and birth certificates; Jira provider.
+
+**R4 — Frontier.** Managed design blocks; constraint registry; requirements
+traceability; multi-board system view; fleet and field tracking; MCAD loop;
+outbound events; AI-assisted review.
+
+Two cross-cutting notes:
+
+- **Composable permissions is on the critical path for more than it appears.**
+  Bring-up needs a technician role, the manufacturing portal needs external
+  vendor scoping, and the release workflow needs approver roles. Doing it once,
+  early, in R1 is much cheaper than three partial workarounds.
+- **Keep the sources-of-truth discipline.** The pattern that already works —
+  definitions in Git (reviewable, versioned, diffable), instance records in
+  PostgreSQL — should be applied to bring-up procedures, constraints,
+  requirements, and variants alike. It is what keeps Prism honest about being a
+  layer around Git rather than a competing vault, and it is a real
+  differentiator against every tool listed in §2.


### PR DESCRIPTION
The `kicad-monkey-local` image target asked PyPI for a `kicad-cruncher`
matching the mounted working tree's own version. The two packages share a
date-based version scheme but not a release cadence: kicad-monkey 2026.7.28
shipped without a matching cruncher, so any build against a working tree at
that version died with

```
No solution found when resolving dependencies:
Because there is no version of kicad-cruncher==2026.7.28 and you require
kicad-cruncher==2026.7.28, we can conclude that your requirements are
unsatisfiable.
```

before it ever reached the working-tree install.

Nothing about this target needs the versions to match. kicad-cruncher declares
`kicad-monkey>=2026.7.17`, and the `uv pip check` that already runs after the
working tree goes in is what actually proves the mounted tree satisfies it —
the version pin was only ever a guess at compatibility that the check verifies
properly.

Verified by building and running the stack against the kicad-monkey `dev`
branch: kicad-monkey 2026.7.28 from the working tree, kicad-cruncher 2026.7.17,
`uv pip check` clean, health endpoint ready.