### PR TITLE
fix(dnp): report DNP parts as DNP in the side panel and the BOM

### DIFF
--- a/backend/app/services/semantic_index_service.py
+++ b/backend/app/services/semantic_index_service.py
@@ -413,6 +413,35 @@ def _schematic_instance_fields(project_file: Path) -> dict[str, dict[str, str]]:
     return result
 
 
+_TRUTHY_FLAGS = {"1", "true", "yes", "y", "dnp"}
+
+
+def _resolve_dnp(parameters: dict[str, str], casefolded: dict[str, str]) -> str:
+    """Decide whether a component is DNP, from whichever field carries it.
+
+    ``kicad_dnp`` is kicad-monkey's parse of the symbol's own ``(dnp ...)``
+    attribute and wins outright.  Failing that, KiCad's netlist marks a DNP
+    part with a *valueless* ``dnp`` property — presence is the signal, and it
+    is also how DNP inherited from a parent sheet reaches us.  That flag is
+    matched on the exact lowercase key so a user field named ``DNP`` left
+    blank, which means the opposite, is not mistaken for it.
+    """
+
+    explicit = casefolded.get("kicaddnp", "").strip()
+    if explicit:
+        return "Yes" if explicit.casefold() in _TRUTHY_FLAGS else "No"
+
+    if "dnp" in parameters and not parameters["dnp"].strip():
+        return "Yes"
+
+    for alias in ("DNP", "Do Not Populate", "Do Not Fit"):
+        value = casefolded.get(re.sub(r"[^a-z0-9]", "", alias.casefold()), "").strip()
+        if value:
+            return "Yes" if value.casefold() in _TRUTHY_FLAGS else "No"
+
+    return "No"
+
+
 def _canonical_fields(component: dict[str, Any]) -> dict[str, str]:
     parameters = {
         str(key): _string(value)
@@ -425,14 +454,16 @@ def _canonical_fields(component: dict[str, Any]) -> dict[str, str]:
     }
 
     def pick(name: str, *aliases: str) -> str:
+        # A present-but-empty field must not shadow a populated alias; KiCad
+        # emits plenty of blank properties, and the first non-blank one is
+        # what the panel should show.
         for candidate in (name, *aliases):
             value = casefolded.get(re.sub(r"[^a-z0-9]", "", candidate.casefold()))
-            if value is not None:
+            if value:
                 return value
         return ""
 
