### PR TITLE
Fix project imports, rendering status, catalog workflow, and workspace actions

### DIFF
--- a/backend/app/api/folders.py
+++ b/backend/app/api/folders.py
@@ -20,6 +20,11 @@ class MoveProjectRequest(BaseModel):
     folder_id: Optional[str] = None
 
 
+class MoveProjectsRequest(BaseModel):
+    project_ids: List[str] = Field(min_length=1)
+    folder_id: Optional[str] = None
+
+
 class UpdateFolderRequest(BaseModel):
     name: Optional[str] = None
     parent_id: Optional[str] = None
@@ -102,8 +107,26 @@ async def delete_folder(folder_id: str, cascade: bool = Query(default=True)):
 
 @router.post("/projects/{project_id}/move", dependencies=[Depends(require_designer)])
 async def move_project_to_folder(project_id: str, request: MoveProjectRequest):
-    result = await asyncio.to_thread(workspace.move_project_to_folder, project_id, request.folder_id)
+    try:
+        result = await asyncio.to_thread(workspace.move_project_to_folder, project_id, request.folder_id)
+    except ValueError as error:
+        raise HTTPException(status_code=_status_code_for_value_error(error), detail=str(error))
     if not result:
         raise HTTPException(status_code=404, detail="Project not found")
 
     return {"message": "Project moved successfully"}
+
+
+@router.post("/projects/move", dependencies=[Depends(require_designer)])
+async def move_projects_to_folder(request: MoveProjectsRequest):
+    try:
+        moved = await asyncio.to_thread(
+            workspace.move_projects_to_folder,
+            request.project_ids,
+            request.folder_id,
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=_status_code_for_value_error(error), detail=str(error))
+
+    noun = "project" if moved == 1 else "projects"
+    return {"message": f"{moved} {noun} moved successfully", "moved": moved}

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -554,8 +554,15 @@ class ImportRequest(BaseModel):
     selected_paths: Optional[List[str]] = None
     ref: Optional[str] = None
 
-@router.post("/analyze", dependencies=[Depends(require_designer)])
-async def analyze_repository(request: AnalyzeRequest):
+
+class RegenerateThumbnailsRequest(BaseModel):
+    project_ids: List[str] = Field(min_length=1)
+
+@router.post("/analyze")
+async def analyze_repository(
+    request: AnalyzeRequest,
+    user: AuthenticatedUser = Depends(require_designer),
+):
     """
     Analyze a repository to determine import type and discover KiCAD projects.
     Returns Type-1 or Type-2 classification and project list.
@@ -565,6 +572,7 @@ async def analyze_repository(request: AnalyzeRequest):
             project_import_service.start_analyze_job,
             request.url,
             request.ref,
+            requested_by=user.email,
         )
         return {"job_id": job_id, "status": "started"}
 
@@ -604,8 +612,11 @@ async def import_access_help(request: AnalyzeRequest):
     }
 
 
-@router.post("/import", dependencies=[Depends(require_designer)])
-async def import_project(request: ImportRequest):
+@router.post("/import")
+async def import_project(
+    request: ImportRequest,
+    user: AuthenticatedUser = Depends(require_designer),
+):
     """
     Start an async project import job.
     For Type-1: imports single project at root.
@@ -618,6 +629,7 @@ async def import_project(request: ImportRequest):
             import_type=request.import_type,
             selected_paths=request.selected_paths,
             ref=request.ref,
+            requested_by=user.email,
         )
         return {"job_id": job_id, "status": "started"}
     except (RemoteUrlError, GitAccessError, ValueError) as e:
