### PR TITLE
Add issue templates to main so GitHub serves them

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Report reproducible incorrect behavior in KiCAD Prism
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Search existing issues first. Do not include credentials, private repositories, proprietary designs, database dumps, or security vulnerabilities.
+
+  - type: input
+    id: version
+    attributes:
+      label: Prism version
+      description: Release tag or full commit SHA
+      placeholder: v3.0.0-alpha.1 or abcdef123...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Deployment or upgrade
+        - Authentication or access
+        - Workspace or Git import
+        - Schematic, PCB, 3D, BOM, or cross-probe
+        - Design Comparison
+        - Comments
+        - Workflows or Assets
+        - Library Manager
+        - Remote Symbol Provider
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Host OS, CPU architecture, Docker version, browser, KiCad version, and authentication mode as relevant
+      placeholder: |
+        Host: Ubuntu 24.04, amd64
+        Docker: 28.x / Compose v2.x
+        Browser: Firefox ...
+        KiCad: 10.0.x
+        Auth: OIDC
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Use a small public project or sanitized example when possible
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs or screenshots
+      description: Remove tokens, cookies, private URLs, identities, and design data
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing open and closed issues.
+          required: true
+        - label: I removed secrets and proprietary data.
+          required: true
+        - label: This is not a security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Setup and workflow questions
+    url: https://github.com/krishna-swaroop/KiCAD-Prism/discussions
+    about: Ask for help or discuss a workflow before filing a defect.
+  - name: Security vulnerability
+    url: https://github.com/krishna-swaroop/KiCAD-Prism/security/advisories/new
+    about: Report suspected vulnerabilities privately.
+  - name: Documentation
+    url: https://github.com/krishna-swaroop/KiCAD-Prism/blob/dev/docs/README.md
+    about: Read the current platform, deployment, team, and operations guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: Feature request
+description: Propose an engineering workflow or product improvement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the workflow and outcome before prescribing an implementation. Large proposals may be moved to a discussion.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Workflow problem
+      description: Who is affected, what are they trying to accomplish, and where does the current process fail?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current workaround
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe observable acceptance criteria
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Product area
+      options:
+        - Project review
+        - Git integration
+        - Workflows or Assets
+        - Library governance
+        - Remote Symbol Provider
+        - Authentication or administration
+        - Deployment or operations
+        - Developer experience
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups and public example repositories are welcome; do not attach proprietary data.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and discussions.
+          required: true
+        - label: I described the user workflow and acceptance outcome.
+          required: true


### PR DESCRIPTION
## Why

GitHub reads `.github/ISSUE_TEMPLATE` **only from the default branch**, which is `main`. The bug report, feature request, and config forms have lived on `dev` since they were written, so every new issue still opens as a blank textarea.

## What

Takes the three template files from `dev` unchanged (verified byte-identical):

- `bug_report.yml` — version, affected area, environment, repro steps; labels `bug`
- `feature_request.yml` — workflow and outcome before implementation; labels `enhancement`
- `config.yml` — `blank_issues_enabled: false`, plus contact links to Discussions, private security advisories, and the docs index

## What this deliberately is not

Not a `dev` -> `main` merge. The rest of `.github` diverges on release-pipeline concerns (`docker-publish.yml`, +293/-50) and dev-only CI (`dev-quality-gate.yml`), none of which should land on `main` as a side effect of publishing issue forms. `pull_request_template.md` is likewise left on `dev` — separate ask.

## Verified

- `bug` and `enhancement` labels exist on the repo, so the declared labels apply rather than being silently dropped
- Discussions is enabled, so the Discussions contact link resolves
- `docs/README.md` exists on `dev`, so the documentation contact link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)