-    dnp_source = pick("DNP", "kicad_dnp", "Do Not Populate", "Do Not Fit")
-    dnp = "Yes" if dnp_source.strip().casefold() in {"1", "true", "yes", "y", "dnp"} else "No"
+    dnp = _resolve_dnp(parameters, casefolded)
     required = {
         "Value": _string(component.get("value")) or pick("Value"),
         "DNP": dnp,

--- a/backend/tests/test_semantic_index_service.py
+++ b/backend/tests/test_semantic_index_service.py
@@ -767,5 +767,53 @@ class SchematicInstanceFieldTests(unittest.TestCase):
         self.assertNotIn("pin-uuid-1", fields)
 
 
+class CanonicalFieldTests(unittest.TestCase):
+    """How a component's DNP state and aliased fields are read.
+
+    KiCad records "do not populate" in two unrelated shapes, and Prism sees
+    both: kicad-monkey's parsed ``kicad_dnp`` boolean, and the raw netlist's
+    valueless ``dnp`` property, which is what carries DNP inherited from a
+    parent sheet.  Reading only the first key that exists made every DNP part
+    report "No", because the valueless one sorts first and looks empty.
+    """
+
+    @staticmethod
+    def _fields(**parameters: str) -> dict[str, str]:
+        return semantic_index_service._canonical_fields({"parameters": parameters})
+
+    def test_the_parsed_symbol_attribute_marks_a_part_dnp(self) -> None:
+        self.assertEqual(self._fields(kicad_dnp="true")["DNP"], "Yes")
+
+    def test_a_valueless_netlist_flag_marks_a_part_dnp(self) -> None:
+        """KiCad emits `(property (name "dnp"))` only for parts that are DNP."""
+        self.assertEqual(self._fields(dnp="")["DNP"], "Yes")
+
+    def test_the_valueless_flag_does_not_shadow_the_parsed_attribute(self) -> None:
+        self.assertEqual(self._fields(dnp="", kicad_dnp="true")["DNP"], "Yes")
+
+    def test_a_populated_part_reports_no(self) -> None:
+        self.assertEqual(self._fields(kicad_dnp="false")["DNP"], "No")
+
+    def test_a_blank_user_field_named_dnp_means_populated(self) -> None:
+        """Unlike the netlist flag, an empty user field is the default, not a mark."""
+        self.assertEqual(self._fields(DNP="", kicad_dnp="false")["DNP"], "No")
+
+    def test_a_user_field_alias_can_mark_a_part_dnp(self) -> None:
+        self.assertEqual(self._fields(**{"Do Not Populate": "yes"})["DNP"], "Yes")
+
+    def test_the_parsed_attribute_overrules_a_stale_user_field(self) -> None:
+        self.assertEqual(self._fields(DNP="no", kicad_dnp="true")["DNP"], "Yes")
+
+    def test_a_component_with_no_dnp_information_reports_no(self) -> None:
+        self.assertEqual(self._fields(Value="10k")["DNP"], "No")
+
+    def test_a_blank_field_does_not_shadow_a_populated_alias(self) -> None:
+        fields = self._fields(
+            **{"Datasheet": "", "Datasheet Link": "https://example.invalid/ds.pdf"}
+        )
+
+        self.assertEqual(fields["Datasheet"], "https://example.invalid/ds.pdf")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/kicad-prism-viewer/pipeline/topology_compiler/bom.py
+++ b/kicad-prism-viewer/pipeline/topology_compiler/bom.py
@@ -244,7 +244,9 @@ def _row_payload(row_id: str, line, component_by_ref: Mapping[str, object]) -> d
     source_components = [component_by_ref[designator] for designator in designators if designator in component_by_ref]
     fields = _merged_fields(source_components)
     row_fields = {
-        column: _column_value(column, fields, line=line, designators=designators)
+        column: _column_value(
+            column, fields, dnp=bool(line.dnp), line=line, designators=designators
+        )
         for column in PRIMARY_COLUMNS
     }
     return {
@@ -269,7 +271,12 @@ def _component_payload(component, row_id: str) -> dict[str, object]:
         "sheet": component.sheet,
         "libraryRef": component.library_ref,
         "fields": {
-            column: _column_value(column, fields, designators=[component.designator])
+            column: _column_value(
+                column,
+                fields,
+                dnp=bool(component.dnp),
+                designators=[component.designator],
+            )
             for column in PRIMARY_COLUMNS
         },
         "canonicalFields": fields,
@@ -306,6 +313,7 @@ def _column_value(
     column: str,
     fields: Mapping[str, str],
     *,
+    dnp: bool,
     line=None,
     designators: list[str] | None = None,
 ) -> str:
@@ -314,9 +322,11 @@ def _column_value(
     if column == "Qty":
         return str(line.quantity if line is not None else 1)
     if column == "DNP":
-        if line is not None:
-            return "Yes" if line.dnp else "No"
-        return "Yes" if str(fields.get("dnp", "")).casefold() in {"1", "true", "yes"} else "No"
+        # The resolved flag, never the raw field.  KiCad writes a DNP part's
+        # `dnp` property with no value at all, and `_component_fields` drops
+        # empty values, so reading the field reported every DNP component as
+        # populated.
+        return "Yes" if dnp else "No"
     key = DISPLAY_TO_CANONICAL.get(column, column)
     return str(fields.get(key, ""))
 

--- a/kicad-prism-viewer/tests/test_bom_artifact.py
+++ b/kicad-prism-viewer/tests/test_bom_artifact.py
@@ -163,3 +163,30 @@ def test_bom_artifact_accepts_reused_assembly_without_from_file(tmp_path, monkey
     assert summary["components"] == 2
     assert "bom_normalize_group_ms" in timings
     assert "bom_design_reuse_ms" not in timings
+
+
+def test_a_dnp_component_reports_yes_in_its_own_dnp_column(tmp_path, monkeypatch):
+    """KiCad writes a DNP part's `dnp` property with no value at all.
+
+    The per-component DNP cell used to be re-derived from that field, which is
+    dropped as empty before it ever reaches the column, so every DNP component
+    read as populated even though the payload's own boolean was right beside
+    it.  The row-level cell was always correct, so the two disagreed.
+    """
+    install_fake_kicad_cruncher(monkeypatch)
+    project = tmp_path / "fixture.kicad_pro"
+    project.write_text("{}", encoding="utf-8")
+
+    raw = FakeManufacturingDesign().to_bom()
+    raw[0] = {**raw[0], "dnp": True, "parameters": {**raw[0]["parameters"], "dnp": ""}}
+
+    build_bom_artifact(project, tmp_path, raw_components=raw)
+    payload = json.loads((tmp_path / "bom" / "bom.json").read_text(encoding="utf-8"))
+
+    by_reference = {component["reference"]: component for component in payload["components"]}
+
+    assert by_reference["R2"]["dnp"] is True
+    assert by_reference["R2"]["fields"]["DNP"] == "Yes"
+    assert by_reference["R1"]["dnp"] is False
+    assert by_reference["R1"]["fields"]["DNP"] == "No"
+    assert payload["counts"]["dnpComponents"] == 1


### PR DESCRIPTION
Part of #86 — the field-parsing half. The rendering half is in krishna-swaroop/ecad-viewer#3.

## The bug

Every DNP component read as `DNP: No`, in the component side panel and in the BOM table, for the same underlying reason in two different shapes.

KiCad marks a DNP part in its netlist with a **valueless** property — `(property (name "dnp"))` — where presence is the signal. Confirmed in this project's own netlist:

```
(comp (ref "R108")
  ...
  (property (name "dnp"))
```

kicad-monkey passes that through as an empty string alongside its own parsed `kicad_dnp` boolean. For R106/R108 in JTYU-OBC the design JSON carries `"dnp": ""` and `"kicad_dnp": "true"` side by side.

**Side panel.** `_canonical_fields` did `pick("DNP", "kicad_dnp", ...)`, and `pick` returned the first key that *existed*. The empty `dnp` sorts first and looks blank, so it shadowed the populated `kicad_dnp` and the answer was always `No`.

**BOM.** `_column_value` re-derived the per-component DNP cell from `fields["dnp"]` — which `_component_fields` had already dropped for being empty. The row-level cell used `line.dnp` and was correct, so the two disagreed about the same part. In the checked-in profile run, R108 has `dnp: true` and `fields.DNP: "No"`.

## What changed

DNP resolution is now explicit rather than emergent from alias ordering:

1. `kicad_dnp` — kicad-monkey's parse of the symbol's own `(dnp ...)` attribute — wins outright.
2. Failing that, the valueless `dnp` presence flag counts as DNP. This is also the field that carries DNP inherited from a parent sheet.
3. Failing that, a truthy `DNP` / `Do Not Populate` / `Do Not Fit` user field.
4. Otherwise `No`.

The presence flag is matched on the **exact lowercase key**, so a user field named `DNP` left blank — which means the opposite — is not misread as a mark.

`pick()` no longer lets any blank field shadow a populated alias. That was never DNP-specific; it could equally hide a `Datasheet` behind an empty `Datasheet Link`.

The BOM artifact now threads the resolved boolean it already had into the column instead of re-deriving it from a field.

## Verification

Against the checked-in JTYU-OBC design JSON (`data/design-change-review/JTYU-OBC_8f71cfea_to_75cf484e/head/`):

```
R106   DNP=Yes  kicad_dnp='true'   dnp=''
R108   DNP=Yes  kicad_dnp='true'   dnp=''
C99    DNP=No   kicad_dnp='false'  dnp=None

DNP=Yes: 107   kicad_dnp==true: 107
```

Backend 481 passed / 29 skipped. Pipeline 85 passed. New coverage for the presence flag, the blank-user-field case, the stale-user-field case, and the blank-alias shadowing.

## Not in this PR

- The viewer bundle re-vendor — it follows once ecad-viewer#3 merges.
- Sheet-level DNP inheritance in kicad-monkey, which is what makes the presence flag meaningful for nested sheets. Issues to follow.