### PR TITLE
Reveal project selection checkbox on hover

### DIFF
--- a/frontend/src/components/workspace/workspace-gallery-view.tsx
+++ b/frontend/src/components/workspace/workspace-gallery-view.tsx
@@ -62,10 +62,12 @@ export function WorkspaceGalleryView({
           ) : (
             <div className={PROJECT_GRID_CLASS}>
               {searchResults.map((project) => (
-                <div key={project.id} className="relative">
+                <div key={project.id} className="group relative">
                   {canManageProjects && (
                     <div
-                      className="absolute left-2 top-2 z-10"
+                      className={`absolute left-2 top-2 z-10 transition-opacity focus-within:opacity-100 group-hover:opacity-100 ${
+                        bulkSelectedProjectIds.has(project.id) ? "opacity-100" : "opacity-0"
+                      }`}
                       onClick={(event) => event.stopPropagation()}
                       onDoubleClick={(event) => event.stopPropagation()}
                     >
@@ -154,16 +156,18 @@ export function WorkspaceGalleryView({
             ) : (
               <div className={PROJECT_GRID_CLASS}>
                 {visibleProjects.map((project) => (
-                  <div key={project.id} className="relative">
-                  {canManageProjects && (
-                    <div
-                      className="absolute left-2 top-2 z-10"
-                      onClick={(event) => event.stopPropagation()}
-                      onDoubleClick={(event) => event.stopPropagation()}
-                    >
-                      <Checkbox
-                        className="h-5 w-5 border-2 bg-background/95 shadow-md"
-                        checked={bulkSelectedProjectIds.has(project.id)}
+                  <div key={project.id} className="group relative">
+                    {canManageProjects && (
+                      <div
+                        className={`absolute left-2 top-2 z-10 transition-opacity focus-within:opacity-100 group-hover:opacity-100 ${
+                          bulkSelectedProjectIds.has(project.id) ? "opacity-100" : "opacity-0"
+                        }`}
+                        onClick={(event) => event.stopPropagation()}
+                        onDoubleClick={(event) => event.stopPropagation()}
+                      >
+                        <Checkbox
+                          className="h-5 w-5 border-2 bg-background/95 shadow-md"
+                          checked={bulkSelectedProjectIds.has(project.id)}
                           onCheckedChange={(checked) => onToggleProjectSelection(project.id, checked === true)}
                           aria-label={`Select ${getProjectDisplayName(project)}`}
                         />


### PR DESCRIPTION
## Problem

The bulk-selection checkbox overlaid on the top-left of every project card in the workspace gallery was always visible, with a heavy `border-2 / bg-background/95 / shadow-md` treatment. It cluttered the grid even when no bulk selection was in progress.

## Change

In `workspace-gallery-view.tsx` (both card blocks — search results and folder listing):

- Moved `group` onto the card wrapper `div`. The `group` class previously lived on `<Card>` inside `ProjectCard`, which is a *sibling* of the checkbox, so `group-hover:` could not reach it.
- The checkbox wrapper is now `opacity-0` with `transition-opacity`, plus `group-hover:opacity-100` and `focus-within:opacity-100`, and is forced to `opacity-100` while that project is bulk-selected — so an active selection is never hidden.
- Fixed mangled indentation in the second copy of the block so both read identically.

Scope is gallery view only: the kebab action menu, Git/repo badges, and the list-view checkbox column are unchanged.

## Accessibility

`opacity-0` keeps the checkbox in the DOM, the accessibility tree, and the tab order; `focus-within` reveals it the moment it receives keyboard focus. No conditional rendering or `hidden`/`invisible`.

## Verification

- `tsc --noEmit -p tsconfig.app.json` — clean
- `vitest run workspace-gallery-view.test.tsx` — passes
- `eslint` on the changed file — clean

Not yet manually verified in a browser.