### PR TITLE
Fix v3 alpha release screenshot links

### DIFF
--- a/docs/releases/v3.0.0-alpha.md
+++ b/docs/releases/v3.0.0-alpha.md
@@ -55,7 +55,7 @@ The headline changes in v3.0.0-alpha are:
 The workspace remains the front door to Prism, but project handling is much
 more capable than it was in v2.
 
-![KiCAD Prism project workspace](../../assets/v3.0.0-alpha/01-workspace.jpg)
+![KiCAD Prism project workspace](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/01-workspace.jpg)
 
 Repositories are no longer treated as if every Git repository contains exactly
 one KiCad project at its root. Prism now discovers projects in the layouts that
@@ -90,7 +90,7 @@ The same workspace flow is also usable for a second real project shape. The
 USB-PD-Trigger-Board example below shows the searchable, thumbnail-backed
 project card without requiring a reviewer to know the repository layout first.
 
-![USB-PD-Trigger-Board project workspace](../../assets/v3.0.0-alpha/10-usb-pd-workspace.jpg)
+![USB-PD-Trigger-Board project workspace](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/10-usb-pd-workspace.jpg)
 
 ## The new visual review experience
 
@@ -99,7 +99,7 @@ It is no longer a collection of disconnected previews. Schematic, PCB, 3D, BOM,
 stackup, and assembly views share a common project context and a consistent set
 of selection, navigation, and commenting behaviours.
 
-![Schematic visualizer with hierarchical page navigator](../../assets/v3.0.0-alpha/04-schematic-visualizer.jpg)
+![Schematic visualizer with hierarchical page navigator](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/04-schematic-visualizer.jpg)
 
 ### Hierarchical schematic navigation
 
@@ -159,7 +159,7 @@ visualizer useful as an intake surface without making it a KiCad-file authoring
 surface: the source design remains in Git, while the catalog receives a
 reviewable, provenance-pinned component record.
 
-![Import a Cynthion BOM component into the Component database](../../assets/v3.0.0-alpha/09-import-from-visualizer.jpg)
+![Import a Cynthion BOM component into the Component database](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/09-import-from-visualizer.jpg)
 
 ## Design Comparison: review the design, not the Git syntax
 
@@ -167,7 +167,7 @@ Design Comparison is the centrepiece of v3.0.0-alpha. A reviewer chooses a base
 and compare revision from History, then reviews parser-owned changes across the
 design in a dedicated three-zone workspace.
 
-![Design Comparison showing a schematic component value change](../../assets/v3.0.0-alpha/03-design-comparison.jpg)
+![Design Comparison showing a schematic component value change](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/03-design-comparison.jpg)
 
 The left rail is the review queue, grouped by domain and change type. The middle
 is the visual evidence. The right rail explains the selected change and hosts
@@ -261,7 +261,7 @@ v3 introduces a full Library Manager alongside the project workspace. It is a
 revisioned, server-indexed component system rather than a browser over a loose
 folder of symbols and footprints.
 
-![Library Manager component catalog](../../assets/v3.0.0-alpha/02-library-manager.jpg)
+![Library Manager component catalog](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/02-library-manager.jpg)
 
 ### Catalog and revisions
 
@@ -289,7 +289,7 @@ Released is meaningful: the Remote Symbol Provider and KiCad database-library
 exports expose place-ready, released component revisions rather than every
 draft or partially imported row.
 
-![Component lifecycle and approval review](../../assets/v3.0.0-alpha/08-lifecycle-approval.jpg)
+![Component lifecycle and approval review](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/08-lifecycle-approval.jpg)
 
 The release-review surface brings readiness evidence, the current lifecycle
 stage, revision ownership, reviewer identity, evidence failures, structured
@@ -311,7 +311,7 @@ classification, package correction, and other changes that are inefficient one
 component at a time. Large-grid scrolling and viewport calculations were
 hardened during the v3 cycle to avoid blank or jumping content.
 
-![Cynthion Import Center and bulk remediation](../../assets/v3.0.0-alpha/07-import-center-bulk-remediation.jpg)
+![Cynthion Import Center and bulk remediation](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/07-import-center-bulk-remediation.jpg)
 
 The Cynthion import view shows the intended remediation loop: select a project,
 review rows that need attention, group repeated references by MPN, link an
@@ -339,7 +339,7 @@ pinned to the immutable base/compare pair and, where applicable, the selected
 change. That prevents a discussion about one revision pair from silently
 appearing to describe a later design.
 
-![Cynthion comments dialog](../../assets/v3.0.0-alpha/06-comments-dialog.jpg)
+![Cynthion comments dialog](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/06-comments-dialog.jpg)
 
 The comments dialog keeps All, Open, and Resolved filters beside the schematic
 context, so a reviewer can check the discussion state without leaving the
@@ -355,7 +355,7 @@ The global command palette makes the larger v3 surface area manageable. Press
 Library Manager sections, workspace actions, and help without hunting through
 the navigation.
 
-![Global command palette](../../assets/v3.0.0-alpha/05-command-palette.jpg)
+![Global command palette](https://raw.githubusercontent.com/krishna-swaroop/KiCAD-Prism/main/assets/v3.0.0-alpha/05-command-palette.jpg)
 
 Other quality-of-life improvements include:
 


### PR DESCRIPTION
## Summary\n\nUpdate every screenshot in `docs/releases/v3.0.0-alpha.md` to use the direct `main`-branch asset URL under `assets/v3.0.0-alpha/`.\n\nRelative paths render from the repository file view but resolve incorrectly when the markdown is displayed as a GitHub Release, producing Not Found images. The new raw GitHub URLs work in both contexts.\n\n## Validation\n\n- Confirmed all ten referenced JPGs exist on `origin/main`.\n- `git diff --check` passes.\n\nNo image files or application code were changed.