### PR TITLE
fix(viewer): comparison close crash, eager board parse, sheet single-click, and a CI flake

### DIFF
--- a/frontend/src/components/design-comparison/comparison-presentation-shell.test.tsx
+++ b/frontend/src/components/design-comparison/comparison-presentation-shell.test.tsx
@@ -1573,4 +1573,40 @@ describe("ComparisonPresentationShell", () => {
         )).toEqual(resizeCounts.map((count) => count + 1));
         rectSpy.mockRestore();
     });
+
+    it("closes without crashing when the viewer is already torn down", async () => {
+        const view = render(
+            <ComparisonPresentationShell
+                {...shellProps}
+                presentationMode="composite"
+            />,
+        );
+
+        // Wait for the session to reach "ready": the preview effect returns
+        // early before that, so unmounting sooner registers no cleanup at all
+        // and the test would pass without exercising anything.
+        await waitFor(() => {
+            expect(FakeEcadViewer.instances).toHaveLength(1);
+            expect(FakeEcadViewer.sessions[0]?.setPresentation).toHaveBeenCalled();
+        });
+        await waitFor(() => {
+            expect(
+                FakeEcadViewer.instances[0]?.previewDocumentDiff,
+            ).toHaveBeenCalled();
+        });
+
+        // Closing runs the preview effect's cleanup, but `useEffect` destroys are
+        // passive: React detaches the DOM first and flushes them afterwards, so
+        // the real viewer has already released its renderer and throws
+        // `Uninitialized` from `start_layer`. A throw in a cleanup reaches the
+        // nearest error boundary, so pressing Esc blanked the panel instead of
+        // closing it.
+        for (const instance of FakeEcadViewer.instances) {
+            instance.previewDocumentDiff.mockImplementation(() => {
+                if (!instance.isConnected) throw new Error("Uninitialized");
+            });
+        }
+
+        expect(() => view.unmount()).not.toThrow();
+    });
 });

--- a/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
+++ b/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
@@ -27,6 +27,7 @@ import type {
     ECadViewerElement,
     EcadComparisonSession,
     EcadDocumentComparisonPreparation,
+    EcadDocumentComparisonSelection,
     EcadPcbLayerState,
     EcadTransitionTraceDetail,
 } from "@/types/ecad-viewer";
@@ -138,6 +139,36 @@ function viewerState(viewer: ECadViewerElement | null) {
         activePage: viewer?.getActiveSchematicPage?.() ?? null,
         camera: viewer?.camera ?? null,
     };