@@ -987,6 +999,39 @@ async def regenerate_project_thumbnail(project_id: str, user: AuthenticatedUser 
         "status": "queued",
         "job_id": job_id,
         "message": "Rendering the board thumbnail",
+    }
+
+
+@router.post("/thumbnails/regenerate")
+async def regenerate_project_thumbnails(
+    request: RegenerateThumbnailsRequest,
+    user: AuthenticatedUser = Depends(require_designer),
+):
+    """Queue board renders for all selected visible projects."""
+    project_ids = list(dict.fromkeys(project_id.strip() for project_id in request.project_ids if project_id.strip()))
+    if not project_ids:
+        raise HTTPException(status_code=400, detail="At least one project is required")
+
+    # Apply the same role-aware visibility check used by the single-project
+    # endpoint before any jobs are enqueued.
+    for project_id in project_ids:
+        get_project_for_role_or_404(project_id, user.role)
+
+    try:
+        job_ids = await asyncio.to_thread(
+            project_import_service.start_thumbnail_jobs,
+            project_ids,
+            requested_by=user.email,
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+
+    count = len(job_ids)
+    return {
+        "status": "queued",
+        "job_ids": job_ids,
+        "count": count,
+        "message": f"Rendering {count} board thumbnail{'s' if count != 1 else ''}",
     }
 
 

--- a/backend/app/services/derived_assets.py
+++ b/backend/app/services/derived_assets.py
@@ -84,6 +84,14 @@ def store_thumbnail(
     directory.mkdir(parents=True, exist_ok=True)
     target = directory / f"{prefix}.{digest[:16]}.webp"
     source.replace(target)
+    # Render/encode staging files are created with NamedTemporaryFile and are
+    # therefore mode 0600 on Linux.  ``replace`` preserves that mode, but the
+    # generated asset is served by nginx (a different uid from the worker), so
+    # a successfully rendered thumbnail otherwise becomes unreadable at the
+    # final hand-off.  The derived store contains public workspace thumbnails,
+    # not credentials; make the completed artifact readable by its serving
+    # process while keeping it non-executable and owner-writable only.
+    target.chmod(0o644)
     for stale in directory.glob(f"{prefix}.*.webp"):
         if stale != target:
             stale.unlink(missing_ok=True)

--- a/backend/app/services/project_import_service.py
+++ b/backend/app/services/project_import_service.py
@@ -10,7 +10,7 @@ import subprocess
 import shutil
 import tempfile
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Sequence
 from dataclasses import dataclass
 from git import Git, Repo, RemoteProgress
 from app.core.config import settings
@@ -146,6 +146,72 @@ def list_remote_branches(parsed: ParsedRemote) -> tuple[List[str], Optional[str]
             branches.append(parts[1].removeprefix("refs/heads/"))
     branches.sort(key=lambda name: (name != default_branch, name.casefold()))
     return branches, default_branch
+
+
+def _github_ssh_equivalent(parsed: ParsedRemote) -> Optional[ParsedRemote]:
+    """Return the workspace-SSH spelling of one GitHub HTTPS remote.
+
+    GitHub's Clone menu presents HTTPS first, while Prism's deployment uses a
+    shared machine-user SSH key for private repositories.  Requiring every
+    designer to understand that deployment detail made imports appear tied to
+    the laptop or role of the person pasting the URL.  Keep HTTPS as the first
+    attempt (so public repositories and ``GITHUB_TOKEN`` continue to work), but
+    provide the equivalent SSH address when that attempt needs credentials.
+    """
+    if parsed.scheme != "https" or parsed.host.casefold() != "github.com":
+        return None
+    if parsed.port not in (None, 443):
+        return None
+    path = parsed.path.strip("/")
+    if not path:
+        return None
+    if not path.endswith(".git"):
+        path += ".git"
+    return parse_remote_url(f"git@github.com:{path}", remote_url_policy())
+
+
+def resolve_remote_access(
+    parsed: ParsedRemote,
+) -> tuple[ParsedRemote, List[str], Optional[str]]:
+    """Resolve a readable transport and return its branch information.
+
+    A private GitHub repository addressed by HTTPS normally responds with a
+    credentials error even when Prism's workspace SSH identity is authorized.
+    In that narrow case, retry the same canonical repository over SSH.  Other
+    failures retain their original meaning and SSH URLs remain untouched.
+    """
+    try:
+        branches, default_branch = list_remote_branches(parsed)
+        return parsed, branches, default_branch
+    except GitAccessError as https_error:
+        if https_error.reason not in {"credentials-required", "repository-not-found"}:
+            raise
+        ssh_remote = _github_ssh_equivalent(parsed)
+        if ssh_remote is None:
+            raise
+
+        print(
+            f"HTTPS access to {_describe_target(parsed)} needs credentials; "
+            "retrying with Prism's workspace SSH identity",
+            flush=True,
+        )
+        try:
+            branches, default_branch = list_remote_branches(ssh_remote)
+        except GitAccessError as ssh_error:
+            # SSH-specific diagnostics (missing/untrusted client or an
+            # unauthorized key) are more actionable than the original generic
+            # HTTPS credential prompt.  A not-found response after the SSH
+            # attempt also correctly covers a typo or a key lacking this one
+            # repository's permission.
+            if ssh_error.reason in {
+                "ssh-unavailable",
+                "host-key-unverified",
+                "ssh-key-not-authorized",
+                "repository-not-found",
+            }:
+                raise ssh_error from https_error
+            raise https_error from ssh_error
+        return ssh_remote, branches, default_branch
 
 
 def _validate_ref(ref: Optional[str]) -> Optional[str]:
@@ -550,7 +616,9 @@ def _repository_lock_key(parsed: ParsedRemote) -> str:
 
 def start_import_job(repo_url: str, import_type: str,
                      selected_paths: Optional[List[str]] = None,
-                     ref: Optional[str] = None) -> str:
+                     ref: Optional[str] = None,
+                     *,
+                     requested_by: str = "project-import") -> str:
     """
     Start an asynchronous import job.
     Returns job ID for polling.
@@ -578,7 +646,7 @@ def start_import_job(repo_url: str, import_type: str,
         },
         worker_pool="prism",
         artifact_key=active_key,
-        requested_by="project-import",
+        requested_by=requested_by,
         max_attempts=1,
         resources={"prism_worker": 1, "import": 1},
         locks=[{"key": _repository_lock_key(parsed), "mode": "write"}],
@@ -586,7 +654,12 @@ def start_import_job(repo_url: str, import_type: str,
     return str(queued["job_id"])
 
 
-def start_analyze_job(repo_url: str, ref: Optional[str] = None) -> str:
+def start_analyze_job(
+    repo_url: str,
+    ref: Optional[str] = None,
+    *,
+    requested_by: str = "project-import",
+) -> str:
     """
     Start an asynchronous analysis job.
     Returns job ID.
@@ -601,7 +674,7 @@ def start_analyze_job(repo_url: str, ref: Optional[str] = None) -> str:
         {"repo_url": parsed.url, "ref": validated_ref},
         worker_pool="prism",
         artifact_key=active_key,
-        requested_by="project-import",
+        requested_by=requested_by,
         max_attempts=2,
         resources={"prism_worker": 1, "import": 1},
         locks=[{"key": _repository_lock_key(parsed), "mode": "read"}],
@@ -666,7 +739,7 @@ def run_project_analyze_job_v3(context: JobContext) -> JobResult:
     context.progress(
         stage="list-branches", message="Listing remote branches", percent=0, force=True
     )
-    branches, default_branch = list_remote_branches(parsed)
+    parsed, branches, default_branch = resolve_remote_access(parsed)
     if requested_ref and branches and requested_ref not in branches:
         raise ValueError(f"Branch '{requested_ref}' does not exist on this remote")
     selected_ref = requested_ref or default_branch
@@ -792,8 +865,6 @@ def _discover_remote_projects(
 def run_project_import_job_v3(context: JobContext) -> JobResult:
     payload = context.payload
     parsed = parse_remote_url(str(payload["repo_url"]), remote_url_policy())
-    repo_url = parsed.url
-    repo_name = parsed.repo_name
     requested_paths = [str(path) for path in payload.get("selected_paths") or []]
     ref = _validate_ref(payload.get("ref"))
     cloned_in_job = False
@@ -804,6 +875,10 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
         percent=0,
         force=True,
     )
+    if _github_ssh_equivalent(parsed) is not None:
+        parsed, _branches, _default_branch = resolve_remote_access(parsed)
+    repo_url = parsed.url
+    repo_name = parsed.repo_name
     existing_repo = find_existing_repository(parsed)
 
     # The client's import_type and selected_paths are hints. Re-derive both from
@@ -1030,6 +1105,46 @@ def start_thumbnail_job(project_id: str, *, requested_by: str = "") -> Optional[
     return str(queued["job_id"])
 
 
+def start_thumbnail_jobs(
+    project_ids: Sequence[str],
+    *,
+    requested_by: str = "",
+) -> list[str]:
+    """Queue fresh board renders for a validated set of projects.
+
+    Validate the complete selection before enqueueing anything so a stale
+    visible-result selection cannot produce a confusing partial bulk action.
+    Individual jobs remain independently deduplicated and independently
+    reportable to the worker queue.
+    """
+    normalized_ids = list(
+        dict.fromkeys(
+            project_id.strip()
+            for project_id in project_ids
+            if project_id and project_id.strip()
+        )
+    )
+    if not normalized_ids:
+        raise ValueError("At least one project is required")
+
+    missing_ids = [
+        project_id
+        for project_id in normalized_ids
+        if not workspace.get_project_by_id(project_id)
+    ]
+    if missing_ids:
+        noun = "Project" if len(missing_ids) == 1 else "Projects"
+        raise ValueError(f"{noun} not found: {', '.join(missing_ids)}")
+
+    job_ids: list[str] = []
+    for project_id in normalized_ids:
+        job_id = start_thumbnail_job(project_id, requested_by=requested_by)
+        if not job_id:
+            raise ValueError(f"Project not found: {project_id}")
+        job_ids.append(job_id)
+    return job_ids
+
+
 def run_project_thumbnail_job_v3(context: JobContext) -> JobResult:
     project_id = str(context.payload["project_id"])
     row = workspace.get_project_by_id(project_id)
@@ -1050,6 +1165,20 @@ def run_project_thumbnail_job_v3(context: JobContext) -> JobResult:
     for line in logs:
         print(line, flush=True)
     context.check_cancelled()
+
+    # ``generate_thumbnail_for_project`` reports every renderer/encoder
+    # failure as ``False`` so callers that merely refresh a project can remain
+    # best-effort.  A thumbnail *job* has a stronger contract: returning a
+    # JobResult marks it completed.  Surface the captured renderer diagnostic
+    # as an exception instead of recording a failed kicad-cli invocation as a
+    # successful job.
+    no_board = any(
+        line.startswith("No .kicad_pcb file found")
+        for line in logs
+    )
+    if not rendered and not no_board:
+        detail = logs[-1] if logs else "Thumbnail renderer did not produce an image"
+        raise RuntimeError(detail)
 
     context.progress(
         stage="record-thumbnail", message="Recording thumbnail", percent=90, force=True

--- a/backend/app/services/workspace_service.py
+++ b/backend/app/services/workspace_service.py
@@ -401,7 +401,61 @@ class WorkspaceService:
         return cur.rowcount > 0
 
     def move_project_to_folder(self, project_id: str, folder_id: Optional[str]) -> bool:
-        return self.update_project(project_id, folder_id=folder_id)
+        try:
+            return self.move_projects_to_folder([project_id], folder_id) == 1
+        except ValueError as error:
+            if "project not found" in str(error).lower():
+                return False
+            raise
+
+    def move_projects_to_folder(self, project_ids: List[str], folder_id: Optional[str]) -> int:
+        """Move a validated set of projects in one database transaction.
+
+        Both the destination and the complete project set are locked and
+        validated before the UPDATE is issued. This prevents a partial move
+        when a stale or invalid project id is included in a bulk selection.
+        """
+        normalized_ids = list(
+            dict.fromkeys(
+                project_id.strip()
+                for project_id in project_ids
+                if project_id.strip()
+            )
+        )
+        if not normalized_ids:
+            raise ValueError("At least one project is required")
+
+        with self._connect() as conn:
+            if folder_id is not None:
+                folder = conn.execute(
+                    "SELECT id FROM ws_folders WHERE id=%s FOR KEY SHARE",
+                    (folder_id,),
+                ).fetchone()
+                if not folder:
+                    raise ValueError("Folder not found")
+
+            rows = conn.execute(
+                "SELECT id FROM ws_projects WHERE id = ANY(%s) FOR UPDATE",
+                (normalized_ids,),
+            ).fetchall()
+            existing_ids = {str(row["id"]) for row in rows}
+            missing_ids = [
+                project_id
+                for project_id in normalized_ids
+                if project_id not in existing_ids
+            ]
+            if missing_ids:
+                noun = "Project" if len(missing_ids) == 1 else "Projects"
+                raise ValueError(f"{noun} not found: {', '.join(missing_ids)}")
+
+            cursor = conn.execute(
+                "UPDATE ws_projects SET folder_id=%s WHERE id = ANY(%s)",
+                (folder_id, normalized_ids),
+            )
+            if cursor.rowcount != len(normalized_ids):
+                raise RuntimeError("Bulk project move did not update the validated project set")
+            conn.commit()
+        return len(normalized_ids)
 
     def delete_project(self, project_id: str) -> bool:
         with self._connect() as conn:

--- a/backend/tests/test_derived_assets.py
+++ b/backend/tests/test_derived_assets.py
@@ -4,6 +4,7 @@ user's Git checkout untouched."""
 from __future__ import annotations
 
 import io
+import stat
 import tempfile
 import unittest
 from pathlib import Path
@@ -47,6 +48,18 @@ class ThumbnailStorageStaysOutsideTheCheckout(unittest.TestCase):
         self.assertEqual(found, stored)
         self.assertEqual(size, len(b"render-bytes"))
         self.assertTrue(digest)
+
+    def test_stored_thumbnail_is_readable_by_the_nginx_worker(self) -> None:
+        source = self._write_render()
+        source.chmod(0o600)
+
+        stored, _, _ = derived_assets.store_thumbnail(self.checkout, source)
+
+        mode = stat.S_IMODE(stored.stat().st_mode)
+        self.assertEqual(
+            mode & (stat.S_IRGRP | stat.S_IROTH),
+            stat.S_IRGRP | stat.S_IROTH,
+        )
 
     def test_regenerating_replaces_rather_than_accumulates(self) -> None:
         derived_assets.store_thumbnail(self.checkout, self._write_render(b"first"))

--- a/backend/tests/test_project_import_v3_jobs.py
+++ b/backend/tests/test_project_import_v3_jobs.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from app.services import project_import_service
+from app.services.git_failures import GitAccessError
 from app.services.git_remote_url import RemoteUrlError
 
 
@@ -80,6 +81,7 @@ class ProjectImportV3JobTests(unittest.TestCase):
                 "https://example.com/boards.git",
                 "type2",
                 ["boards/a", "boards/b"],
+                requested_by="designer@example.com",
             )
 
         self.assertEqual(job_id, "job-import")
@@ -88,6 +90,67 @@ class ProjectImportV3JobTests(unittest.TestCase):
         self.assertEqual(call.kwargs["resources"]["import"], 1)
         self.assertEqual(call.kwargs["locks"][0]["mode"], "write")
         self.assertEqual(call.kwargs["max_attempts"], 1)
+        self.assertEqual(call.kwargs["requested_by"], "designer@example.com")
+
+    def test_private_github_https_falls_back_to_workspace_ssh(self) -> None:
+        https = project_import_service.parse_remote_url(
+            "https://github.com/example/private-board"
+        )
+        credential_error = GitAccessError(
+            "HTTPS credentials required", reason="credentials-required"
+        )
+        with mock.patch.object(
+            project_import_service,
+            "list_remote_branches",
+            side_effect=[credential_error, (["main"], "main")],
+        ) as list_branches:
+            resolved, branches, default_branch = (
+                project_import_service.resolve_remote_access(https)
+            )
+
+        self.assertEqual(resolved.url, "git@github.com:example/private-board.git")
+        self.assertEqual(branches, ["main"])
+        self.assertEqual(default_branch, "main")
+        self.assertEqual(
+            [call.args[0].url for call in list_branches.call_args_list],
+            [
+                "https://github.com/example/private-board",
+                "git@github.com:example/private-board.git",
+            ],
+        )
+
+    def test_successful_https_access_does_not_switch_transport(self) -> None:
+        https = project_import_service.parse_remote_url(
+            "https://github.com/example/public-board.git"
+        )
+        with mock.patch.object(
+            project_import_service,
+            "list_remote_branches",
+            return_value=(["main"], "main"),
+        ) as list_branches:
+            resolved, _branches, _default_branch = (
+                project_import_service.resolve_remote_access(https)
+            )
+
+        self.assertIs(resolved, https)
+        list_branches.assert_called_once_with(https)
+
+    def test_ssh_diagnostic_replaces_generic_https_credential_error(self) -> None:
+        https = project_import_service.parse_remote_url(
+            "https://github.com/example/private-board"
+        )
+        with mock.patch.object(
+            project_import_service,
+            "list_remote_branches",
+            side_effect=[
+                GitAccessError("HTTPS credentials required", reason="credentials-required"),
+                GitAccessError("SSH key refused", reason="ssh-key-not-authorized"),
+            ],
+        ):
+            with self.assertRaises(GitAccessError) as caught:
+                project_import_service.resolve_remote_access(https)
+
+        self.assertEqual(caught.exception.reason, "ssh-key-not-authorized")
 
     def test_analyze_handler_returns_legacy_compatible_result_shape(self) -> None:
         progress_updates: list[dict[str, object]] = []
@@ -332,6 +395,21 @@ class EnqueueValidatesRemoteUrls(unittest.TestCase):
         first, second = enqueue.call_args_list
         self.assertEqual(
             first.kwargs["locks"][0]["key"], second.kwargs["locks"][0]["key"]
+        )
+
+    def test_analyze_enqueue_records_authenticated_requester(self) -> None:
+        with mock.patch.object(
+            project_import_service.v3_jobs,
+            "enqueue",
+            return_value={"job_id": "job-1"},
+        ) as enqueue:
+            project_import_service.start_analyze_job(
+                "git@github.com:org/repo.git",
+                requested_by="rhythm@pixxel.co.in",
+            )
+
+        self.assertEqual(
+            enqueue.call_args.kwargs["requested_by"], "rhythm@pixxel.co.in"
         )
 
 

--- a/backend/tests/test_thumbnail_jobs.py
+++ b/backend/tests/test_thumbnail_jobs.py
@@ -51,6 +51,47 @@ class ThumbnailJobEnqueue(unittest.TestCase):
             self.assertIsNone(project_import_service.start_thumbnail_job("missing"))
         enqueue.assert_not_called()
 
+    def test_bulk_enqueue_validates_before_starting_each_job(self) -> None:
+        with (
+            mock.patch.object(
+                project_import_service.workspace,
+                "get_project_by_id",
+                side_effect=lambda project_id: {"id": project_id},
+            ),
+            mock.patch.object(
+                project_import_service,
+                "start_thumbnail_job",
+                side_effect=["job-1", "job-2"],
+            ) as start,
+        ):
+            job_ids = project_import_service.start_thumbnail_jobs(
+                ["prj_1", "prj_2", "prj_1"],
+                requested_by="designer@example.com",
+            )
+
+        self.assertEqual(job_ids, ["job-1", "job-2"])
+        self.assertEqual(
+            start.call_args_list,
+            [
+                mock.call("prj_1", requested_by="designer@example.com"),
+                mock.call("prj_2", requested_by="designer@example.com"),
+            ],
+        )
+
+    def test_bulk_enqueue_rejects_missing_project_before_starting_jobs(self) -> None:
+        with (
+            mock.patch.object(
+                project_import_service.workspace,
+                "get_project_by_id",
+                side_effect=lambda project_id: None if project_id == "missing" else {"id": project_id},
+            ),
+            mock.patch.object(project_import_service, "start_thumbnail_job") as start,
+        ):
+            with self.assertRaisesRegex(ValueError, "Project not found: missing"):
+                project_import_service.start_thumbnail_jobs(["prj_1", "missing"])
+
+        start.assert_not_called()
+
 
 class ThumbnailJobHandler(unittest.TestCase):
     def test_handler_renders_and_records_the_result(self) -> None:
@@ -87,6 +128,71 @@ class ThumbnailJobHandler(unittest.TestCase):
             "prj_1", thumbnail_source="generated"
         )
         self.assertTrue(result.details["rendered"])
+
+    def test_handler_fails_when_the_renderer_produces_no_thumbnail(self) -> None:
+        with tempfile.TemporaryDirectory() as project_path:
+            context = SimpleNamespace(
+                payload={"project_id": "prj_1"},
+                check_cancelled=mock.Mock(),
+                progress=lambda **values: None,
+            )
+
+            def failed_render(_project_path, logs):
+                logs.append("kicad-cli render failed (code 1): render error")
+                return False
+
+            with (
+                mock.patch.object(
+                    project_import_service.workspace,
+                    "get_project_by_id",
+                    return_value={"id": "prj_1", "path": project_path},
+                ),
+                mock.patch.object(
+                    project_import_service,
+                    "generate_thumbnail_for_project",
+                    side_effect=failed_render,
+                ),
+                mock.patch.object(
+                    project_import_service, "refresh_project_assets"
+                ) as refresh,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "kicad-cli render failed"):
+                    project_import_service.run_project_thumbnail_job_v3(context)
+
+        refresh.assert_not_called()
+
+    def test_handler_completes_as_not_applicable_when_project_has_no_board(self) -> None:
+        with tempfile.TemporaryDirectory() as project_path:
+            context = SimpleNamespace(
+                payload={"project_id": "prj_1"},
+                check_cancelled=mock.Mock(),
+                progress=lambda **values: None,
+            )
+
+            def no_board(_project_path, logs):
+                logs.append(f"No .kicad_pcb file found to generate thumbnail for {_project_path}")
+                return False
+
+            with (
+                mock.patch.object(
+                    project_import_service.workspace,
+                    "get_project_by_id",
+                    return_value={"id": "prj_1", "path": project_path},
+                ),
+                mock.patch.object(
+                    project_import_service,
+                    "generate_thumbnail_for_project",
+                    side_effect=no_board,
+                ),
+                mock.patch.object(
+                    project_import_service, "refresh_project_assets", return_value={}
+                ) as refresh,
+            ):
+                result = project_import_service.run_project_thumbnail_job_v3(context)
+
+        refresh.assert_called_once_with("prj_1")
+        self.assertEqual(result.message, "No board to render")
+        self.assertFalse(result.details["rendered"])
 
     def test_handler_rejects_a_project_whose_checkout_is_gone(self) -> None:
         context = SimpleNamespace(

--- a/backend/tests/test_workspace_bulk_move.py
+++ b/backend/tests/test_workspace_bulk_move.py
@@ -1,0 +1,105 @@
+from contextlib import contextmanager
+import unittest
+from unittest.mock import patch
+
+from app.services.workspace_service import WorkspaceService
+
+
+class _Result:
+    def __init__(self, rows=None, rowcount=0):
+        self._rows = list(rows or [])
+        self.rowcount = rowcount
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+
+class _Connection:
+    def __init__(self, *, folder_exists=True, existing_project_ids=()):
+        self.folder_exists = folder_exists
+        self.existing_project_ids = set(existing_project_ids)
+        self.statements = []
+        self.commits = 0
+
+    def execute(self, query, params=()):
+        statement = " ".join(query.split())
+        self.statements.append((statement, params))
+
+        if statement.startswith("SELECT id FROM ws_folders"):
+            return _Result([{"id": params[0]}] if self.folder_exists else [])
+        if statement.startswith("SELECT id FROM ws_projects"):
+            requested = params[0]
+            return _Result(
+                [{"id": project_id} for project_id in requested if project_id in self.existing_project_ids]
+            )
+        if statement.startswith("UPDATE ws_projects"):
+            return _Result(rowcount=len(params[1]))
+        raise AssertionError(f"Unexpected SQL: {statement}")
+
+    def commit(self):
+        self.commits += 1
+
+
+class WorkspaceBulkMoveTests(unittest.TestCase):
+    def run_with_connection(self, connection, callback):
+        service = WorkspaceService()
+
+        @contextmanager
+        def connect():
+            yield connection
+
+        with patch.object(service, "_connect", connect):
+            return callback(service)
+
+    def test_bulk_move_validates_then_updates_all_projects_once(self):
+        connection = _Connection(existing_project_ids={"prj_a", "prj_b"})
+        moved = self.run_with_connection(
+            connection,
+            lambda service: service.move_projects_to_folder(
+                ["prj_a", "prj_b", "prj_a"], "fld_target"
+            ),
+        )
+
+        self.assertEqual(moved, 2)
+        self.assertEqual(connection.commits, 1)
+        self.assertEqual(
+            [statement.split()[0] for statement, _ in connection.statements],
+            ["SELECT", "SELECT", "UPDATE"],
+        )
+        update_statement, update_params = connection.statements[-1]
+        self.assertIn("WHERE id = ANY(%s)", update_statement)
+        self.assertEqual(update_params, ("fld_target", ["prj_a", "prj_b"]))
+
+    def test_bulk_move_does_not_update_any_project_when_one_is_missing(self):
+        connection = _Connection(existing_project_ids={"prj_a"})
+
+        with self.assertRaisesRegex(ValueError, "Project not found: prj_missing"):
+            self.run_with_connection(
+                connection,
+                lambda service: service.move_projects_to_folder(
+                    ["prj_a", "prj_missing"], "fld_target"
+                ),
+            )
+
+        self.assertEqual(connection.commits, 0)
+        self.assertTrue(
+            all(not statement.startswith("UPDATE") for statement, _ in connection.statements)
+        )
+
+    def test_bulk_move_does_not_update_projects_when_destination_is_missing(self):
+        connection = _Connection(folder_exists=False, existing_project_ids={"prj_a", "prj_b"})
+
+        with self.assertRaisesRegex(ValueError, "Folder not found"):
+            self.run_with_connection(
+                connection,
+                lambda service: service.move_projects_to_folder(
+                    ["prj_a", "prj_b"], "fld_missing"
+                ),
+            )
+
+        self.assertEqual(connection.commits, 0)
+        self.assertEqual(len(connection.statements), 1)
+        self.assertTrue(connection.statements[0][0].startswith("SELECT id FROM ws_folders"))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,11 +7,11 @@ import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
 import { ApiHttpError, fetchApi } from '@/lib/api';
 import { fetchAuthConfig, fetchCurrentUser, isAuthCallbackPath } from '@/lib/auth';
-import { roleLabel } from '@/lib/roles';
 import { IS_APPLE_PLATFORM } from '@/lib/shortcuts';
 import { useHotkeys } from '@/hooks/use-hotkeys';
 import { CommandPalette } from '@/components/command-palette';
 import { KeyboardShortcutsDialog } from '@/components/keyboard-shortcuts-dialog';
+import { RoleAuthorityPopover } from '@/components/role-authority-popover';
 import prismLogoMark from './assets/branding/kicad-prism/kicad-prism-icon.svg';
 
 const LoginPage = lazy(() =>
@@ -246,7 +246,7 @@ function App() {
                                     {user && user.email !== 'guest@local' && (
                                         <>
                                             <span className="text-sm text-muted-foreground">
-                                                Welcome, {user.name} ({roleLabel(user.role)})
+                                                Welcome, {user.name} (<RoleAuthorityPopover role={user.role} />)
                                             </span>
                                             <Button variant="ghost" size="sm" onClick={handleLogout}>Logout</Button>
                                         </>

--- a/frontend/src/components/import-dialog.test.ts
+++ b/frontend/src/components/import-dialog.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { importReviewTitle } from "./import-dialog";
+
+describe("importReviewTitle", () => {
+  it("reports an empty analysis instead of claiming multiple projects", () => {
+    expect(importReviewTitle({ import_type: "type2", projects: [] })).toBe(
+      "No Projects Detected",
+    );
+  });
+
+  it("preserves the single and multiple project titles", () => {
+    const project = {
+      name: "Power",
+      relative_path: ".",
+      has_schematic: true,
+      has_pcb: true,
+    };
+    expect(importReviewTitle({ import_type: "type1", projects: [project] })).toBe(
+      "Single Project Detected",
+    );
+    expect(importReviewTitle({ import_type: "type2", projects: [project] })).toBe(
+      "Multiple Projects Detected",
+    );
+  });
+});

--- a/frontend/src/components/import-dialog.tsx
+++ b/frontend/src/components/import-dialog.tsx
@@ -38,6 +38,15 @@ interface AnalysisResult {
   imported_paths?: string[];
 }
 
+export function importReviewTitle(
+  analysis: Pick<AnalysisResult, "import_type" | "projects">,
+): string {
+  if (analysis.projects.length === 0) return "No Projects Detected";
+  return analysis.import_type === "type1"
+    ? "Single Project Detected"
+    : "Multiple Projects Detected";
+}
+
 interface JobStatus {
   job_id: string;
   status: "queued" | "running" | "completed" | "failed" | "cancelled";
@@ -610,9 +619,7 @@ export function ImportDialog({
           <>
             <DialogHeader>
               <DialogTitle>
-                {state.analysis.import_type === "type1"
-                  ? "Single Project Detected"
-                  : "Multiple Projects Detected"}
+                {importReviewTitle(state.analysis)}
               </DialogTitle>
               <DialogDescription>
                 {state.analysis.projects.length === 0

--- a/frontend/src/components/role-authority-popover.test.tsx
+++ b/frontend/src/components/role-authority-popover.test.tsx
@@ -1,0 +1,20 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RoleAuthorityPopover } from "./role-authority-popover";
+
+afterEach(cleanup);
+
+describe("RoleAuthorityPopover", () => {
+  it("opens the authority matrix from the role label and highlights the current role", () => {
+    render(<RoleAuthorityPopover role="component_qa" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show permissions for Component QA" }));
+
+    const matrix = screen.getByRole("table", { name: "Role authority matrix" });
+    expect(screen.getByText("Your role is Component QA. The highlighted column shows what you can do.")).toBeInTheDocument();
+    expect(within(matrix).getByRole("columnheader", { name: "Component QA (current)" })).toBeInTheDocument();
+    expect(within(matrix).getByLabelText("Review component QA: Component QA is allowed")).toBeInTheDocument();
+    expect(within(matrix).getByLabelText("Manage projects: Component QA is not allowed")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/role-authority-popover.tsx
+++ b/frontend/src/components/role-authority-popover.tsx
@@ -1,0 +1,121 @@
+import { Check, Info, Minus } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import {
+  ROLE_AUTHORITIES,
+  ROLE_OPTIONS,
+  roleHasAuthority,
+  roleLabel,
+} from "@/lib/roles";
+import type { UserRole } from "@/types/auth";
+
+interface RoleAuthorityPopoverProps {
+  role: UserRole;
+}
+
+export function RoleAuthorityPopover({ role }: RoleAuthorityPopoverProps) {
+  let previousCategory = "";
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Show permissions for ${roleLabel(role)}`}
+          className="inline-flex items-center gap-1 rounded-sm font-medium text-foreground underline decoration-dotted underline-offset-4 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          {roleLabel(role)}
+          <Info aria-hidden="true" className="h-3.5 w-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-[min(52rem,calc(100vw-2rem))] gap-0 overflow-hidden rounded-md p-0"
+      >
+        <PopoverHeader className="border-b p-4">
+          <PopoverTitle>Role permissions</PopoverTitle>
+          <PopoverDescription>
+            Your role is {roleLabel(role)}. The highlighted column shows what you can do.
+          </PopoverDescription>
+        </PopoverHeader>
+
+        <div className="overflow-x-auto">
+          <table aria-label="Role authority matrix" className="w-full min-w-[46rem] border-collapse text-left">
+            <thead>
+              <tr className="border-b bg-muted/40">
+                <th scope="col" className="w-[17rem] px-3 py-2 font-medium">
+                  Permission
+                </th>
+                {ROLE_OPTIONS.map((matrixRole) => {
+                  const current = matrixRole === role;
+                  return (
+                    <th
+                      key={matrixRole}
+                      scope="col"
+                      aria-label={`${roleLabel(matrixRole)}${current ? " (current)" : ""}`}
+                      className={cn(
+                        "min-w-[5.5rem] px-2 py-2 text-center text-[11px] font-medium leading-tight",
+                        current && "bg-primary/10 text-primary",
+                      )}
+                    >
+                      {roleLabel(matrixRole)}
+                      {current && <span className="mt-0.5 block text-[10px] font-normal">Your role</span>}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {ROLE_AUTHORITIES.map((authority) => {
+                const showCategory = authority.category !== previousCategory;
+                previousCategory = authority.category;
+                return (
+                  <tr key={authority.key} className="border-b last:border-b-0">
+                    <th scope="row" className="px-3 py-2 align-top font-normal">
+                      {showCategory && (
+                        <span className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          {authority.category}
+                        </span>
+                      )}
+                      <span className="block font-medium text-foreground">{authority.label}</span>
+                      <span className="mt-0.5 block text-[11px] leading-snug text-muted-foreground">
+                        {authority.description}
+                      </span>
+                    </th>
+                    {ROLE_OPTIONS.map((matrixRole) => {
+                      const allowed = roleHasAuthority(matrixRole, authority.key);
+                      return (
+                        <td
+                          key={matrixRole}
+                          aria-label={`${authority.label}: ${roleLabel(matrixRole)} is ${allowed ? "allowed" : "not allowed"}`}
+                          className={cn(
+                            "px-2 py-2 text-center align-middle",
+                            matrixRole === role && "bg-primary/10",
+                          )}
+                        >
+                          {allowed ? (
+                            <Check aria-hidden="true" className="mx-auto h-4 w-4 text-success" />
+                          ) : (
+                            <Minus aria-hidden="true" className="mx-auto h-4 w-4 text-muted-foreground/50" />
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { FolderPlus, LayoutGrid, PanelLeftClose, PanelLeftOpen, RefreshCw, Settings } from "lucide-react";
+import { FolderInput, FolderPlus, Image, LayoutGrid, PanelLeftClose, PanelLeftOpen, RefreshCw, Settings } from "lucide-react";
 import { toast } from "sonner";
 
 import type { User } from "@/types/auth";
@@ -56,7 +56,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const { projects, folders, loading, error, folderById, refresh, createFolder, renameFolder, deleteFolder, moveProject, deleteProject } =
+  const { projects, folders, loading, error, folderById, refresh, createFolder, renameFolder, deleteFolder, moveProjects, deleteProject } =
     useWorkspaceData();
 
   const requestedSection = searchParams.get("section") === "library-manager" ? "library-manager" : "projects";
@@ -70,6 +70,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [bulkSelectedProjectIds, setBulkSelectedProjectIds] = useState<Set<string>>(() => new Set());
 
   const [folderToRename, setFolderToRename] = useState<FolderTreeItem | null>(null);
   const [isRenamingFolder, setIsRenamingFolder] = useState(false);
@@ -77,8 +78,9 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const [folderToDelete, setFolderToDelete] = useState<FolderTreeItem | null>(null);
   const [isDeletingFolder, setIsDeletingFolder] = useState(false);
 
-  const [projectToMove, setProjectToMove] = useState<Project | null>(null);
+  const [projectsToMove, setProjectsToMove] = useState<Project[]>([]);
   const [isMovingProject, setIsMovingProject] = useState(false);
+  const [isRegeneratingThumbnails, setIsRegeneratingThumbnails] = useState(false);
 
   const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
   const [isDeletingProject, setIsDeletingProject] = useState(false);
@@ -171,6 +173,10 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const totalPages = Math.max(1, Math.ceil(allListProjects.length / WORKSPACE_PAGE_SIZE));
   const pageStart = (currentPage - 1) * WORKSPACE_PAGE_SIZE;
   const listProjects = allListProjects.slice(pageStart, pageStart + WORKSPACE_PAGE_SIZE);
+  const visibleProjectIdsKey = listProjects.map((project) => project.id).join("\u0000");
+  const selectedVisibleProjects = listProjects.filter((project) => bulkSelectedProjectIds.has(project.id));
+  const allVisibleProjectsSelected =
+    listProjects.length > 0 && selectedVisibleProjects.length === listProjects.length;
   const pageLabel =
     allListProjects.length === 0
       ? "0 projects"
@@ -183,6 +189,37 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   useEffect(() => {
     setCurrentPage((page) => Math.min(page, totalPages));
   }, [totalPages]);
+
+  useEffect(() => {
+    const visibleIds = new Set(visibleProjectIdsKey ? visibleProjectIdsKey.split("\u0000") : []);
+    setBulkSelectedProjectIds((current) => {
+      const retained = new Set([...current].filter((projectId) => visibleIds.has(projectId)));
+      if (retained.size === current.size && [...retained].every((projectId) => current.has(projectId))) {
+        return current;
+      }
+      return retained;
+    });
+  }, [visibleProjectIdsKey]);
+
+  const toggleProjectSelection = (projectId: string, selected: boolean) => {
+    setBulkSelectedProjectIds((current) => {
+      const next = new Set(current);
+      if (selected) {
+        next.add(projectId);
+      } else {
+        next.delete(projectId);
+      }
+      return next;
+    });
+  };
+
+  const toggleVisibleProjectSelection = () => {
+    setBulkSelectedProjectIds(
+      allVisibleProjectsSelected
+        ? new Set()
+        : new Set(listProjects.map((project) => project.id)),
+    );
+  };
 
   // Actions that need this screen's dialog state, published to the ⌘K palette
   // for as long as the workspace is mounted.
@@ -292,7 +329,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
     }
   };
 
-  const handleMoveProject = async (projectId: string, folderId: string | null) => {
+  const handleMoveProjects = async (projectIds: string[], folderId: string | null) => {
     if (!canManageProjects) {
       toast.error("You do not have permission to move projects");
       return;
@@ -300,15 +337,16 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
 
     setIsMovingProject(true);
     try {
-      const movedProjectName = projectToMove ? getProjectDisplayName(projectToMove) : "project";
-      const result = await moveProject(projectId, folderId);
+      const movedProjectName = projectsToMove.length === 1 ? getProjectDisplayName(projectsToMove[0]) : null;
+      const result = await moveProjects(projectIds, folderId);
       if (!result.ok) {
-        toast.error(result.error || "Failed to move project");
+        toast.error(result.error || (projectIds.length === 1 ? "Failed to move project" : "Failed to move projects"));
         return;
       }
 
-      toast.success(`Moved "${movedProjectName}"`);
-      setProjectToMove(null);
+      toast.success(movedProjectName ? `Moved "${movedProjectName}"` : `Moved ${projectIds.length} projects`);
+      setProjectsToMove([]);
+      setBulkSelectedProjectIds(new Set());
     } finally {
       setIsMovingProject(false);
     }
@@ -366,6 +404,45 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
       await refresh();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to render thumbnail", { id: toastId });
+    }
+  };
+
+  const handleRegenerateThumbnails = async (projectsToRegenerate: Project[]) => {
+    if (!canManageProjects) {
+      toast.error("You do not have permission to regenerate thumbnails");
+      return;
+    }
+    if (projectsToRegenerate.length === 0) return;
+
+    setIsRegeneratingThumbnails(true);
+    const count = projectsToRegenerate.length;
+    const toastId = toast.loading(`Rendering thumbnails for ${count} projects...`);
+    try {
+      const response = await fetchApi("/api/projects/thumbnails/regenerate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_ids: projectsToRegenerate.map((project) => project.id) }),
+      });
+
+      if (!response.ok) {
+        toast.error(await readApiError(response, "Failed to queue thumbnail renders"), { id: toastId });
+        return;
+      }
+
+      const payload = (await response.json()) as { job_ids?: string[]; count?: number };
+      const jobIds = payload.job_ids ?? [];
+      const jobs = await Promise.all(jobIds.map((jobId) => watchPrismJob(jobId)));
+      jobs.forEach((job) => throwIfJobFailed(job, "Failed to render thumbnail"));
+
+      toast.success(`Rendered ${payload.count ?? count} thumbnail${(payload.count ?? count) === 1 ? "" : "s"}`, {
+        id: toastId,
+      });
+      setBulkSelectedProjectIds(new Set());
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to render thumbnails", { id: toastId });
+    } finally {
+      setIsRegeneratingThumbnails(false);
     }
   };
 
@@ -494,9 +571,43 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                 <div className="relative mt-6 min-h-0 flex-1 overflow-hidden">
                   <div className="h-full overflow-y-auto pr-1">
                     <div className="mb-4 flex items-center justify-between rounded-lg border bg-card/30 px-3 py-2">
-                      <p className="text-xs text-muted-foreground">
-                        Page {currentPage} of {totalPages} · {pageLabel}
-                      </p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-xs text-muted-foreground">
+                          Page {currentPage} of {totalPages} · {pageLabel}
+                        </p>
+                        {canManageProjects && listProjects.length > 0 && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2 text-[11px]"
+                            onClick={toggleVisibleProjectSelection}
+                          >
+                            {allVisibleProjectsSelected ? "Clear selection" : `Select visible (${listProjects.length})`}
+                          </Button>
+                        )}
+                        {canManageProjects && selectedVisibleProjects.length > 0 && (
+                          <>
+                            <Button
+                              size="sm"
+                              className="h-7 px-2 text-[11px]"
+                              onClick={() => setProjectsToMove(selectedVisibleProjects)}
+                            >
+                              <FolderInput className="mr-1.5 h-3.5 w-3.5" />
+                              Move selected ({selectedVisibleProjects.length})
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-7 px-2 text-[11px]"
+                              disabled={isRegeneratingThumbnails}
+                              onClick={() => void handleRegenerateThumbnails(selectedVisibleProjects)}
+                            >
+                              <Image className="mr-1.5 h-3.5 w-3.5" />
+                              Regenerate thumbnails ({selectedVisibleProjects.length})
+                            </Button>
+                          </>
+                        )}
+                      </div>
                       <div className="flex items-center gap-1.5">
                         <Button
                           size="sm"
@@ -542,16 +653,18 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                         isSearching={isSearching}
                         searchResults={listProjects}
                         selectedProjectId={selectedProjectId}
+                        bulkSelectedProjectIds={bulkSelectedProjectIds}
                         currentFolderId={currentFolderId}
                         visibleFolders={visibleFolders}
                         visibleProjects={listProjects}
                         getProjectDisplayName={getProjectDisplayName}
                         onSelectProject={selectProject}
+                        onToggleProjectSelection={toggleProjectSelection}
                         onOpenProject={openProject}
                         onOpenFolder={(folderId) => setFolderInUrl(folderId)}
                         onRenameFolder={setFolderToRename}
                         onDeleteFolder={setFolderToDelete}
-                        onMoveProject={setProjectToMove}
+                        onMoveProject={(project) => setProjectsToMove([project])}
                         onDeleteProject={setProjectToDelete}
                         onRegenerateThumbnail={handleRegenerateThumbnail}
                         canManageProjects={canManageProjects}
@@ -560,17 +673,19 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                       <WorkspaceListView
                         isSearching={isSearching}
                         selectedProjectId={selectedProjectId}
+                        bulkSelectedProjectIds={bulkSelectedProjectIds}
                         currentFolderId={currentFolderId}
                         breadcrumbs={breadcrumbs}
                         listFolders={listFolders}
                         listProjects={listProjects}
                         getProjectDisplayName={getProjectDisplayName}
                         onSelectProject={selectProject}
+                        onToggleProjectSelection={toggleProjectSelection}
                         onOpenProject={openProject}
                         onOpenFolder={(folderId) => setFolderInUrl(folderId)}
                         onRenameFolder={setFolderToRename}
                         onDeleteFolder={setFolderToDelete}
-                        onMoveProject={setProjectToMove}
+                        onMoveProject={(project) => setProjectsToMove([project])}
                         onDeleteProject={setProjectToDelete}
                         onRegenerateThumbnail={handleRegenerateThumbnail}
                         canManageProjects={canManageProjects}
@@ -645,14 +760,14 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
           />
         </Suspense>
       )}
-      {projectToMove && (
+      {projectsToMove.length > 0 && (
         <Suspense fallback={null}>
           <MoveProjectDialog
-            project={projectToMove}
+            projects={projectsToMove}
             folders={folders}
             isMoving={isMovingProject}
-            onClose={() => setProjectToMove(null)}
-            onConfirm={handleMoveProject}
+            onClose={() => setProjectsToMove([])}
+            onConfirm={handleMoveProjects}
             getProjectDisplayName={getProjectDisplayName}
           />
         </Suspense>

--- a/frontend/src/components/workspace/move-project-dialog.test.tsx
+++ b/frontend/src/components/workspace/move-project-dialog.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { FolderTreeItem, Project } from "@/types/project";
+import { MoveProjectDialog } from "./move-project-dialog";
+
+afterEach(cleanup);
+
+function project(id: string, folderId: string | null): Project {
+  return {
+    id,
+    name: id,
+    description: "",
+    path: `/projects/${id}`,
+    last_modified: "2026-08-01T00:00:00Z",
+    folder_id: folderId,
+  };
+}
+
+const folders: FolderTreeItem[] = [
+  {
+    id: "fld_a",
+    name: "Folder A",
+    parent_id: null,
+    depth: 0,
+    has_children: false,
+    direct_project_count: 1,
+    total_project_count: 1,
+  },
+  {
+    id: "fld_target",
+    name: "Target",
+    parent_id: null,
+    depth: 0,
+    has_children: false,
+    direct_project_count: 0,
+    total_project_count: 0,
+  },
+];
+
+describe("MoveProjectDialog bulk moves", () => {
+  it("submits all selected project ids in one confirmation", () => {
+    const onConfirm = vi.fn();
+    render(
+      <MoveProjectDialog
+        projects={[project("prj_a", "fld_a"), project("prj_b", null)]}
+        folders={folders}
+        isMoving={false}
+        onClose={() => {}}
+        onConfirm={onConfirm}
+        getProjectDisplayName={(item) => item.name}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Move 2 Projects" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Move" })).toBeDisabled();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Destination folder" }), {
+      target: { value: "fld_target" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(["prj_a", "prj_b"], "fld_target");
+  });
+});

--- a/frontend/src/components/workspace/move-project-dialog.tsx
+++ b/frontend/src/components/workspace/move-project-dialog.tsx
@@ -13,18 +13,19 @@ import {
 } from "@/components/ui/dialog";
 
 interface MoveProjectDialogProps {
-  project: Project | null;
+  projects: Project[];
   folders: FolderTreeItem[];
   isMoving: boolean;
   onClose: () => void;
-  onConfirm: (projectId: string, folderId: string | null) => void | Promise<void>;
+  onConfirm: (projectIds: string[], folderId: string | null) => void | Promise<void>;
   getProjectDisplayName: (project: Project) => string;
 }
 
 const ROOT_VALUE = "__root__";
+const UNSELECTED_VALUE = "__unselected__";
 
 export function MoveProjectDialog({
-  project,
+  projects,
   folders,
   isMoving,
   onClose,
@@ -88,14 +89,27 @@ export function MoveProjectDialog({
   }, [folders]);
 
   useEffect(() => {
-    setTargetFolderId(project?.folder_id ?? ROOT_VALUE);
-  }, [project]);
-
-  const submit = () => {
-    if (!project) {
+    if (projects.length === 0) {
+      setTargetFolderId(ROOT_VALUE);
       return;
     }
-    void onConfirm(project.id, targetFolderId === ROOT_VALUE ? null : targetFolderId);
+
+    const sourceFolderIds = new Set(projects.map((project) => project.folder_id ?? null));
+    if (sourceFolderIds.size === 1) {
+      setTargetFolderId(projects[0].folder_id ?? ROOT_VALUE);
+    } else {
+      setTargetFolderId(UNSELECTED_VALUE);
+    }
+  }, [projects]);
+
+  const submit = () => {
+    if (projects.length === 0 || targetFolderId === UNSELECTED_VALUE) {
+      return;
+    }
+    void onConfirm(
+      projects.map((project) => project.id),
+      targetFolderId === ROOT_VALUE ? null : targetFolderId,
+    );
   };
 
   const handleDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -104,7 +118,7 @@ export function MoveProjectDialog({
     }
 
     event.preventDefault();
-    if (isMoving || !project) {
+    if (isMoving || projects.length === 0 || targetFolderId === UNSELECTED_VALUE) {
       return;
     }
 
@@ -112,22 +126,34 @@ export function MoveProjectDialog({
   };
 
   return (
-    <Dialog open={!!project} onOpenChange={(open) => !open && onClose()}>
+    <Dialog open={projects.length > 0} onOpenChange={(open) => !open && onClose()}>
       <DialogContent onKeyDown={handleDialogKeyDown}>
         <DialogHeader>
-          <DialogTitle>Move Project</DialogTitle>
-          <DialogDescription>Select where this project should live.</DialogDescription>
+          <DialogTitle>{projects.length === 1 ? "Move Project" : `Move ${projects.length} Projects`}</DialogTitle>
+          <DialogDescription>
+            {projects.length === 1
+              ? "Select where this project should live."
+              : "Select one destination for all selected projects. The move is applied atomically."}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground">
-            Project: {project ? getProjectDisplayName(project) : ""}
+            {projects.length === 1
+              ? `Project: ${getProjectDisplayName(projects[0])}`
+              : `${projects.length} selected projects`}
           </p>
           <select
+            aria-label="Destination folder"
             className="w-full rounded-md border bg-background px-3 py-2 text-sm"
             value={targetFolderId}
             onChange={(event) => setTargetFolderId(event.target.value)}
           >
+            {targetFolderId === UNSELECTED_VALUE && (
+              <option value={UNSELECTED_VALUE} disabled>
+                Choose a destination
+              </option>
+            )}
             <option value={ROOT_VALUE}>Workspace Root</option>
             {folders.map((folder) => (
               <option key={folder.id} value={folder.id}>
@@ -141,7 +167,10 @@ export function MoveProjectDialog({
           <Button variant="outline" onClick={onClose} disabled={isMoving}>
             Cancel
           </Button>
-          <Button onClick={submit} disabled={isMoving || !project}>
+          <Button
+            onClick={submit}
+            disabled={isMoving || projects.length === 0 || targetFolderId === UNSELECTED_VALUE}
+          >
             {isMoving ? "Moving..." : "Move"}
           </Button>
         </DialogFooter>

--- a/frontend/src/components/workspace/workspace-gallery-view.test.tsx
+++ b/frontend/src/components/workspace/workspace-gallery-view.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import type { Project } from "@/types/project";
+import { WorkspaceGalleryView } from "./workspace-gallery-view";
+
+afterEach(cleanup);
+
+const project: Project = {
+  id: "prj_card",
+  name: "Card Board",
+  description: "",
+  path: "/projects/card",
+  last_modified: "2026-08-01T00:00:00Z",
+  folder_id: null,
+};
+
+describe("WorkspaceGalleryView project selection", () => {
+  it("uses a compact square shadcn checkbox on project cards", () => {
+    const onToggleProjectSelection = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <WorkspaceGalleryView
+          searchQuery=""
+          isSearching={false}
+          searchResults={[]}
+          selectedProjectId={null}
+          bulkSelectedProjectIds={new Set()}
+          currentFolderId={null}
+          visibleFolders={[]}
+          visibleProjects={[project]}
+          getProjectDisplayName={(item) => item.name}
+          onSelectProject={() => {}}
+          onToggleProjectSelection={onToggleProjectSelection}
+          onOpenProject={() => {}}
+          onOpenFolder={() => {}}
+          onRenameFolder={() => {}}
+          onDeleteFolder={() => {}}
+          onMoveProject={() => {}}
+          onDeleteProject={() => {}}
+          onRegenerateThumbnail={() => {}}
+          canManageProjects
+        />
+      </MemoryRouter>,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Select Card Board" });
+    expect(checkbox).toHaveClass("h-5", "w-5", "border-2", "rounded-sm");
+
+    fireEvent.click(checkbox);
+    expect(onToggleProjectSelection).toHaveBeenCalledWith("prj_card", true);
+  });
+});

--- a/frontend/src/components/workspace/workspace-gallery-view.tsx
+++ b/frontend/src/components/workspace/workspace-gallery-view.tsx
@@ -2,6 +2,7 @@ import { Folder } from "lucide-react";
 
 import { FolderTreeItem, Project } from "@/types/project";
 import { ProjectCard } from "@/components/project-card";
+import { Checkbox } from "@/components/ui/checkbox";
 
 import { FolderActionMenu, ProjectActionMenu } from "./workspace-action-menus";
 import { PROJECT_GRID_CLASS } from "./workspace-types";
@@ -11,11 +12,13 @@ interface WorkspaceGalleryViewProps {
   isSearching: boolean;
   searchResults: Project[];
   selectedProjectId: string | null;
+  bulkSelectedProjectIds: ReadonlySet<string>;
   currentFolderId: string | null;
   visibleFolders: FolderTreeItem[];
   visibleProjects: Project[];
   getProjectDisplayName: (project: Project) => string;
   onSelectProject: (project: Project) => void;
+  onToggleProjectSelection: (projectId: string, selected: boolean) => void;
   onOpenProject: (project: Project) => void;
   onOpenFolder: (folderId: string) => void;
   onRenameFolder: (folder: FolderTreeItem) => void;
@@ -31,11 +34,13 @@ export function WorkspaceGalleryView({
   isSearching,
   searchResults,
   selectedProjectId,
+  bulkSelectedProjectIds,
   currentFolderId,
   visibleFolders,
   visibleProjects,
   getProjectDisplayName,
   onSelectProject,
+  onToggleProjectSelection,
   onOpenProject,
   onOpenFolder,
   onRenameFolder,
@@ -57,24 +62,39 @@ export function WorkspaceGalleryView({
           ) : (
             <div className={PROJECT_GRID_CLASS}>
               {searchResults.map((project) => (
-                <ProjectCard
-                  key={project.id}
-                  project={project}
-                  selected={selectedProjectId === project.id}
-                  searchQuery={searchQuery}
-                  onClick={() => onSelectProject(project)}
-                  onDoubleClick={() => onOpenProject(project)}
-                  actions={
-                    <ProjectActionMenu
-                      project={project}
-                      projectName={getProjectDisplayName(project)}
-                      onMove={onMoveProject}
-                      onDelete={onDeleteProject}
-                      onRegenerateThumbnail={onRegenerateThumbnail}
-                      canManage={canManageProjects}
-                    />
-                  }
-                />
+                <div key={project.id} className="relative">
+                  {canManageProjects && (
+                    <div
+                      className="absolute left-2 top-2 z-10"
+                      onClick={(event) => event.stopPropagation()}
+                      onDoubleClick={(event) => event.stopPropagation()}
+                    >
+                      <Checkbox
+                        className="h-5 w-5 border-2 bg-background/95 shadow-md"
+                        checked={bulkSelectedProjectIds.has(project.id)}
+                        onCheckedChange={(checked) => onToggleProjectSelection(project.id, checked === true)}
+                        aria-label={`Select ${getProjectDisplayName(project)}`}
+                      />
+                    </div>
+                  )}
+                  <ProjectCard
+                    project={project}
+                    selected={selectedProjectId === project.id || bulkSelectedProjectIds.has(project.id)}
+                    searchQuery={searchQuery}
+                    onClick={() => onSelectProject(project)}
+                    onDoubleClick={() => onOpenProject(project)}
+                    actions={
+                      <ProjectActionMenu
+                        project={project}
+                        projectName={getProjectDisplayName(project)}
+                        onMove={onMoveProject}
+                        onDelete={onDeleteProject}
+                        onRegenerateThumbnail={onRegenerateThumbnail}
+                        canManage={canManageProjects}
+                      />
+                    }
+                  />
+                </div>
               ))}
             </div>
           )}
@@ -134,23 +154,38 @@ export function WorkspaceGalleryView({
             ) : (
               <div className={PROJECT_GRID_CLASS}>
                 {visibleProjects.map((project) => (
-                  <ProjectCard
-                    key={project.id}
-                    project={project}
-                    selected={selectedProjectId === project.id}
-                    onClick={() => onSelectProject(project)}
-                    onDoubleClick={() => onOpenProject(project)}
-                    actions={
-                      <ProjectActionMenu
-                        project={project}
-                        projectName={getProjectDisplayName(project)}
-                        onMove={onMoveProject}
-                        onDelete={onDeleteProject}
-                        onRegenerateThumbnail={onRegenerateThumbnail}
-                        canManage={canManageProjects}
-                      />
-                    }
-                  />
+                  <div key={project.id} className="relative">
+                  {canManageProjects && (
+                    <div
+                      className="absolute left-2 top-2 z-10"
+                      onClick={(event) => event.stopPropagation()}
+                      onDoubleClick={(event) => event.stopPropagation()}
+                    >
+                      <Checkbox
+                        className="h-5 w-5 border-2 bg-background/95 shadow-md"
+                        checked={bulkSelectedProjectIds.has(project.id)}
+                          onCheckedChange={(checked) => onToggleProjectSelection(project.id, checked === true)}
+                          aria-label={`Select ${getProjectDisplayName(project)}`}
+                        />
+                      </div>
+                    )}
+                    <ProjectCard
+                      project={project}
+                      selected={selectedProjectId === project.id || bulkSelectedProjectIds.has(project.id)}
+                      onClick={() => onSelectProject(project)}
+                      onDoubleClick={() => onOpenProject(project)}
+                      actions={
+                        <ProjectActionMenu
+                          project={project}
+                          projectName={getProjectDisplayName(project)}
+                          onMove={onMoveProject}
+                          onDelete={onDeleteProject}
+                          onRegenerateThumbnail={onRegenerateThumbnail}
+                          canManage={canManageProjects}
+                        />
+                      }
+                    />
+                  </div>
                 ))}
               </div>
             )}

--- a/frontend/src/components/workspace/workspace-list-view.test.tsx
+++ b/frontend/src/components/workspace/workspace-list-view.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Project } from "@/types/project";
+import { WorkspaceListView } from "./workspace-list-view";
+
+afterEach(cleanup);
+
+const project: Project = {
+  id: "prj_visible",
+  name: "Visible Board",
+  description: "",
+  path: "/projects/visible",
+  last_modified: "2026-08-01T00:00:00Z",
+  folder_id: null,
+};
+
+describe("WorkspaceListView bulk selection", () => {
+  it("selects a visible project without opening its properties", () => {
+    const onSelectProject = vi.fn();
+    const onToggleProjectSelection = vi.fn();
+
+    render(
+      <WorkspaceListView
+        isSearching={false}
+        selectedProjectId={null}
+        bulkSelectedProjectIds={new Set()}
+        currentFolderId={null}
+        breadcrumbs={[]}
+        listFolders={[]}
+        listProjects={[project]}
+        getProjectDisplayName={(item) => item.display_name || item.name}
+        onSelectProject={onSelectProject}
+        onToggleProjectSelection={onToggleProjectSelection}
+        onOpenProject={() => {}}
+        onOpenFolder={() => {}}
+        onRenameFolder={() => {}}
+        onDeleteFolder={() => {}}
+        onMoveProject={() => {}}
+        onDeleteProject={() => {}}
+        onRegenerateThumbnail={() => {}}
+        canManageProjects
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Visible Board" }));
+
+    expect(onToggleProjectSelection).toHaveBeenCalledWith("prj_visible", true);
+    expect(onSelectProject).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/workspace/workspace-list-view.tsx
+++ b/frontend/src/components/workspace/workspace-list-view.tsx
@@ -2,18 +2,21 @@ import { Folder } from "lucide-react";
 
 import { SearchProject } from "@/hooks/use-workspace-search";
 import { FolderTreeItem, Project } from "@/types/project";
+import { Checkbox } from "@/components/ui/checkbox";
 
 import { FolderActionMenu, ProjectActionMenu } from "./workspace-action-menus";
 
 interface WorkspaceListViewProps {
   isSearching: boolean;
   selectedProjectId: string | null;
+  bulkSelectedProjectIds: ReadonlySet<string>;
   currentFolderId: string | null;
   breadcrumbs: FolderTreeItem[];
   listFolders: FolderTreeItem[];
   listProjects: Project[];
   getProjectDisplayName: (project: Project) => string;
   onSelectProject: (project: Project) => void;
+  onToggleProjectSelection: (projectId: string, selected: boolean) => void;
   onOpenProject: (project: Project) => void;
   onOpenFolder: (folderId: string) => void;
   onRenameFolder: (folder: FolderTreeItem) => void;
@@ -44,12 +47,14 @@ function resolveProjectLocation(
 export function WorkspaceListView({
   isSearching,
   selectedProjectId,
+  bulkSelectedProjectIds,
   currentFolderId,
   breadcrumbs,
   listFolders,
   listProjects,
   getProjectDisplayName,
   onSelectProject,
+  onToggleProjectSelection,
   onOpenProject,
   onOpenFolder,
   onRenameFolder,
@@ -61,7 +66,8 @@ export function WorkspaceListView({
 }: WorkspaceListViewProps) {
   return (
     <div className="overflow-hidden rounded-xl border">
-      <div className="grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] border-b bg-muted/30 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      <div className="grid grid-cols-[auto_minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] gap-x-3 border-b bg-muted/30 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <span className="w-4"><span className="sr-only">Select</span></span>
         <div>Name</div>
         <div>Description</div>
         <div>Location</div>
@@ -76,8 +82,9 @@ export function WorkspaceListView({
           {listFolders.map((folder) => (
             <div
               key={folder.id}
-              className="grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] items-center border-b px-4 py-2"
+              className="grid grid-cols-[auto_minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] items-center gap-x-3 border-b px-4 py-2"
             >
+              <span className="w-4" />
               <button
                 type="button"
                 className="flex min-w-0 items-center gap-2 text-left text-sm font-medium hover:text-primary"
@@ -103,10 +110,23 @@ export function WorkspaceListView({
           {listProjects.map((project) => (
             <div
               key={project.id}
-              className={`grid grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] items-center border-b px-4 py-2 transition-colors ${selectedProjectId === project.id ? "bg-primary/5" : "hover:bg-muted/30"}`}
+              className={`grid grid-cols-[auto_minmax(0,2fr)_minmax(0,2fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] items-center gap-x-3 border-b px-4 py-2 transition-colors ${selectedProjectId === project.id || bulkSelectedProjectIds.has(project.id) ? "bg-primary/5" : "hover:bg-muted/30"}`}
               onClick={() => onSelectProject(project)}
               onDoubleClick={() => onOpenProject(project)}
             >
+              <div
+                className="flex w-4 items-center"
+                onClick={(event) => event.stopPropagation()}
+                onDoubleClick={(event) => event.stopPropagation()}
+              >
+                {canManageProjects && (
+                  <Checkbox
+                    checked={bulkSelectedProjectIds.has(project.id)}
+                    onCheckedChange={(checked) => onToggleProjectSelection(project.id, checked === true)}
+                    aria-label={`Select ${getProjectDisplayName(project)}`}
+                  />
+                )}
+              </div>
               <button
                 type="button"
                 className="truncate text-left text-sm font-medium hover:text-primary"

--- a/frontend/src/hooks/use-workspace-data.ts
+++ b/frontend/src/hooks/use-workspace-data.ts
@@ -19,6 +19,7 @@ interface WorkspaceDataState {
   renameFolder: (folderId: string, name: string) => Promise<WorkspaceActionResult>;
   deleteFolder: (folderId: string) => Promise<WorkspaceActionResult>;
   moveProject: (projectId: string, folderId: string | null) => Promise<WorkspaceActionResult>;
+  moveProjects: (projectIds: string[], folderId: string | null) => Promise<WorkspaceActionResult>;
   deleteProject: (projectId: string) => Promise<WorkspaceActionResult>;
 }
 
@@ -151,19 +152,26 @@ export function useWorkspaceData(): WorkspaceDataState {
     [runMutation]
   );
 
-  const moveProject = useCallback(
-    async (projectId: string, folderId: string | null): Promise<WorkspaceActionResult> => {
+  const moveProjects = useCallback(
+    async (projectIds: string[], folderId: string | null): Promise<WorkspaceActionResult> => {
       return runMutation(
-        `/api/folders/projects/${projectId}/move`,
+        "/api/folders/projects/move",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ folder_id: folderId }),
+          body: JSON.stringify({ project_ids: projectIds, folder_id: folderId }),
         },
-        "Failed to move project"
+        projectIds.length === 1 ? "Failed to move project" : "Failed to move projects"
       );
     },
     [runMutation]
+  );
+
+  const moveProject = useCallback(
+    async (projectId: string, folderId: string | null): Promise<WorkspaceActionResult> => {
+      return moveProjects([projectId], folderId);
+    },
+    [moveProjects]
   );
 
   const deleteProject = useCallback(
@@ -190,6 +198,7 @@ export function useWorkspaceData(): WorkspaceDataState {
     renameFolder,
     deleteFolder,
     moveProject,
+    moveProjects,
     deleteProject,
   };
 }

--- a/frontend/src/lib/roles.test.ts
+++ b/frontend/src/lib/roles.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canManageProjects,
+  canOpenLibraryManager,
+  canReviewCatalogQa,
+  canWriteCatalog,
+  roleHasAuthority,
+} from "./roles";
+
+describe("role authorities", () => {
+  it("matches the project mutation roles enforced by the backend", () => {
+    expect(canManageProjects("viewer")).toBe(false);
+    expect(canManageProjects("component_designer")).toBe(false);
+    expect(canManageProjects("component_qa")).toBe(false);
+    expect(canManageProjects("designer")).toBe(true);
+    expect(canManageProjects("admin")).toBe(true);
+  });
+
+  it("matches the catalog read, write, and QA role sets", () => {
+    expect(canOpenLibraryManager("viewer")).toBe(false);
+    expect(canOpenLibraryManager("designer")).toBe(true);
+    expect(canOpenLibraryManager("component_designer")).toBe(true);
+    expect(canOpenLibraryManager("component_qa")).toBe(true);
+    expect(canOpenLibraryManager("admin")).toBe(true);
+
+    expect(canWriteCatalog("designer")).toBe(false);
+    expect(canWriteCatalog("component_designer")).toBe(true);
+    expect(canWriteCatalog("component_qa")).toBe(false);
+    expect(canWriteCatalog("admin")).toBe(true);
+
+    expect(canReviewCatalogQa("component_designer")).toBe(false);
+    expect(canReviewCatalogQa("component_qa")).toBe(true);
+    expect(canReviewCatalogQa("admin")).toBe(true);
+  });
+
+  it("allows only admins to administer the workspace", () => {
+    expect(roleHasAuthority("designer", "administer_workspace")).toBe(false);
+    expect(roleHasAuthority("admin", "administer_workspace")).toBe(true);
+  });
+});

--- a/frontend/src/lib/roles.ts
+++ b/frontend/src/lib/roles.ts
@@ -11,6 +11,82 @@ export const ROLE_LABELS: Record<UserRole, string> = {
 
 export const ROLE_OPTIONS: UserRole[] = ["viewer", "designer", "component_designer", "component_qa", "admin"];
 
+export type RoleAuthorityKey =
+  | "view_projects"
+  | "manage_projects"
+  | "comment_on_projects"
+  | "view_catalog"
+  | "edit_catalog"
+  | "review_catalog_qa"
+  | "administer_workspace";
+
+export interface RoleAuthority {
+  key: RoleAuthorityKey;
+  category: "Projects" | "Component library" | "Administration";
+  label: string;
+  description: string;
+  roles: readonly UserRole[];
+}
+
+/**
+ * The role matrix mirrors the backend dependencies in core/security.py:
+ * every signed-in role can read projects, project mutations require Designer,
+ * catalog reads/writes use their dedicated allow-lists, and settings require
+ * Admin. Keeping the UI helpers on this same data prevents the popover and the
+ * controls it describes from drifting apart.
+ */
+export const ROLE_AUTHORITIES: readonly RoleAuthority[] = [
+  {
+    key: "view_projects",
+    category: "Projects",
+    label: "View available projects",
+    description: "Browse projects, schematics, boards, and existing comments.",
+    roles: ["viewer", "designer", "component_designer", "component_qa", "admin"],
+  },
+  {
+    key: "manage_projects",
+    category: "Projects",
+    label: "Manage projects",
+    description: "Import, sync, configure, move, and delete projects.",
+    roles: ["designer", "admin"],
+  },
+  {
+    key: "comment_on_projects",
+    category: "Projects",
+    label: "Write project comments",
+    description: "Create, edit, reply to, delete, and publish comments.",
+    roles: ["designer", "admin"],
+  },
+  {
+    key: "view_catalog",
+    category: "Component library",
+    label: "View component library",
+    description: "Browse components, revisions, validation, and release queues.",
+    roles: ["designer", "component_designer", "component_qa", "admin"],
+  },
+  {
+    key: "edit_catalog",
+    category: "Component library",
+    label: "Edit component library",
+    description: "Create components, edit metadata, and attach library assets.",
+    roles: ["component_designer", "admin"],
+  },
+  {
+    key: "review_catalog_qa",
+    category: "Component library",
+    label: "Review component QA",
+    description: "Approve or return components that are in QA review.",
+    roles: ["component_qa", "admin"],
+  },
+  {
+    key: "administer_workspace",
+    category: "Administration",
+    label: "Administer workspace",
+    description: "Manage users, sessions, Git access, and workspace settings.",
+    roles: ["admin"],
+  },
+] as const;
+
 const WORKFLOW_TRANSITIONS: Record<WorkflowStage, WorkflowStage[]> = {
   open: ["in_progress", "archived"],
   in_progress: ["qa_review", "open", "archived"],
@@ -24,20 +100,25 @@ export function roleLabel(role: UserRole): string {
   return ROLE_LABELS[role] ?? role;
 }
 
+export function roleHasAuthority(role: UserRole | null | undefined, authority: RoleAuthorityKey): boolean {
+  if (!role) return false;
+  return ROLE_AUTHORITIES.find((entry) => entry.key === authority)?.roles.includes(role) ?? false;
+}
+
 export function canManageProjects(role?: UserRole | null): boolean {
-  return role === "admin" || role === "designer";
+  return roleHasAuthority(role, "manage_projects");
 }
 
 export function canOpenLibraryManager(role?: UserRole | null): boolean {
-  return role === "admin" || role === "designer" || role === "component_designer" || role === "component_qa";
+  return roleHasAuthority(role, "view_catalog");
 }
 
 export function canWriteCatalog(role?: UserRole | null): boolean {
-  return role === "admin" || role === "component_designer";
+  return roleHasAuthority(role, "edit_catalog");
 }
 
 export function canReviewCatalogQa(role?: UserRole | null): boolean {
-  return role === "admin" || role === "component_qa";
+  return roleHasAuthority(role, "review_catalog_qa");
 }
 
 export function workflowStage(component: CatalogComponent): WorkflowStage {

--- a/kicad-prism-viewer/pipeline/topology_compiler/schematic_scene.py
+++ b/kicad-prism-viewer/pipeline/topology_compiler/schematic_scene.py
@@ -104,6 +104,7 @@ _ITALIC_TILT = 1.0 / 8.0
 _LABEL_TEXT_INSET_MM = 1.05
 _LABEL_TEXT_KINDS = {"label", "hierarchical_label"}
 _SVG_TAG_RE = re.compile(r"<\s*([a-zA-Z][\w:-]*)\b")
+_DNP_MARKER_RGB = "#dc090d"
 
 
 def _mm(value: Any) -> float:
@@ -1032,6 +1033,20 @@ def _is_symbol_record(record: Any) -> bool:
     return str(getattr(record, "kind", "") or "") in {"symbol_instance", "symbol_overplot"}
 
 
+def _is_dnp_marker_operation(data: dict[str, Any]) -> bool:
+    """Identify KiCad's red assembly-exclusion cross operations.
+
+    kicad-monkey emits the cross as two thick segments at the end of a DNP
+    symbol record.  They used to be folded into the generic ``symbol_body``
+    feature, which let later body geometry obscure them and made their bounds
+    indistinguishable from the grey symbol.  The layer color is KiCad's stable
+    semantic marker for these otherwise ordinary segments.
+    """
+    kind = str(data.get("kind") or "")
+    color = str(data.get("stroke_color") or data.get("color") or "").casefold()
+    return kind in {"Line", "PenTo", "ThickSegment"} and color.startswith(_DNP_MARKER_RGB)
+
+
 def _component_indexes(design_payload: dict[str, Any], topology: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     by_designator: dict[str, dict[str, Any]] = {}
     for component in design_payload.get("components", []) or []:
@@ -1228,6 +1243,10 @@ def _symbol_body_key(sheet_instance_path: str, source_id: str) -> str:
     return stable_feature_key(sheet_instance_path, source_id, 0, "symbol_body", 0)
 
 
+def _dnp_marker_key(sheet_instance_path: str, source_id: str) -> str:
+    return stable_feature_key(sheet_instance_path, source_id, 0, "dnp_marker", 0)
+
+
 def _pin_feature_key(sheet_instance_path: str, pin_source_id: str) -> str:
     return stable_feature_key(sheet_instance_path, pin_source_id, 0, "pin", 0)
 
@@ -1289,6 +1308,7 @@ def _symbol_owner_features(
     pin_bounds: dict[str, list[list[float]]] = defaultdict(list)
     current_pin: dict[str, Any] | None = None
     body_bounds: list[list[float]] = []
+    dnp_marker_bounds: list[list[float]] = []
     for operation in getattr(record, "operations", []) or []:
         data = operation.to_dict() if hasattr(operation, "to_dict") else dict(operation)
         kind = str(data.get("kind") or "")
@@ -1307,7 +1327,9 @@ def _symbol_owner_features(
             continue
         if current_pin:
             pin_bounds[current_pin["pinSourceId"]].append(bounds)
-        elif kind not in NON_GEOMETRY_OPERATION_KINDS:
+        elif _is_dnp_marker_operation(data):
+            dnp_marker_bounds.append(bounds)
+        elif kind not in NON_GEOMETRY_OPERATION_KINDS and kind != "Text":
             body_bounds.append(bounds)
 
     component_meta = component_by_designator.get(reference, {})
@@ -1344,6 +1366,22 @@ def _symbol_owner_features(
     if bounds := _union_bounds(body_bounds) or parent_feature.get("boundsMm"):
         body["boundsMm"] = bounds
     features = [body]
+    if marker_bounds := _union_bounds(dnp_marker_bounds):
+        features.append(
+            {
+                **feature_base,
+                "id": 0,
+                "stableKey": _dnp_marker_key(sheet_instance_path, source_id),
+                "sourceId": f"{source_id}:dnp-marker",
+                "uuid": parent_feature.get("uuid", ""),
+                "objectId": parent_feature.get("objectId", ""),
+                "kind": "dnp_marker",
+                "semanticRole": "dnp_marker",
+                "parentStableKey": body["stableKey"],
+                "boundsMm": marker_bounds,
+                "dnp": True,
+            }
+        )
     for pin_source_id, pin in sorted(pins.items()):
         feature = {
             **feature_base,
@@ -1425,7 +1463,10 @@ def _operation_descriptors(
                 semantic_role = "pin_body"
             metadata = dict(current_pin)
         elif is_symbol:
-            if operation_kind == "Text":
+            if _is_dnp_marker_operation(data):
+                semantic_role = "dnp_marker"
+                parent_stable_key = _dnp_marker_key(page["sheetInstancePath"], source_id)
+            elif operation_kind == "Text":
                 semantic_role = _symbol_text_role(data, parent_feature, outside_text_count, inferred_reference)
                 outside_text_count += 1
             else:
@@ -1448,6 +1489,9 @@ def _operation_descriptors(
         elif semantic_role == "symbol_body":
             feature_key = _symbol_body_key(page["sheetInstancePath"], source_id)
             feature_role = "symbol_body"
+        elif semantic_role == "dnp_marker":
+            feature_key = _dnp_marker_key(page["sheetInstancePath"], source_id)
+            feature_role = "dnp_marker"
         elif semantic_role == "pin_body":
             feature_key = _pin_feature_key(page["sheetInstancePath"], feature_source_id)
             feature_role = "pin"
@@ -1602,6 +1646,15 @@ def _record_feature(
         value = extras.get(key)
         if value not in (None, ""):
             feature[key] = str(value)
+    if _is_symbol_record(record):
+        feature.update(
+            {
+                "dnp": bool(extras.get("dnp")),
+                "excludeFromSimulation": bool(extras.get("exclude_from_sim")),
+                "inBom": bool(extras.get("in_bom", True)),
+                "onBoard": bool(extras.get("on_board", True)),
+            }
+        )
     if component_by_designator and feature.get("reference"):
         component_meta = component_by_designator.get(str(feature["reference"]), {})
         for key, value in component_meta.items():
@@ -1717,6 +1770,16 @@ def _page_chunks(
                 primitive_feature["boundsMm"] = primitive["boundsMm"]
             primitives.append(primitive)
             primitive_features.append(primitive_feature)
+
+    # DNP crosses are an overplot in KiCad and must remain above all symbol,
+    # pin and wire geometry, including records that happen to follow the
+    # component in the source schematic.
+    order = sorted(
+        range(len(primitives)),
+        key=lambda index: primitives[index].get("semanticRole") == "dnp_marker",
+    )
+    primitives = [primitives[index] for index in order]
+    primitive_features = [primitive_features[index] for index in order]
 
     lod0 = {
         "schema": f"{SCHEMA}.chunk",

--- a/kicad-prism-viewer/tests/fixtures/vr5510_dnp_passives.json
+++ b/kicad-prism-viewer/tests/fixtures/vr5510_dnp_passives.json
@@ -1,0 +1,41 @@
+{
+  "source": "issue-86/VR5510_PMIC.kicad_sch (sanitized)",
+  "symbols": [
+    {
+      "reference": "R106",
+      "libId": "Device:R_Small_US",
+      "body": [
+        {"kind": "PlotPoly", "points": [[309626000, 218440000], [310007000, 217424000], [310388000, 218440000], [310769000, 219456000], [311150000, 218440000]], "fill": "NO_FILL", "width_nm": 152400, "stroke_color": "#9C9B99FF"},
+        {"kind": "PlotPoly", "points": [[311150000, 218440000], [311531000, 217424000], [311912000, 218440000], [312293000, 219456000], [312674000, 218440000]], "fill": "NO_FILL", "width_nm": 152400, "stroke_color": "#9C9B99FF"}
+      ],
+      "marker": [
+        {"kind": "ThickSegment", "start_x": 308940200, "start_y": 217164920, "end_x": 313359800, "end_y": 219715080, "width_nm": 457200, "stroke_color": "#DC090DD9"},
+        {"kind": "ThickSegment", "start_x": 313359800, "start_y": 217164920, "end_x": 308940200, "end_y": 219715080, "width_nm": 457200, "stroke_color": "#DC090DD9"}
+      ]
+    },
+    {
+      "reference": "R108",
+      "libId": "Device:R_Small_US",
+      "body": [
+        {"kind": "PlotPoly", "points": [[313436000, 198120000], [313817000, 197104000], [314198000, 198120000], [314579000, 199136000], [314960000, 198120000]], "fill": "NO_FILL", "width_nm": 152400, "stroke_color": "#9C9B99FF"},
+        {"kind": "PlotPoly", "points": [[314960000, 198120000], [315341000, 197104000], [315722000, 198120000], [316103000, 199136000], [316484000, 198120000]], "fill": "NO_FILL", "width_nm": 152400, "stroke_color": "#9C9B99FF"}
+      ],
+      "marker": [
+        {"kind": "ThickSegment", "start_x": 312750200, "start_y": 196844920, "end_x": 317169800, "end_y": 199395080, "width_nm": 457200, "stroke_color": "#DC090DD9"},
+        {"kind": "ThickSegment", "start_x": 317169800, "start_y": 196844920, "end_x": 312750200, "end_y": 199395080, "width_nm": 457200, "stroke_color": "#DC090DD9"}
+      ]
+    },
+    {
+      "reference": "C111",
+      "libId": "Device:C_Small",
+      "body": [
+        {"kind": "PlotPoly", "points": [[318516000, 225552000], [321564000, 225552000]], "fill": "NO_FILL", "width_nm": 304800, "stroke_color": "#9C9B99FF"},
+        {"kind": "PlotPoly", "points": [[318516000, 226568000], [321564000, 226568000]], "fill": "NO_FILL", "width_nm": 330200, "stroke_color": "#9C9B99FF"}
+      ],
+      "marker": [
+        {"kind": "ThickSegment", "start_x": 317764160, "start_y": 224226120, "end_x": 322315840, "end_y": 227906580, "width_nm": 457200, "stroke_color": "#DC090DD9"},
+        {"kind": "ThickSegment", "start_x": 322315840, "start_y": 224226120, "end_x": 317764160, "end_y": 227906580, "width_nm": 457200, "stroke_color": "#DC090DD9"}
+      ]
+    }
+  ]
+}

--- a/kicad-prism-viewer/tests/test_schematic_scene.py
+++ b/kicad-prism-viewer/tests/test_schematic_scene.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import unittest
+from pathlib import Path
 
 from pipeline.topology_compiler.schematic_scene import (
     SCHEMA,
@@ -10,6 +12,7 @@ from pipeline.topology_compiler.schematic_scene import (
     _pin_lookup_indexes,
     _polyline_bounds,
     _page_chunks,
+    _record_feature,
     _symbol_owner_features,
     _native_preview_svg,
     _native_overlay_svg,
@@ -607,6 +610,93 @@ class SchematicSceneSchemaTests(unittest.TestCase):
         descriptors = _operation_descriptors(page, record, 1, parent, {"bySvgId": {}, "byDesignatorPin": {}}, {})
 
         self.assertTrue(descriptors[0]["metadata"]["dnp"])
+
+    def test_vr5510_dnp_passives_keep_cross_as_a_top_layer_feature(self):
+        """Regression for issue #86 using sanitized R106/R108/C111 IR.
+
+        The fixture contains only the body and DNP-marker operations parsed
+        from the reported schematic; no project fields or net data are copied.
+        """
+        fixture_path = Path(__file__).parent / "fixtures" / "vr5510_dnp_passives.json"
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        page = {
+            "id": "page-vr5510",
+            "name": "VR5510_PMIC",
+            "sheetInstancePath": "/root/vr5510",
+            "sourceWidthMm": 420,
+            "sourceHeightMm": 297,
+        }
+
+        for item in fixture["symbols"]:
+            with self.subTest(reference=item["reference"]):
+                record = FakeSymbolRecord(
+                    [FakeOperation(operation) for operation in [*item["body"], *item["marker"]]],
+                    extras={
+                        "reference": item["reference"],
+                        "lib_id": item["libId"],
+                        "dnp": True,
+                        "in_bom": True,
+                        "on_board": True,
+                    },
+                )
+                record.uuid = f"fixture-{item['reference'].lower()}"
+                parent = _record_feature(
+                    page["id"],
+                    page["sheetInstancePath"],
+                    record,
+                    1,
+                    0,
+                    {},
+                )
+                self.assertTrue(parent["dnp"])
+
+                owners = _symbol_owner_features(
+                    page["id"],
+                    page["sheetInstancePath"],
+                    record,
+                    1,
+                    parent,
+                    {"bySvgId": {}, "byDesignatorPin": {}},
+                    {},
+                )
+                body = next(feature for feature in owners if feature["kind"] == "symbol_body")
+                marker = next(feature for feature in owners if feature["kind"] == "dnp_marker")
+                self.assertTrue(marker["dnp"])
+                self.assertLess(body["boundsMm"][0], body["boundsMm"][2])
+                self.assertLess(marker["boundsMm"][0], body["boundsMm"][0])
+                self.assertGreater(marker["boundsMm"][2], body["boundsMm"][2])
+
+                feature_ids = deterministic_feature_ids(
+                    {parent["stableKey"], *(feature["stableKey"] for feature in owners)}
+                )
+                parent["id"] = feature_ids[parent["stableKey"]]
+                for feature in owners:
+                    feature["id"] = feature_ids[feature["stableKey"]]
+                _, _, lod2, unsupported, primitive_features = _page_chunks(
+                    page,
+                    [record],
+                    [parent, *owners],
+                    feature_ids,
+                )
+
+                self.assertEqual(unsupported, [])
+                marker_primitives = [
+                    primitive
+                    for primitive in lod2["primitives"]
+                    if primitive["semanticRole"] == "dnp_marker"
+                ]
+                self.assertEqual(len(marker_primitives), 2)
+                self.assertEqual(
+                    {primitive["featureId"] for primitive in marker_primitives},
+                    {marker["id"]},
+                )
+                self.assertEqual(
+                    [primitive["semanticRole"] for primitive in lod2["primitives"][-2:]],
+                    ["dnp_marker", "dnp_marker"],
+                )
+                self.assertTrue(
+                    all(feature["kind"] == "dnp_marker" for feature in primitive_features[-2:])
+                )
 
     def test_repeated_hierarchy_symbol_and_pin_keys_are_instance_scoped(self):
         symbol_uuid = "same-symbol"

--- a/kicad-prism-viewer/viewer/src/schematic-world-renderer.js
+++ b/kicad-prism-viewer/viewer/src/schematic-world-renderer.js
@@ -2233,6 +2233,7 @@ function parseColor(color) {
 
 function vectorColor(feature, primitiveKind, sourceColor = "") {
   const parsed = parseColor(sourceColor || feature?.color || "");
+  if (feature?.kind === "dnp_marker") return parsed || [0.86, 0.04, 0.05, 0.85];
   if (feature?.dnp && ["symbol_reference", "symbol_value", "symbol_text"].includes(String(feature?.kind || ""))) {
     return [0.50, 0.52, 0.54, 0.56];
   }
@@ -2255,6 +2256,7 @@ function mutedVectorColor(feature, primitiveKind, sourceColor = "") {
 
 function nativeStrokePixelWidth(feature, primitiveKind, selected) {
   if (selected) return 5.5;
+  if (feature?.kind === "dnp_marker") return 3.0;
   if (["pin_name", "pin_number"].includes(String(feature?.kind || ""))) return 1.5;
   if (feature?.kind === "pin_body") return 1.7;
   if (String(primitiveKind || "").startsWith("text")) return 1.35;


### PR DESCRIPTION
## What changed
- Fix project import handling for SSH/HTTP requests, Git access, and job failure propagation.
- Add the role-authority popover and correct zero/one/multiple project workspace states.
- Fix DNP resistor red-cross boundary rendering with a regression fixture.
- Add visible-result bulk move and bulk thumbnail regeneration with atomic validation.
- Fix thumbnail precedence and failed kicad-cli render reporting.
- Move the requested catalog repair cases through the workflow without releasing incomplete component heads.

## Verification
- Backend targeted suites passed for import, thumbnail, derived-assets, and bulk-move jobs.
- Frontend build, ESLint, and full test suite passed.
- Schematic parser/viewer regression tests passed.
- git diff --check passed.

The live catalog workflow repair was applied directly to the running database and is not represented as source changes in this PR.