### PR TITLE
feat(ui): contain render-phase crashes to the panel that threw

### DIFF
--- a/frontend/src/components/error-boundary.test.tsx
+++ b/frontend/src/components/error-boundary.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { ErrorBoundary } from "./error-boundary";
+
+/**
+ * React logs every caught error to the console on its own, which would bury the
+ * real vitest output under expected noise. Silenced per test, and restored so a
+ * genuine unexpected error still surfaces elsewhere.
+ */
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function Boom({ shouldThrow, message = "grid exploded" }: { shouldThrow: boolean; message?: string }) {
+  if (shouldThrow) throw new Error(message);
+  return <p>panel content</p>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders its children while nothing throws", () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("panel content")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("catches a render-phase throw and shows the failing message instead of unmounting", () => {
+    render(
+      <ErrorBoundary label="the bulk edit grid">
+        <Boom shouldThrow message="can't access property &quot;scrollTop&quot;, currentTarget is null" />
+      </ErrorBoundary>,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Something went wrong in the bulk edit grid.");
+    expect(alert).toHaveTextContent("currentTarget is null");
+    expect(screen.queryByText("panel content")).not.toBeInTheDocument();
+  });
+
+  it("logs the error with its label and reports it to onError", () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary label="the visualizer" onError={onError}>
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0][0].message).toBe("grid exploded");
+    // The component stack is the part that names the component that threw.
+    expect(onError.mock.calls[0][1].componentStack).toContain("Boom");
+    expect(console.error).toHaveBeenCalledWith(
+      "[ErrorBoundary: the visualizer]",
+      expect.any(Error),
+      expect.any(String),
+    );
+  });
+
+  it("recovers when the reviewer retries and the cause is gone", () => {
+    function Harness() {
+      const [broken, setBroken] = useState(true);
+      return (
+        <>
+          <button type="button" onClick={() => setBroken(false)}>fix it</button>
+          <ErrorBoundary>
+            <Boom shouldThrow={broken} />
+          </ErrorBoundary>
+        </>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "fix it" }));
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(screen.getByText("panel content")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("stays in the fallback when retrying and the cause is still there", () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("clears the error on its own when a reset key changes", () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={["commit-a"]}>
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    // Navigating to a different revision is a fresh attempt, not the same
+    // broken one — the reviewer should not have to press anything.
+    rerender(
+      <ErrorBoundary resetKeys={["commit-b"]}>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("panel content")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("keeps the fallback when the reset keys are unchanged", () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={["commit-a"]}>
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    );
+
+    rerender(
+      <ErrorBoundary resetKeys={["commit-a"]}>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders a custom fallback with a working reset", () => {
+    function Harness() {
+      const [broken, setBroken] = useState(true);
+      return (
+        <ErrorBoundary
+          fallback={({ error, reset }) => (
+            <div>
+              <span>custom: {error.message}</span>
+              <button type="button" onClick={() => { setBroken(false); reset(); }}>retry</button>
+            </div>
+          )}
+        >
+          <Boom shouldThrow={broken} />
+        </ErrorBoundary>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByText("custom: grid exploded")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "retry" }));
+    expect(screen.getByText("panel content")).toBeInTheDocument();
+  });
+
+  it("lets an inner boundary contain a crash without the outer one firing", () => {
+    render(
+      <ErrorBoundary label="the tab">
+        <p>sibling panel</p>
+        <ErrorBoundary label="the visualizer">
+          <Boom shouldThrow />
+        </ErrorBoundary>
+      </ErrorBoundary>,
+    );
+
+    // The sibling survives: that containment is the whole point of nesting.
+    expect(screen.getByText("sibling panel")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong in the visualizer.");
+  });
+});

--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,0 +1,116 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Contains a render-phase crash to one region of the app.
+ *
+ * Without a boundary React unmounts the entire tree when any component throws
+ * while rendering, so the window goes white and the reviewer loses whatever
+ * they were doing. That is what a null `currentTarget` in one grid's scroll
+ * handler did to the whole workspace. The throw itself was the bug; taking the
+ * application down with it was this gap.
+ *
+ * Boundaries are therefore placed per region rather than only at the root — a
+ * root-only boundary still costs the reviewer the whole screen, it just paints
+ * the loss more politely. Wrapping each heavy panel means a broken viewer or
+ * comparison pane leaves the surrounding navigation intact and reachable.
+ *
+ * What this cannot catch: React only routes *render*, lifecycle and constructor
+ * errors here. Event handlers, `setTimeout` callbacks and rejected promises do
+ * not unmount the tree on their own, so they never reach a boundary and still
+ * need their own try/catch.
+ */
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  /** Names the region in the fallback copy and in the console log. */
+  label?: string;
+  /**
+   * Clears a caught error whenever one of these values changes.
+   *
+   * A boundary that has caught stays caught until something remounts it, so a
+   * panel keyed to the selected project would otherwise stay broken after the
+   * reviewer moves to a different one. Listing that id here retries on its own.
+   */
+  resetKeys?: readonly unknown[];
+  /** Replaces the default fallback panel. */
+  fallback?: (state: { error: Error; reset: () => void }) => ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+  /** Snapshot of `resetKeys` from the render that last set `error`. */
+  resetKeys: readonly unknown[];
+};
+
+function keysChanged(previous: readonly unknown[], next: readonly unknown[]): boolean {
+  if (previous.length !== next.length) return true;
+  return previous.some((value, index) => !Object.is(value, next[index]));
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null, resetKeys: this.props.resetKeys ?? [] };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  static getDerivedStateFromProps(
+    props: ErrorBoundaryProps,
+    state: ErrorBoundaryState,
+  ): Partial<ErrorBoundaryState> | null {
+    const next = props.resetKeys ?? [];
+    if (state.error && keysChanged(state.resetKeys, next)) {
+      return { error: null, resetKeys: next };
+    }
+    if (!state.error && keysChanged(state.resetKeys, next)) {
+      return { resetKeys: next };
+    }
+    return null;
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Logged rather than swallowed: the fallback tells the reviewer their panel
+    // is gone, but only the component stack tells us which component took it.
+    console.error(`[ErrorBoundary${this.props.label ? `: ${this.props.label}` : ""}]`, error, info.componentStack);
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    if (this.props.fallback) return this.props.fallback({ error, reset: this.reset });
+
+    const { label } = this.props;
+    return (
+      <div
+        role="alert"
+        className="flex h-full min-h-[12rem] w-full flex-col items-center justify-center gap-3 bg-background p-6 text-center"
+      >
+        <AlertTriangle className="h-6 w-6 text-destructive" aria-hidden="true" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">
+            {label ? `Something went wrong in ${label}.` : "Something went wrong."}
+          </p>
+          {/* The message is the one detail that distinguishes "the backend is
+              down" from "this panel has a bug", and reviewers report it to us. */}
+          <p className="max-w-prose break-words text-xs text-muted-foreground">{error.message}</p>
+          <p className="text-xs text-muted-foreground">
+            The rest of the workspace is still usable.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={this.reset} className="gap-1.5">
+          <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+          Try again
+        </Button>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -27,6 +27,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { DesignComparisonWorkspace } from "./design-comparison/design-comparison-workspace";
 import {
     applyOpenComparisonParams,
@@ -688,14 +689,22 @@ export function HistoryViewer({
 
             {/* Design Comparison Workspace */}
             {showDiff && baseRevision && compareRevision && (
-                <DesignComparisonWorkspace
-                    projectId={projectId}
-                    base={baseRevision.sha}
-                    head={compareRevision.sha}
-                    branchTipSha={branchTipSha}
-                    canComment={canComment}
-                    onClose={closeComparison}
-                />
+                // Contained separately from the commit list: a comparison that
+                // throws should still leave the reviewer their history, and the
+                // revision pair they picked is what to retry on.
+                <ErrorBoundary
+                    label="the design comparison"
+                    resetKeys={[projectId, baseRevision.sha, compareRevision.sha]}
+                >
+                    <DesignComparisonWorkspace
+                        projectId={projectId}
+                        base={baseRevision.sha}
+                        head={compareRevision.sha}
+                        branchTipSha={branchTipSha}
+                        canComment={canComment}
+                        onClose={closeComparison}
+                    />
+                </ErrorBoundary>
             )}
 
             {/* Releases Section */}

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import type { User } from "@/types/auth";
 import type { FolderTreeItem, Project } from "@/types/project";
 import { Button } from "@/components/ui/button";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { useWorkspaceData } from "@/hooks/use-workspace-data";
 import { useWorkspaceSearch } from "@/hooks/use-workspace-search";
 import { canManageProjects as roleCanManageProjects, canOpenLibraryManager } from "@/lib/roles";
@@ -546,175 +547,181 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
             )}
           </header>
 
+          {/* Scoped to the content area so a crash here leaves the sidebar and
+              the section switcher alive — the reviewer can navigate out of a
+              broken section instead of reloading. Keyed to the section so
+              switching away and back retries rather than staying broken. */}
           <main className="min-h-0 flex-1 overflow-hidden">
-            {loading ? (
-              <WorkspaceLoadingState />
-            ) : section === "library-manager" ? (
-              canOpenLibrary ? (
-                <LibraryManagerWorkspace user={user} projects={projects} />
+            <ErrorBoundary label="this section" resetKeys={[section]}>
+              {loading ? (
+                <WorkspaceLoadingState />
+              ) : section === "library-manager" ? (
+                canOpenLibrary ? (
+                  <LibraryManagerWorkspace user={user} projects={projects} />
+                ) : (
+                  <WorkspaceAppsPlaceholder
+                    canOpenLibraryManager={canOpenLibrary}
+                    onOpenLibraryManager={() => {}}
+                  />
+                )
               ) : (
-                <WorkspaceAppsPlaceholder
-                  canOpenLibraryManager={canOpenLibrary}
-                  onOpenLibraryManager={() => {}}
-                />
-              )
-            ) : (
-              <div className="flex h-full min-h-0 flex-col p-6">
-                <WorkspaceBreadcrumbs
-                  isSearching={isSearching}
-                  breadcrumbs={breadcrumbs}
-                  viewMode={viewMode}
-                  onGoRoot={() => setFolderInUrl(null)}
-                  onSelectFolder={(folderId) => setFolderInUrl(folderId)}
-                />
+                <div className="flex h-full min-h-0 flex-col p-6">
+                  <WorkspaceBreadcrumbs
+                    isSearching={isSearching}
+                    breadcrumbs={breadcrumbs}
+                    viewMode={viewMode}
+                    onGoRoot={() => setFolderInUrl(null)}
+                    onSelectFolder={(folderId) => setFolderInUrl(folderId)}
+                  />
 
-                <div className="relative mt-6 min-h-0 flex-1 overflow-hidden">
-                  <div className="h-full overflow-y-auto pr-1">
-                    <div className="mb-4 flex items-center justify-between rounded-lg border bg-card/30 px-3 py-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="text-xs text-muted-foreground">
-                          Page {currentPage} of {totalPages} · {pageLabel}
-                        </p>
-                        {canManageProjects && listProjects.length > 0 && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="h-7 px-2 text-[11px]"
-                            onClick={toggleVisibleProjectSelection}
-                          >
-                            {allVisibleProjectsSelected ? "Clear selection" : `Select visible (${listProjects.length})`}
-                          </Button>
-                        )}
-                        {canManageProjects && selectedVisibleProjects.length > 0 && (
-                          <>
-                            <Button
-                              size="sm"
-                              className="h-7 px-2 text-[11px]"
-                              onClick={() => setProjectsToMove(selectedVisibleProjects)}
-                            >
-                              <FolderInput className="mr-1.5 h-3.5 w-3.5" />
-                              Move selected ({selectedVisibleProjects.length})
-                            </Button>
+                  <div className="relative mt-6 min-h-0 flex-1 overflow-hidden">
+                    <div className="h-full overflow-y-auto pr-1">
+                      <div className="mb-4 flex items-center justify-between rounded-lg border bg-card/30 px-3 py-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="text-xs text-muted-foreground">
+                            Page {currentPage} of {totalPages} · {pageLabel}
+                          </p>
+                          {canManageProjects && listProjects.length > 0 && (
                             <Button
                               size="sm"
                               variant="outline"
                               className="h-7 px-2 text-[11px]"
-                              disabled={isRegeneratingThumbnails}
-                              onClick={() => void handleRegenerateThumbnails(selectedVisibleProjects)}
+                              onClick={toggleVisibleProjectSelection}
                             >
-                              <Image className="mr-1.5 h-3.5 w-3.5" />
-                              Regenerate thumbnails ({selectedVisibleProjects.length})
+                              {allVisibleProjectsSelected ? "Clear selection" : `Select visible (${listProjects.length})`}
                             </Button>
-                          </>
-                        )}
+                          )}
+                          {canManageProjects && selectedVisibleProjects.length > 0 && (
+                            <>
+                              <Button
+                                size="sm"
+                                className="h-7 px-2 text-[11px]"
+                                onClick={() => setProjectsToMove(selectedVisibleProjects)}
+                              >
+                                <FolderInput className="mr-1.5 h-3.5 w-3.5" />
+                                Move selected ({selectedVisibleProjects.length})
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-7 px-2 text-[11px]"
+                                disabled={isRegeneratingThumbnails}
+                                onClick={() => void handleRegenerateThumbnails(selectedVisibleProjects)}
+                              >
+                                <Image className="mr-1.5 h-3.5 w-3.5" />
+                                Regenerate thumbnails ({selectedVisibleProjects.length})
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1.5">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2 text-[11px]"
+                            disabled={currentPage <= 1}
+                            onClick={() => setCurrentPage(1)}
+                          >
+                            First
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2 text-[11px]"
+                            disabled={currentPage <= 1}
+                            onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+                          >
+                            Previous
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2 text-[11px]"
+                            disabled={currentPage >= totalPages}
+                            onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+                          >
+                            Next
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2 text-[11px]"
+                            disabled={currentPage >= totalPages}
+                            onClick={() => setCurrentPage(totalPages)}
+                          >
+                            Last
+                          </Button>
+                        </div>
                       </div>
-                      <div className="flex items-center gap-1.5">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-7 px-2 text-[11px]"
-                          disabled={currentPage <= 1}
-                          onClick={() => setCurrentPage(1)}
-                        >
-                          First
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-7 px-2 text-[11px]"
-                          disabled={currentPage <= 1}
-                          onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
-                        >
-                          Previous
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-7 px-2 text-[11px]"
-                          disabled={currentPage >= totalPages}
-                          onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
-                        >
-                          Next
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-7 px-2 text-[11px]"
-                          disabled={currentPage >= totalPages}
-                          onClick={() => setCurrentPage(totalPages)}
-                        >
-                          Last
-                        </Button>
-                      </div>
+                      {viewMode === "gallery" ? (
+                        <WorkspaceGalleryView
+                          searchQuery={searchQuery}
+                          isSearching={isSearching}
+                          searchResults={listProjects}
+                          selectedProjectId={selectedProjectId}
+                          bulkSelectedProjectIds={bulkSelectedProjectIds}
+                          currentFolderId={currentFolderId}
+                          visibleFolders={visibleFolders}
+                          visibleProjects={listProjects}
+                          getProjectDisplayName={getProjectDisplayName}
+                          onSelectProject={selectProject}
+                          onToggleProjectSelection={toggleProjectSelection}
+                          onOpenProject={openProject}
+                          onOpenFolder={(folderId) => setFolderInUrl(folderId)}
+                          onRenameFolder={setFolderToRename}
+                          onDeleteFolder={setFolderToDelete}
+                          onMoveProject={(project) => setProjectsToMove([project])}
+                          onDeleteProject={setProjectToDelete}
+                          onRegenerateThumbnail={handleRegenerateThumbnail}
+                          canManageProjects={canManageProjects}
+                        />
+                      ) : (
+                        <WorkspaceListView
+                          isSearching={isSearching}
+                          selectedProjectId={selectedProjectId}
+                          bulkSelectedProjectIds={bulkSelectedProjectIds}
+                          currentFolderId={currentFolderId}
+                          breadcrumbs={breadcrumbs}
+                          listFolders={listFolders}
+                          listProjects={listProjects}
+                          getProjectDisplayName={getProjectDisplayName}
+                          onSelectProject={selectProject}
+                          onToggleProjectSelection={toggleProjectSelection}
+                          onOpenProject={openProject}
+                          onOpenFolder={(folderId) => setFolderInUrl(folderId)}
+                          onRenameFolder={setFolderToRename}
+                          onDeleteFolder={setFolderToDelete}
+                          onMoveProject={(project) => setProjectsToMove([project])}
+                          onDeleteProject={setProjectToDelete}
+                          onRegenerateThumbnail={handleRegenerateThumbnail}
+                          canManageProjects={canManageProjects}
+                        />
+                      )}
                     </div>
-                    {viewMode === "gallery" ? (
-                      <WorkspaceGalleryView
-                        searchQuery={searchQuery}
-                        isSearching={isSearching}
-                        searchResults={listProjects}
-                        selectedProjectId={selectedProjectId}
-                        bulkSelectedProjectIds={bulkSelectedProjectIds}
-                        currentFolderId={currentFolderId}
-                        visibleFolders={visibleFolders}
-                        visibleProjects={listProjects}
-                        getProjectDisplayName={getProjectDisplayName}
-                        onSelectProject={selectProject}
-                        onToggleProjectSelection={toggleProjectSelection}
-                        onOpenProject={openProject}
-                        onOpenFolder={(folderId) => setFolderInUrl(folderId)}
-                        onRenameFolder={setFolderToRename}
-                        onDeleteFolder={setFolderToDelete}
-                        onMoveProject={(project) => setProjectsToMove([project])}
-                        onDeleteProject={setProjectToDelete}
-                        onRegenerateThumbnail={handleRegenerateThumbnail}
-                        canManageProjects={canManageProjects}
-                      />
-                    ) : (
-                      <WorkspaceListView
-                        isSearching={isSearching}
-                        selectedProjectId={selectedProjectId}
-                        bulkSelectedProjectIds={bulkSelectedProjectIds}
-                        currentFolderId={currentFolderId}
-                        breadcrumbs={breadcrumbs}
-                        listFolders={listFolders}
-                        listProjects={listProjects}
-                        getProjectDisplayName={getProjectDisplayName}
-                        onSelectProject={selectProject}
-                        onToggleProjectSelection={toggleProjectSelection}
-                        onOpenProject={openProject}
-                        onOpenFolder={(folderId) => setFolderInUrl(folderId)}
-                        onRenameFolder={setFolderToRename}
-                        onDeleteFolder={setFolderToDelete}
-                        onMoveProject={(project) => setProjectsToMove([project])}
-                        onDeleteProject={setProjectToDelete}
-                        onRegenerateThumbnail={handleRegenerateThumbnail}
-                        canManageProjects={canManageProjects}
-                      />
-                    )}
-                  </div>
 
-                  <div className="pointer-events-none absolute inset-y-0 right-0 z-20 flex justify-end">
-                    <div className="pointer-events-auto h-full">
-                      <WorkspaceProjectPropertiesSheet
-                        open={selectedProject !== null}
-                        project={selectedProject}
-                        folderById={folderById}
-                        onOpenChange={(open) => {
-                          if (!open) {
-                            setSelectedProjectId(null);
-                          }
-                        }}
-                        onOpenProject={openProject}
-                        canManageProjects={canManageProjects}
-                        onRegenerateThumbnail={handleRegenerateThumbnail}
-                        onUploadThumbnail={handleUploadThumbnail}
-                        onRevertThumbnail={handleRevertThumbnail}
-                      />
+                    <div className="pointer-events-none absolute inset-y-0 right-0 z-20 flex justify-end">
+                      <div className="pointer-events-auto h-full">
+                        <WorkspaceProjectPropertiesSheet
+                          open={selectedProject !== null}
+                          project={selectedProject}
+                          folderById={folderById}
+                          onOpenChange={(open) => {
+                            if (!open) {
+                              setSelectedProjectId(null);
+                            }
+                          }}
+                          onOpenProject={openProject}
+                          canManageProjects={canManageProjects}
+                          onRegenerateThumbnail={handleRegenerateThumbnail}
+                          onUploadThumbnail={handleUploadThumbnail}
+                          onRevertThumbnail={handleRevertThumbnail}
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            </ErrorBoundary>
           </main>
         </div>
       </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client"
 
 import "./index.css"
 import App from "./App.tsx"
+import { ErrorBoundary } from "./components/error-boundary.tsx"
 import prismFavicon from "./assets/branding/kicad-prism/kicad-prism-favicon.ico"
 
 const faviconLink = document.querySelector("link[rel='icon']") ?? document.createElement("link")
@@ -15,6 +16,11 @@ if (!faviconLink.parentNode) {
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    {/* Last resort only. Anything that reaches here has already cost the
+        reviewer the whole window, so the boundaries that matter are the ones
+        around each panel further down the tree. */}
+    <ErrorBoundary label="KiCAD Prism">
+      <App />
+    </ErrorBoundary>
   </StrictMode>
 )

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { Suspense, lazy, useEffect, useMemo, useState, type ComponentType } from "react";
 import { Button } from "@/components/ui/button";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { ArrowLeft, FileText, History, Box, FolderOpen, ChevronLeft, ChevronRight, GitBranch, RotateCcw, PlayCircle, RefreshCw, Menu, Settings } from "lucide-react";
 import { fetchApi, fetchJson, readApiError } from "@/lib/api";
 import { toast } from "sonner";
@@ -548,64 +549,73 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                 </aside>
 
                 <main className={cn("min-h-0 min-w-0 flex-1", activeSection === "visualizers" ? "overflow-hidden" : "overflow-auto p-6")}>
-                    {activeSection === "overview" && (
-                        <div className="space-y-6">
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                <span>Last Updated: {project.last_modified}</span>
+                    {/* Keyed to the section: a reviewer whose History tab throws
+                        can move to Assets and back to get a fresh attempt,
+                        rather than being stuck with a dead tab until reload.
+                        The viewer and history panels carry their own boundaries
+                        inside this one, so the heavy code fails closer to where
+                        it broke. */}
+                    <ErrorBoundary label="this tab" resetKeys={[activeSection, projectId]}>
+                        {activeSection === "overview" && (
+                            <div className="space-y-6">
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <span>Last Updated: {project.last_modified}</span>
+                                </div>
+
+                                {readme && (
+                                    <Suspense fallback={<div className="text-sm text-muted-foreground">Loading README...</div>}>
+                                        <MarkdownContent
+                                            content={readme}
+                                            resolveImageSrc={resolveProjectAssetSrc}
+                                        />
+                                    </Suspense>
+                                )}
+
+                                {!readme && (
+                                    <p className="text-muted-foreground">No README.md found for this project.</p>
+                                )}
                             </div>
+                        )}
 
-                            {readme && (
-                                <Suspense fallback={<div className="text-sm text-muted-foreground">Loading README...</div>}>
-                                    <MarkdownContent
-                                        content={readme}
-                                        resolveImageSrc={resolveProjectAssetSrc}
-                                    />
-                                </Suspense>
-                            )}
+                        {activeSection === "assets" && (
+                            <div>
+                                <h2 className="text-2xl font-bold mb-6">Assets Portal</h2>
+                                {projectId && (
+                                    <Suspense fallback={<div className="text-sm text-muted-foreground">Loading assets...</div>}>
+                                        <AssetsPortal projectId={projectId} commit={activeCommit} />
+                                    </Suspense>
+                                )}
+                            </div>
+                        )}
 
-                            {!readme && (
-                                <p className="text-muted-foreground">No README.md found for this project.</p>
-                            )}
-                        </div>
-                    )}
+                        {activeSection === "documentation" && (
+                            <div>
+                                <h2 className="text-2xl font-bold mb-6">Documentation</h2>
+                                {projectId && (
+                                    <Suspense fallback={<div className="text-sm text-muted-foreground">Loading documentation...</div>}>
+                                        <DocumentationBrowser projectId={projectId} commit={activeCommit} key={activeSection} />
+                                    </Suspense>
+                                )}
+                            </div>
+                        )}
 
-                    {activeSection === "assets" && (
-                        <div>
-                            <h2 className="text-2xl font-bold mb-6">Assets Portal</h2>
-                            {projectId && (
-                                <Suspense fallback={<div className="text-sm text-muted-foreground">Loading assets...</div>}>
-                                    <AssetsPortal projectId={projectId} commit={activeCommit} />
-                                </Suspense>
-                            )}
-                        </div>
-                    )}
-
-                    {activeSection === "documentation" && (
-                        <div>
-                            <h2 className="text-2xl font-bold mb-6">Documentation</h2>
-                            {projectId && (
-                                <Suspense fallback={<div className="text-sm text-muted-foreground">Loading documentation...</div>}>
-                                    <DocumentationBrowser projectId={projectId} commit={activeCommit} key={activeSection} />
-                                </Suspense>
-                            )}
-                        </div>
-                    )}
-
-                    {activeSection === "history" && (
-                        <div>
-                            <h2 className="text-2xl font-bold mb-6">History</h2>
-                            {projectId && (
-                                <Suspense fallback={<div className="text-sm text-muted-foreground">Loading history...</div>}>
-                                    <HistoryViewer
-                                        key={refreshKey}
-                                        projectId={projectId}
-                                        branchRef={selectedBranchRef}
-                                        onViewCommit={handleViewCommit}
-                                        onOpenVisualizer={handleOpenCommitVisualizer}
-                                        canCompareDiffs
-                                        canComment={canMutateProject}
-                                    />
-                                </Suspense>
+                        {activeSection === "history" && (
+                            <div>
+                                <h2 className="text-2xl font-bold mb-6">History</h2>
+                                {projectId && (
+                                    <ErrorBoundary label="the history viewer" resetKeys={[projectId, selectedBranchRef, refreshKey]}>
+                                        <Suspense fallback={<div className="text-sm text-muted-foreground">Loading history...</div>}>
+                                            <HistoryViewer
+                                                key={refreshKey}
+                                                projectId={projectId}
+                                                branchRef={selectedBranchRef}
+                                                onViewCommit={handleViewCommit}
+                                                onOpenVisualizer={handleOpenCommitVisualizer}
+                                                canCompareDiffs
+                                                canComment={canMutateProject}
+                                            />
+                                        </Suspense>
+                                </ErrorBoundary>
                             )}
                         </div>
                     )}
@@ -619,14 +629,19 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                         >
                             <div className="flex-1 min-h-0">
                                 {projectId && (
-                                    <Suspense fallback={<div className="text-sm text-muted-foreground">Loading visualizers...</div>}>
-                                        <Visualizer
-                                            projectId={projectId}
-                                            user={user}
-                                            commit={activeCommit}
-                                            active={!comparisonOpen && activeSection === "visualizers"}
-                                        />
-                                    </Suspense>
+                                    // Its own boundary because this stays mounted while other
+                                    // tabs are on screen: a viewer crash must not reach the
+                                    // section boundary and take down whatever is being viewed.
+                                    <ErrorBoundary label="the visualizer" resetKeys={[projectId, activeCommit]}>
+                                        <Suspense fallback={<div className="text-sm text-muted-foreground">Loading visualizers...</div>}>
+                                            <Visualizer
+                                                projectId={projectId}
+                                                user={user}
+                                                commit={activeCommit}
+                                                active={!comparisonOpen && activeSection === "visualizers"}
+                                            />
+                                        </Suspense>
+                                    </ErrorBoundary>
                                 )}
                             </div>
                         </div>
@@ -638,7 +653,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                         </div>
                     )}
 
-
+                    </ErrorBoundary>
                 </main>
             </div>
         </div>


### PR DESCRIPTION
Stacked on #92 (branched off `feat/automatic-comparison-review-views`).

## Why

The scroll crash fixed in #96 blanked the **entire** application on the deployed dev instance. The throw was one bug; losing the whole window to it was a second, independent gap:

```
grep -rl "componentDidCatch\|getDerivedStateFromError\|ErrorBoundary" frontend/src
# (nothing)
```

With no boundary anywhere, React unmounts the whole tree on any render-phase throw. #96 fixed that particular throw — this fixes the fragility that turned it into a whiteout.

## Placement

Per region, not just at the root. A root-only boundary still costs the reviewer the whole screen; it just paints the loss more politely.

| Boundary | Survives a crash below it |
|---|---|
| app root (`main.tsx`) | last resort |
| workspace content area | sidebar + section switcher stay live, so you can navigate *out* of a broken section |
| each project tab | header, tab rail, branch picker |
| the visualizer | stays mounted while other tabs are on screen, so it must not reach the tab boundary |
| the design comparison | a failed comparison still leaves the commit history usable |

Nesting means the heavy code fails closer to where it broke — an inner boundary catches before the outer one sees anything.

## Recovery

A caught boundary stays caught until something remounts it, which would strand a reviewer on a dead panel even after they navigate away. So alongside the explicit **Try again** button, `resetKeys` clears the error when the thing being viewed changes — the revision pair, the project, the active section. Moving on is its own retry.

Errors are logged with their region label and component stack. The fallback surfaces `error.message`, since that is the one detail distinguishing "the backend is down" from "this panel has a bug" when a reviewer reports it.

## Scope note

React routes only **render**, lifecycle and constructor errors to boundaries. Event handlers, `setTimeout` callbacks and rejected promises don't unmount the tree and never reach one — they still need their own handling. Documented on the component so this isn't mistaken for blanket coverage.

## Verification

- 9 new tests: catching, label/`onError` reporting, retry-succeeds, retry-still-broken, `resetKeys` reset, `resetKeys` unchanged, custom fallback, and nested containment.
- Mutation-checked: deleting `getDerivedStateFromProps` fails exactly the reset-key test and nothing else, so the reset logic is genuinely covered rather than incidentally passing.
- `npx tsc -b` clean, `npm run lint` clean (one pre-existing unrelated warning), **323/323** tests, `npm run build` succeeds.

Not exercised against a running instance.

## Reviewing the diff

Most of the line count in `workspace.tsx` and `ProjectDetailPage.tsx` is re-indentation from the new JSX wrapper. **`git diff -w` shows the 38 lines that actually changed.**