### PR TITLE
fix(catalog): stop the virtualised grids blanking the page on scroll

### DIFF
--- a/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
+++ b/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ConfirmDialog, useConfirmTarget } from "@/components/ui/confirm-dialog";
+import { useVirtualViewport } from "@/hooks/use-virtual-viewport";
 import { fetchApi, fetchJson, readApiError } from "@/lib/api";
 import { canWriteCatalog } from "@/lib/roles";
 import { cn } from "@/lib/utils";
@@ -273,8 +274,7 @@ export function LibraryBulkEditWorkspace({ user }: { user: User | null }) {
   const redoStack = useRef<StagedRows[]>([]);
   const csvInputRef = useRef<HTMLInputElement>(null);
   const preferencesLoaded = useRef(false);
-  const gridViewportRef = useRef<HTMLDivElement>(null);
-  const [gridViewport, setGridViewport] = useState({ height: 640, scrollTop: 0 });
+  const gridViewport = useVirtualViewport();
   const isAdmin = user?.role === "admin";
   const canEdit = canWriteCatalog(user?.role);
   // An empty grid means something different when filters are active than when the
@@ -357,16 +357,6 @@ export function LibraryBulkEditWorkspace({ user }: { user: User | null }) {
   const firstVisibleRow = Math.max(0, Math.floor(Math.max(0, gridViewport.scrollTop - 40) / GRID_ROW_HEIGHT) - GRID_OVERSCAN);
   const lastVisibleRow = Math.min(items.length, Math.ceil((gridViewport.scrollTop + gridViewport.height) / GRID_ROW_HEIGHT) + GRID_OVERSCAN);
   const visibleRows = items.slice(firstVisibleRow, lastVisibleRow);
-
-  useEffect(() => {
-    const viewport = gridViewportRef.current;
-    if (!viewport) return;
-    const updateHeight = () => setGridViewport((current) => ({ ...current, height: viewport.clientHeight || current.height }));
-    updateHeight();
-    const observer = new ResizeObserver(updateHeight);
-    observer.observe(viewport);
-    return () => observer.disconnect();
-  }, []);
 
   const commitStaged = useCallback((next: StagedRows) => {
     setStaged((current) => { undoStack.current.push(cloneStaged(current)); if (undoStack.current.length > 100) undoStack.current.shift(); redoStack.current = []; return next; });
@@ -535,7 +525,7 @@ export function LibraryBulkEditWorkspace({ user }: { user: User | null }) {
 
       <main className="flex min-w-0 flex-1 flex-col p-3">
         <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground"><span>{loading ? "Loading components…" : `${items.length ? (page - 1) * PAGE_SIZE + 1 : 0}–${Math.min(page * PAGE_SIZE, total)} of ${total.toLocaleString()}`}</span><span>{visibleFields.length} visible fields · {Object.keys(staged).length} staged components</span></div>
-        <div ref={gridViewportRef} className={cn("min-h-0 flex-1 overflow-auto border", loading && "opacity-60")} onScroll={(event) => setGridViewport((current) => ({ ...current, scrollTop: event.currentTarget.scrollTop }))} onPaste={handleGridPaste} onKeyDown={(event) => { if ((event.ctrlKey || event.metaKey) && event.key.toLocaleLowerCase() === "z") { event.preventDefault(); if (event.shiftKey) redo(); else undo(); } if ((event.ctrlKey || event.metaKey) && event.key.toLocaleLowerCase() === "y") { event.preventDefault(); redo(); } }}>
+        <div ref={gridViewport.viewportRef} className={cn("min-h-0 flex-1 overflow-auto border", loading && "opacity-60")} onScroll={gridViewport.onScroll} onPaste={handleGridPaste} onKeyDown={(event) => { if ((event.ctrlKey || event.metaKey) && event.key.toLocaleLowerCase() === "z") { event.preventDefault(); if (event.shiftKey) redo(); else undo(); } if ((event.ctrlKey || event.metaKey) && event.key.toLocaleLowerCase() === "y") { event.preventDefault(); redo(); } }}>
           <div className="min-w-max" style={{ width: IDENTITY_WIDTH + visibleFields.reduce((sum, field) => sum + (preferences.widths[field.key] || DEFAULT_WIDTH), 0) }}>
             <div className="sticky top-0 z-20 grid h-10 border-b bg-muted text-xs font-medium" style={{ gridTemplateColumns: gridTemplate }}>
               <div className="sticky left-0 z-30 flex items-center border-r bg-muted px-3">Component</div>

--- a/frontend/src/components/workspace/library-catalog-workspace.tsx
+++ b/frontend/src/components/workspace/library-catalog-workspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   ArrowDown,
@@ -42,6 +42,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { useVirtualViewport } from "@/hooks/use-virtual-viewport";
 import { fetchJson } from "@/lib/api";
 import {
   AVAILABILITY_BADGE_TITLE,
@@ -306,8 +307,7 @@ export function LibraryCatalogWorkspace({
   const [selectedLoading, setSelectedLoading] = useState(false);
   const [selectedError, setSelectedError] = useState("");
   const [selectedRefreshKey, setSelectedRefreshKey] = useState(0);
-  const catalogViewportRef = useRef<HTMLDivElement>(null);
-  const [catalogViewport, setCatalogViewport] = useState({ height: 640, scrollTop: 0 });
+  const catalogViewport = useVirtualViewport();
   const canCreate = canWriteCatalog(user?.role);
 
   const updateCatalogParams = useCallback((values: Record<string, string | null>, replace = false) => {
@@ -398,20 +398,10 @@ export function LibraryCatalogWorkspace({
     return () => controller.abort();
   }, [items, selectedComponentId, selectedRefreshKey]);
 
+  const { resetScroll } = catalogViewport;
   useEffect(() => {
-    const viewport = catalogViewportRef.current;
-    if (!viewport) return;
-    const updateHeight = () => setCatalogViewport((current) => ({ ...current, height: viewport.clientHeight || current.height }));
-    updateHeight();
-    const observer = new ResizeObserver(updateHeight);
-    observer.observe(viewport);
-    return () => observer.disconnect();
-  }, [items.length]);
-
-  useEffect(() => {
-    if (catalogViewportRef.current) catalogViewportRef.current.scrollTop = 0;
-    setCatalogViewport((current) => ({ ...current, scrollTop: 0 }));
-  }, [availability, category, page, sortDirection, sortKey, urlQuery, validation, workflow]);
+    resetScroll();
+  }, [availability, category, page, resetScroll, sortDirection, sortKey, urlQuery, validation, workflow]);
 
   const [pageInput, setPageInput] = useState("");
   const activeFilterCount = [workflow, availability, validation, category].filter((value) => value !== "all").length;
@@ -511,9 +501,9 @@ export function LibraryCatalogWorkspace({
               <span className="min-w-0"><SortControl label="Revision / Updated" sortKey="updated_at" activeKey={sortKey} direction={sortDirection} onSort={handleSort} /></span>
             </div>
             <div
-              ref={catalogViewportRef}
+              ref={catalogViewport.viewportRef}
               className="min-h-0 flex-1 overflow-auto"
-              onScroll={(event) => setCatalogViewport((current) => ({ ...current, scrollTop: event.currentTarget.scrollTop }))}
+              onScroll={catalogViewport.onScroll}
             >
               <div className="relative" style={{ height: items.length * CATALOG_ROW_HEIGHT }}>
               {visibleItems.map((component, visibleIndex) => (

--- a/frontend/src/hooks/use-virtual-viewport.test.tsx
+++ b/frontend/src/hooks/use-virtual-viewport.test.tsx
@@ -1,0 +1,86 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { useVirtualViewport } from "./use-virtual-viewport";
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  // jsdom ships no ResizeObserver; the hook only needs it to not explode.
+  if (!("ResizeObserver" in globalThis)) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+});
+
+function Probe() {
+  const viewport = useVirtualViewport();
+  return (
+    <div ref={viewport.viewportRef} onScroll={viewport.onScroll} data-testid="viewport">
+      <span data-testid="scroll-top">{viewport.scrollTop}</span>
+    </div>
+  );
+}
+
+function scroll(node: HTMLElement, scrollTop: number) {
+  node.scrollTop = scrollTop;
+  node.dispatchEvent(new Event("scroll", { bubbles: true }));
+}
+
+describe("useVirtualViewport", () => {
+  it("keeps tracking the offset when several scroll events batch into one render", () => {
+    render(<Probe />);
+    const node = screen.getByTestId("viewport");
+
+    // Two events in one batch is the case that used to crash. React only
+    // evaluates a functional updater eagerly while the fiber has no queued
+    // work, so the second updater runs during the render phase — after React
+    // has nulled `currentTarget` on the synthetic event. Reading the offset
+    // inside the updater threw there and unmounted the whole workspace.
+    expect(() => {
+      act(() => {
+        scroll(node, 120);
+        scroll(node, 240);
+      });
+    }).not.toThrow();
+
+    expect(screen.getByTestId("scroll-top")).toHaveTextContent("240");
+  });
+
+  it("tracks the offset across separate scroll events", () => {
+    render(<Probe />);
+    const node = screen.getByTestId("viewport");
+
+    act(() => scroll(node, 64));
+    expect(screen.getByTestId("scroll-top")).toHaveTextContent("64");
+
+    act(() => scroll(node, 512));
+    expect(screen.getByTestId("scroll-top")).toHaveTextContent("512");
+  });
+
+  it("returns the container to the top when resetScroll is called", () => {
+    let reset = () => {};
+    function ResetProbe() {
+      const viewport = useVirtualViewport();
+      reset = viewport.resetScroll;
+      return (
+        <div ref={viewport.viewportRef} onScroll={viewport.onScroll} data-testid="viewport">
+          <span data-testid="scroll-top">{viewport.scrollTop}</span>
+        </div>
+      );
+    }
+
+    render(<ResetProbe />);
+    const node = screen.getByTestId("viewport");
+
+    act(() => scroll(node, 800));
+    expect(screen.getByTestId("scroll-top")).toHaveTextContent("800");
+
+    act(() => reset());
+    expect(node.scrollTop).toBe(0);
+    expect(screen.getByTestId("scroll-top")).toHaveTextContent("0");
+  });
+});

--- a/frontend/src/hooks/use-virtual-viewport.ts
+++ b/frontend/src/hooks/use-virtual-viewport.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { UIEvent } from "react";
+
+/** Fallback height used until the element mounts and the observer reports a real one. */
+const DEFAULT_VIEWPORT_HEIGHT = 640;
+
+export type VirtualViewport = {
+  /** Measured client height of the scroll container. */
+  height: number;
+  /** Latest observed scroll offset. */
+  scrollTop: number;
+};
+
+export type UseVirtualViewportResult = VirtualViewport & {
+  /** Attach to the scrolling element: `<div ref={viewportRef} onScroll={onScroll}>`. */
+  viewportRef: (node: HTMLElement | null) => void;
+  onScroll: (event: UIEvent<HTMLElement>) => void;
+  /** Jump the container back to the top, e.g. after the filters or page change. */
+  resetScroll: () => void;
+};
+
+/**
+ * Track the scroll offset and height of a virtualised list container.
+ *
+ * The scroll offset is read from `event.currentTarget` *synchronously*, before
+ * `setViewport` is called. That ordering is the whole point of this hook.
+ * React nulls `currentTarget` on the synthetic event as soon as the handler
+ * returns, and a functional updater is only evaluated eagerly when the fiber
+ * has no work already queued. Scrolling queues updates faster than React
+ * renders, so the second and later updaters run during the render phase — long
+ * after the event was cleaned up. Reading `currentTarget` inside the updater
+ * therefore threw `can't access property "scrollTop", currentTarget is null`
+ * mid-render, which unmounts the tree and blanks the workspace.
+ *
+ * The element is tracked with a callback ref rather than `useRef` so the
+ * observer attaches whenever the node actually mounts, including containers
+ * that render only once their data arrives.
+ */
+export function useVirtualViewport(): UseVirtualViewportResult {
+  const [node, setNode] = useState<HTMLElement | null>(null);
+  const [viewport, setViewport] = useState<VirtualViewport>({ height: DEFAULT_VIEWPORT_HEIGHT, scrollTop: 0 });
+  // Mirrored into a ref so `resetScroll` keeps a stable identity: callers list
+  // it in effect dependency arrays, and a new identity per node would re-run
+  // those effects.
+  const nodeRef = useRef<HTMLElement | null>(null);
+
+  const viewportRef = useCallback((next: HTMLElement | null) => {
+    nodeRef.current = next;
+    setNode(next);
+  }, []);
+
+  useEffect(() => {
+    if (!node) return;
+    const updateHeight = () => setViewport((current) => {
+      const height = node.clientHeight || current.height;
+      return current.height === height ? current : { ...current, height };
+    });
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node]);
+
+  const onScroll = useCallback((event: UIEvent<HTMLElement>) => {
+    // Read before the state update: see the note above.
+    const { scrollTop } = event.currentTarget;
+    setViewport((current) => (current.scrollTop === scrollTop ? current : { ...current, scrollTop }));
+  }, []);
+
+  const resetScroll = useCallback(() => {
+    if (nodeRef.current) nodeRef.current.scrollTop = 0;
+    setViewport((current) => (current.scrollTop === 0 ? current : { ...current, scrollTop: 0 }));
+  }, []);
+
+  return { ...viewport, viewportRef, onScroll, resetScroll };
+}


### PR DESCRIPTION
## The crash

Scrolling the bulk edit grid on the deployed dev instance throws mid-render and leaves a blank workspace:

```
TypeError: can't access property "scrollTop", s.currentTarget is null
    onScroll library-bulk-edit-workspace-CAEe11bS.js:2
    ...
    useState framework-BR3Au4ic.js:38
```

The library catalog list carried an identical copy of the same handler, so it has the same latent crash.

## Why

Both read the scroll offset *inside* the `setState` updater:

```tsx
onScroll={(event) => setGridViewport(
  (current) => ({ ...current, scrollTop: event.currentTarget.scrollTop }))}
```

React nulls `currentTarget` on the synthetic event as soon as the handler returns, and it only evaluates a functional updater eagerly while the fiber has no work already queued. Scrolling queues updates faster than React renders, so from the second event onward the updater is evaluated during the **render phase** — long after the event was cleaned up. The throw happens inside `renderWithHooks`, where no event handler or boundary can catch it, so React unmounts the tree and the page goes white.

That also explains why it looks intermittent: a slow, single-step scroll hits the eager path and works fine.

## The fix

- Read the offset synchronously in the handler, before calling `setState`.
- Fold the duplicated ref + `ResizeObserver` + scroll handler out of both workspaces into one `useVirtualViewport` hook, so there is a single implementation to keep correct rather than two copies of the same trap.
- The hook bails out of no-op updates (scroll events fire well above render rate) and tracks the element with a callback ref, which lets the catalog drop the `[items.length]` dependency it needed to re-attach its observer.

## Verification

- New regression test drives two scroll events through a single React batch — the exact case that used to throw. Reverting just the handler to the old form fails it with the production stack trace (`basicStateReducer` → `updateReducer` → `useState` during render); with the fix it passes.
- `npx tsc -b` clean, `npm run lint` clean (one pre-existing unrelated warning), full suite 128/128 on this base.
- `npm run build` succeeds.

Not exercised against a running instance — verified by the reproduction test and static checks.

## Note

The blank screen is a second-order symptom: this frontend has **no error boundary anywhere**, so any render-phase throw takes down the whole app rather than one panel. Worth adding separately.