+}
+
+/**
+ * Push a preview overlay to a viewer, tolerating one that has already gone.
+ *
+ * `useEffect` cleanups are passive: on unmount React detaches the DOM first and
+ * flushes the destroy functions afterwards, so by the time this runs on close
+ * the `<ecad-viewer>` element has had its `disconnectedCallback` and released
+ * its renderer. Asking it to clear an overlay then throws `Uninitialized` from
+ * deep inside the viewer, and a throw in a cleanup propagates to the nearest
+ * error boundary — which is why closing the comparison took the panel down with
+ * it rather than just closing.
+ *
+ * A detached viewer has no overlay left to clear, so skipping it is the correct
+ * outcome and not merely a way to silence the error. The catch covers the same
+ * race in the other direction (disposal landing mid-call) and records it rather
+ * than swallowing it, since a failure here is never worth a visible crash.
+ */
+function setPreviewOverlay(
+    viewer: ECadViewerElement,
+    selection: EcadDocumentComparisonSelection | null,
+): void {
+    if (!viewer.isConnected) return;
+    try {
+        viewer.previewDocumentDiff?.(selection);
+    } catch (caught) {
+        logComparisonDebugError("session.preview.failed", caught, {
+            clearing: selection === null,
+        });
+    }
 }
 
 function diffForDocument(
@@ -867,11 +898,11 @@ export function ComparisonPresentationShell({
             : null;
         const viewers = activeLayerViewers;
         for (const viewer of viewers) {
-            viewer.previewDocumentDiff?.(nativePreview);
+            setPreviewOverlay(viewer, nativePreview);
         }
         return () => {
             for (const viewer of viewers) {
-                viewer.previewDocumentDiff?.(null);
+                setPreviewOverlay(viewer, null);
             }
         };
     }, [

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -683,7 +683,17 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
         const selection = globalSelection;
         if (viewer && selection) {
             const request = crossProbeRequestForSelection(selection, "SCH", semanticIndex);
-            if (request.page && typeof viewer.showPage === "function") {
+            // Only force the page for a probe that arrived from somewhere else.
+            //
+            // This effect also runs on every selection change while the reviewer
+            // is already in the schematic, and the page hint is derived from the
+            // selection's own anchor. Clicking a hierarchical sheet symbol
+            // anchors the selection to the *child* sheet, so forcing the page
+            // here navigated into it: a single click opened the subsheet. The
+            // viewer already reserves that for a double click. A selection made
+            // in the schematic is by definition already on the right page.
+            const arrivedFromElsewhere = selection.sourceContext !== "SCH";
+            if (arrivedFromElsewhere && request.page && typeof viewer.showPage === "function") {
                 void viewer.showPage(request.page).finally(() => {
                     notifyClientReady("visualizer-schematic");
                 });

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -307,6 +307,17 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
             : "sch";
     });
     const [threeDActivated, setThreeDActivated] = useState(false);
+    /**
+     * Whether the PCB tab has ever been opened.
+     *
+     * The board *source* is fetched eagerly so the tab is ready the moment it is
+     * shown, but mounting the viewer is what parses the board, and that parse
+     * runs on the main thread. Mounting it as soon as the fetch resolved froze
+     * the whole UI while the reviewer was still reading the schematic. Fetch
+     * early, parse on first visit; once visited it stays mounted so switching
+     * back does not re-parse.
+     */
+    const [pcbActivated, setPcbActivated] = useState(false);
     const [schematicContent, setSchematicContent] = useState<string | null>(null);
     const [subsheets, setSubsheets] = useState<{ filename: string, content: string }[]>([]);
     const [viewerSupportFiles, setViewerSupportFiles] = useState<ViewerBlobSource[]>([]);
@@ -638,6 +649,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
         setSemanticIndexError(null);
         setRightRailTab(null);
         setThreeDActivated(false);
+        setPcbActivated(false);
         clearGlobalSelection();
         setComments([]);
         setMentionCandidates([]);
@@ -653,6 +665,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
 
     useEffect(() => {
         if (activeTab === "3d" || activeTab === "stackup") setThreeDActivated(true);
+        if (activeTab === "pcb") setPcbActivated(true);
     }, [activeTab]);
 
     // Re-apply an active cross-probe when SCH/PCB becomes visible so hatch/net
@@ -1257,7 +1270,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
 
                     {/* PCB View - always mounted after first visit */}
                     <div aria-hidden={activeTab !== "pcb"} className={`absolute inset-0 z-10 transition-opacity duration-200 ${activeTab === "pcb" ? "visible pointer-events-auto opacity-100" : "invisible pointer-events-none opacity-0"}`}>
-                        {pcbContentLoaded ? (
+                        {!pcbActivated ? null : pcbContentLoaded ? (
                             pcbSources.length > 0 ? (
                                 <div className="relative h-full min-w-0 overflow-hidden">
                                     <div className="absolute inset-0 min-h-0 min-w-0">

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,28 @@
 import { afterEach } from "vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+
+/**
+ * Give `waitFor` and friends a budget that survives a loaded CI runner.
+ *
+ * Testing Library defaults to one second. That is ample for the work itself —
+ * the comparison shell's "reapplies the selected difference" test settles in
+ * about 40ms — but it is a wall-clock budget, and wall clock is not what the
+ * suite is short of. CI runs 40 test files on a two-core `ubuntu-latest`, so a
+ * worker can sit unscheduled for long enough to blow a one-second deadline
+ * while the work it is waiting on has barely started.
+ *
+ * That is what made the comparison-shell test fail intermittently: it never
+ * reproduced running that file alone, only under whole-suite parallelism, and
+ * the same commit passed on a re-run with no change. A raised ceiling is the
+ * fix for starvation; it would be the wrong fix for a dropped event, which is
+ * why the isolated runs mattered — a lost event fails on its own too.
+ *
+ * The cost is paid only by tests that genuinely fail, which then take longer to
+ * report. Set centrally so the budget is one decision rather than a timeout
+ * argument grafted onto whichever call flaked last.
+ */
+configure({ asyncUtilTimeout: 5_000 });
 
 /**
  * Unmount every rendered tree between tests.

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,5 +12,10 @@ export default defineConfig({
     test: {
         environment: "jsdom",
         setupFiles: ["./src/test/setup.ts"],
+        // Has to clear the Testing Library budget in `src/test/setup.ts`, with
+        // room for the several sequential `waitFor`s a single test can make.
+        // Left at the 5s default, a starved worker would blow the test deadline
+        // before `waitFor` could report which condition was still unmet.
+        testTimeout: 20_000,
     },
 });


### PR DESCRIPTION
Replaces the commits I mistakenly pushed to `fix/error-boundary` **after** #97 had already merged — they were stranded on a closed PR and were never in the feature branch. Same four changes, on a live branch.

## 1. Closing the comparison crashed instead of closing

Esc / the close button blanked the screen and needed a reload.

The preview-overlay effect clears itself in its cleanup. `useEffect` destroys are *passive*: on unmount React detaches the DOM first and flushes them after, so the `<ecad-viewer>` elements have already run `disconnectedCallback` and released their renderers. Clearing an overlay then throws `Uninitialized` out of `start_layer`, and a throw in a cleanup propagates like any other.

Skip viewers that are already detached — one that is gone has no overlay to clear, so that is the right outcome, not a way to quiet the error — and record rather than raise a disposal that lands mid-call.

Verified by a test that unmounts a ready session against a viewer that throws once disconnected; it reproduces `Uninitialized` with the guard removed. Also confirmed React's ordering directly: the node is already detached when the passive destroy runs.

Worth noting this was never cosmetic — with #97's boundary in place the panel showed "Something went wrong" and stayed there, so the comparison still never closed.

## 2. The board parsed while the reviewer was on the schematic

Opening a project froze the UI for as long as the board took to parse.

`4657263` made the board *source* fetch eagerly, to kill an "open the PCB tab to load the board source" placeholder. That part is right. What came with it: the PCB pane renders as soon as the fetch resolves and is only styled invisible, so mounting the viewer — and the main-thread parse mounting triggers — happened on another tab.

Keep the eager fetch, defer only the mount, using the first-visit pattern the 3D tab already uses. Cross-probing from the schematic still lands: the viewer's `onReady` re-dispatches the retained selection.

## 3. A single click on a sheet symbol opened the subsheet

Not the viewer's doing — it gates sheet navigation behind `on_dblclick`, there is no synthetic dblclick anywhere in the bundle, and the one select-based navigation path is dead code (it needs `item == previous`; every dispatch passes `previous: null`). The SHA-256 of the served bundle matches the one in the tree, so that is the code actually running.

The navigation was ours. The cross-probe effect re-forces the schematic page on every selection change, and the page hint comes from the selection's own anchor — clicking a sheet symbol anchors to the *child* sheet, so it called `showPage(childSheet)`. That effect exists to reveal the right sheet when you open the SCH tab after probing from the PCB, so it is now restricted to selections that arrived from another context.

No test: the logic sits inside the visualizer component, which has no harness.

## 4. The CI flake on #92

`reapplies the selected difference after a presentation switch settles` failed on #92 and took the quality gate down with it.

**Not caused by #97.** That PR touched six files, none of them comparison code, and this test imports the shell directly. The same commit passed on a re-run with no change. What #97 did was add a test file, which changed suite scheduling.

The failure is starvation, not logic: the work settles in ~40ms against a 1s wall-clock deadline, and it reproduced only under whole-suite parallelism — never running that file alone across a dozen runs. A dropped event would fail in isolation too; that is the distinction that picks the fix. CI runs 40 files on a two-core runner, so a worker can sit unscheduled past one second.

Raised the Testing Library async budget centrally, and the vitest test timeout with it so a test making several sequential `waitFor` calls still reports which condition was unmet. Confirmed live (`waitFor` now budgets 5010ms). Only failing tests pay; suite runtime unchanged.

## Verification

`tsc -b` clean, lint clean (one pre-existing unrelated warning), 324/324 tests, build succeeds.

## Note

#92 is currently `BEHIND` dev (dev picked up #96). It will need dev merged in before it can go.