### PR TITLE
Cache project sections and adopt safe contributor optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,10 @@ generated.bak.*/
 loadtest/.env.loadtest
 loadtest/results/
 
-# Python packaging metadata
+# Python packaging + tooling artifacts
 *.egg-info/
+build/
+.pytest_cache/
 
 # Project Data
 # (The project database is currently outside the repo, but just in case)

--- a/backend/app/services/comments_store_service.py
+++ b/backend/app/services/comments_store_service.py
@@ -239,33 +239,36 @@ class CommentsStoreService:
                     """,
                     prepare=False,
                 )
-                # Additive columns for area/element-anchored comments (safe on existing DBs).
-                for statement in (
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_x REAL",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_y REAL",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_w REAL",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_h REAL",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS element_id TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS element_ref TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS element_type TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS comment_class TEXT NOT NULL DEFAULT 'general'",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS severity TEXT NOT NULL DEFAULT 'info'",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS mentions JSONB NOT NULL DEFAULT '[]'::jsonb",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'canvas'",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS base_commit TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS compare_commit TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS comparison_domain TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS file_path TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS semantic_item_id TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS anchor_kind TEXT",
-                    # Reserved for future GitHub/GitLab Issues projection (unused today).
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_provider TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_issue_id TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_issue_url TEXT",
-                    "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_sync_state TEXT",
-                ):
-                    conn.execute(statement)
+                # Keep the additive migration idempotent while paying one remote
+                # database round trip instead of one for every column.
+                conn.execute(
+                    ";\n".join((
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_x REAL",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_y REAL",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_w REAL",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS area_h REAL",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS element_id TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS element_ref TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS element_type TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS comment_class TEXT NOT NULL DEFAULT 'general'",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS severity TEXT NOT NULL DEFAULT 'info'",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS mentions JSONB NOT NULL DEFAULT '[]'::jsonb",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'canvas'",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS base_commit TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS compare_commit TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS comparison_domain TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS file_path TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS semantic_item_id TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS anchor_kind TEXT",
+                        # Reserved for future GitHub/GitLab Issues projection (unused today).
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_provider TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_issue_id TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_issue_url TEXT",
+                        "ALTER TABLE comments ADD COLUMN IF NOT EXISTS forge_sync_state TEXT",
+                    )),
+                    prepare=False,
+                )
                 conn.execute(
                     """
                     CREATE INDEX IF NOT EXISTS idx_comments_comparison

--- a/backend/app/services/component_catalog_service_postgres.py
+++ b/backend/app/services/component_catalog_service_postgres.py
@@ -73,8 +73,11 @@ class _CatalogConnection:
         return self._connection.execute(sql, params, prepare=False)
 
     def executescript(self, script: str) -> None:
-        for statement in _split_sql_script(script):
-            self.execute(statement)
+        # Psycopg accepts parameter-free multi-statement DDL through the simple
+        # protocol. The catalog script is idempotent, so send it in one round
+        # trip rather than splitting it into dozens of remote calls.
+        if script.strip():
+            self._connection.execute(script, prepare=False)
 
     def commit(self) -> None:
         self._connection.commit()

--- a/backend/app/services/design_compare_benchmark.py
+++ b/backend/app/services/design_compare_benchmark.py
@@ -12,15 +12,21 @@ import contextlib
 import json
 import os
 import platform
-import resource
 import sys
 import threading
 import time
 from pathlib import Path
 from typing import Any, Iterator
 
+try:
+    import resource  # Unix only; absent on Windows.
+except ImportError:  # pragma: no cover - platform dependent
+    resource = None
+
 
 def _peak_rss_bytes() -> int:
+    if resource is None:
+        return 0
     value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
     # Darwin reports bytes; Linux and the BSDs report KiB.
     return value if sys.platform == "darwin" else value * 1024

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -590,45 +590,37 @@ def _path_is_within(path: str, relative_path: str | None) -> bool:
         return False
 
 
-def _diff_line_stats(
+def _diff_line_stats_map(
     repo: Repo,
     old_sha: str,
     new_sha: str,
-    *paths: str,
-) -> tuple[int | None, int | None]:
-    """Ask Git for real line statistics without reading or size-capping blobs."""
-    unique_paths = list(dict.fromkeys(path for path in paths if path))
+) -> dict[str, tuple[int | None, int | None]]:
+    """Return every changed path's line statistics with one Git invocation."""
+    stats: dict[str, tuple[int | None, int | None]] = {}
     try:
-        output = repo.git.diff(
-            "--numstat",
-            "--no-renames",
-            old_sha,
-            new_sha,
-            "--",
-            *unique_paths,
-        )
+        output = repo.git.diff("--numstat", "--no-renames", old_sha, new_sha)
     except GitCommandError as error:
         logger.debug(
-            "Could not calculate line stats for %s: %s",
-            unique_paths,
+            "Could not calculate line stats for %s..%s: %s",
+            old_sha,
+            new_sha,
             error,
         )
-        return None, None
+        return stats
 
-    additions = 0
-    deletions = 0
-    saw_text = False
     for line in output.splitlines():
         columns = line.split("\t", 2)
-        if len(columns) < 2 or columns[0] == "-" or columns[1] == "-":
+        if len(columns) < 3:
+            continue
+        additions, deletions, path = columns
+        if additions == "-" or deletions == "-":
+            stats[path] = (None, None)
             continue
         try:
-            additions += int(columns[0])
-            deletions += int(columns[1])
-            saw_text = True
+            stats[path] = (int(additions), int(deletions))
         except ValueError:
             continue
-    return (additions, deletions) if saw_text else (None, None)
+    return stats
 
 
 def get_commit_file_summary(
@@ -652,6 +644,7 @@ def get_commit_file_summary(
             if parent
             else repo.tree(_EMPTY_TREE_SHA).diff(commit)
         )
+        line_stats = _diff_line_stats_map(repo, base_sha, commit.hexsha)
 
         result = []
         for d in diffs:
@@ -667,12 +660,9 @@ def get_commit_file_summary(
             else:
                 status = "modified"
 
-            additions, deletions = _diff_line_stats(
-                repo,
-                base_sha,
-                commit.hexsha,
-                d.a_path or "",
+            additions, deletions = line_stats.get(
                 d.b_path or "",
+                line_stats.get(d.a_path or "", (None, None)),
             )
 
             filename = path.split("/")[-1]

--- a/backend/tests/test_design_compare_benchmark.py
+++ b/backend/tests/test_design_compare_benchmark.py
@@ -4,10 +4,17 @@ import threading
 import unittest
 from pathlib import Path
 
+from unittest.mock import patch
+
+from app.services import design_compare_benchmark
 from app.services.design_compare_benchmark import DesignCompareBenchmark
 
 
 class DesignCompareBenchmarkTests(unittest.TestCase):
+    def test_windows_without_resource_reports_no_process_rss(self) -> None:
+        with patch.object(design_compare_benchmark, "resource", None):
+            self.assertEqual(design_compare_benchmark._peak_rss_bytes(), 0)
+
     def test_records_parallel_scopes_and_publishes_atomically(self) -> None:
         benchmark = DesignCompareBenchmark(
             job_id="benchmark-test",

--- a/backend/tests/test_git_commit_summary.py
+++ b/backend/tests/test_git_commit_summary.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from git import Actor, Repo
 
@@ -56,6 +57,20 @@ class GitCommitSummaryTests(unittest.TestCase):
             self.assertEqual(summary["files"][0]["additions"], 1)
             self.assertEqual(summary["files"][0]["deletions"], 2)
             self.assertNotIn("semantic_buckets", summary["files"][0])
+            self.assertNotIn("components", summary["files"][0])
+            self.assertNotIn("nets", summary["files"][0])
+
+    def test_line_statistics_use_one_git_call_for_the_commit(self) -> None:
+        repo = MagicMock()
+        repo.git.diff.return_value = "1\t2\ta.kicad_sch\n-\t-\tpreview.png"
+
+        stats = git_service._diff_line_stats_map(repo, "old", "new")
+
+        repo.git.diff.assert_called_once_with(
+            "--numstat", "--no-renames", "old", "new"
+        )
+        self.assertEqual(stats["a.kicad_sch"], (1, 2))
+        self.assertEqual(stats["preview.png"], (None, None))
 
     def test_type_two_scope_uses_path_boundaries(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -97,6 +112,36 @@ class GitCommitSummaryTests(unittest.TestCase):
 
             self.assertEqual(summary["files"][0]["additions"], 1)
             self.assertEqual(summary["files"][0]["deletions"], 1)
+
+    def test_binary_files_have_no_invented_line_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = Repo.init(root)
+            source = root / "preview.png"
+            source.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x01")
+            _commit_all(repo, "base")
+            source.write_bytes(b"\x89PNG\r\n\x1a\n\x02\x03")
+            commit = _commit_all(repo, "change binary")
+
+            summary = git_service.get_commit_file_summary(str(root), commit.hexsha)
+
+            self.assertIsNone(summary["files"][0]["additions"])
+            self.assertIsNone(summary["files"][0]["deletions"])
+
+    def test_renamed_files_remain_identified_as_renames(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = Repo.init(root)
+            source = root / "old-name.kicad_sch"
+            source.write_text("same content\n", encoding="utf-8")
+            _commit_all(repo, "base")
+            repo.git.mv("old-name.kicad_sch", "new-name.kicad_sch")
+            commit = _commit_all(repo, "rename")
+
+            summary = git_service.get_commit_file_summary(str(root), commit.hexsha)
+
+            self.assertEqual(summary["files"][0]["filename"], "new-name.kicad_sch")
+            self.assertEqual(summary["files"][0]["status"], "renamed")
 
     def test_merge_summary_explicitly_uses_first_parent(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/backend/tests/test_postgres_schema_switching.py
+++ b/backend/tests/test_postgres_schema_switching.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.services.comments_store_service import CommentsStoreService
+from app.services.component_catalog_service_postgres import ComponentCatalogPostgresService
+from app.services.local_artifact_store import LocalArtifactStore
+from app.services.workspace_service import WorkspaceService
+
+
+POSTGRES_URL = os.environ.get("PRISM_DATABASE_URL", "").strip()
+
+
+@unittest.skipUnless(
+    POSTGRES_URL,
+    "PRISM_DATABASE_URL is required for PostgreSQL schema-switching tests",
+)
+class SharedPostgresSchemaSwitchingTests(unittest.TestCase):
+    def test_initialization_is_idempotent_and_each_service_selects_its_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = WorkspaceService()
+            comments = CommentsStoreService()
+            catalog = ComponentCatalogPostgresService(
+                store_root=Path(temporary) / "catalog",
+                database_url=POSTGRES_URL,
+            )
+            artifacts = LocalArtifactStore(Path(temporary) / "artifacts")
+
+            for service in (workspace, comments, catalog, artifacts):
+                service.initialize()
+                service.initialize()
+
+            expected = (
+                (workspace, 'workspace, public'),
+                (comments, 'comments, public'),
+                (catalog, 'catalog, public'),
+                (artifacts, 'operations, catalog, public'),
+                # Re-enter the first service after every alternate schema has
+                # used the shared pool. Its per-call SET must still win.
+                (workspace, 'workspace, public'),
+            )
+            for service, expected_path in expected:
+                with service._connect() as connection:  # type: ignore[attr-defined]
+                    raw = getattr(connection, "_connection", connection)
+                    row = raw.execute("SHOW search_path").fetchone()
+                    actual = next(iter(row.values())) if isinstance(row, dict) else row[0]
+                    self.assertEqual(actual, expected_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/design-comparison/review-state.test.ts
+++ b/frontend/src/components/design-comparison/review-state.test.ts
@@ -109,6 +109,40 @@ describe("semantic comparison state", () => {
         });
     });
 
+    it("round-trips exact added, changed, removed, and multi-sheet items", () => {
+        const changes = [
+            change("component-added", "added", "new-component"),
+            change("component-changed", "changed", "shared-component"),
+            change("component-removed", "removed", "old-component"),
+            {
+                ...change("component-multi-sheet", "changed", "multi-sheet"),
+                domain: "schematic" as const,
+                page: "root.kicad_sch",
+                alsoOnPages: ["root.kicad_sch", "power.kicad_sch"],
+            },
+        ];
+        const groups = [{ id: "components", changes }];
+
+        for (const expected of changes) {
+            const params = applyWorkspaceComparisonParams(
+                new URLSearchParams("section=history"),
+                {
+                    base: "base-sha",
+                    compare: "compare-sha",
+                    activeTab: expected.domain === "schematic" ? "sch" : "pcb",
+                    presentationOverride: null,
+                    selectedChangeId: expected.id,
+                    showSecondary: false,
+                    visibleLayers: [],
+                },
+            );
+            expect(readInitialUrlState(params).selectedChangeId).toBe(expected.id);
+            expect(selectedChanges({ kind: "item", id: expected.id }, groups))
+                .toEqual([expected]);
+        }
+        expect(selectedChanges({ kind: "item", id: "missing" }, groups)).toEqual([]);
+    });
+
     it("distinguishes automatic presentation from an explicit Composite override", () => {
         // No parameter means "follow the selected change", which is what a
         // shared link should do. An explicit `composite` is a reviewer's

--- a/frontend/src/components/history-viewer-cache.test.tsx
+++ b/frontend/src/components/history-viewer-cache.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HistoryViewer } from "./history-viewer";
+
+vi.mock("./design-comparison/design-comparison-workspace", () => ({
+    DesignComparisonWorkspace: () => (
+        <div data-testid="comparison-workspace">comparison</div>
+    ),
+}));
+
+function historyView(active: boolean) {
+    return (
+        <MemoryRouter
+            initialEntries={[
+                "/project/p1?section=history&base=base-sha&compare=compare-sha&view=semantic",
+            ]}
+        >
+            <HistoryViewer
+                projectId="p1"
+                onViewCommit={vi.fn()}
+                onOpenVisualizer={vi.fn()}
+                canCompareDiffs
+                canComment
+                active={active}
+            />
+        </MemoryRouter>
+    );
+}
+
+describe("cached history viewer", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input);
+            const payload = url.includes("/releases?")
+                ? { releases: [], has_more: false }
+                : { commits: [], has_more: false };
+            return new Response(JSON.stringify(payload), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            });
+        }));
+    });
+
+    it("retains loaded history while suppressing its portalled comparison when inactive", async () => {
+        const view = render(historyView(true));
+
+        await waitFor(() => {
+            expect(screen.getByTestId("comparison-workspace")).toBeInTheDocument();
+        });
+        expect(fetch).toHaveBeenCalledTimes(2);
+
+        view.rerender(historyView(false));
+        expect(screen.queryByTestId("comparison-workspace")).not.toBeInTheDocument();
+        expect(fetch).toHaveBeenCalledTimes(2);
+
+        view.rerender(historyView(true));
+        expect(screen.getByTestId("comparison-workspace")).toBeInTheDocument();
+        expect(fetch).toHaveBeenCalledTimes(2);
+    });
+});

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -109,6 +109,7 @@ interface HistoryViewerProps {
     onOpenVisualizer: (commitHash: string, tab?: string) => void;
     canCompareDiffs: boolean;
     canComment: boolean;
+    active?: boolean;
 }
 
 function formatDate(isoDate: string): string {
@@ -459,6 +460,7 @@ export function HistoryViewer({
     onOpenVisualizer,
     canCompareDiffs,
     canComment,
+    active = true,
 }: HistoryViewerProps) {
     const [searchParams, setSearchParams] = useSearchParams();
     const comparisonUrl = useMemo(
@@ -691,7 +693,7 @@ export function HistoryViewer({
             )}
 
             {/* Design Comparison Workspace */}
-            {showDiff && baseRevision && compareRevision && (
+            {active && showDiff && baseRevision && compareRevision && (
                 // Contained separately from the commit list: a comparison that
                 // throws should still leave the reviewer their history, and the
                 // revision pair they picked is what to retry on.

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -262,9 +262,12 @@ function CommitItem({
         if (next) loadSummary();
     };
 
-    useEffect(() => () => {
-        mountedRef.current = false;
-        summaryAbortRef.current?.abort();
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+            summaryAbortRef.current?.abort();
+        };
     }, []);
 
     return (

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -12,6 +12,11 @@ import {
     comparisonIsOpen,
     readComparisonUrlState,
 } from "@/components/design-comparison/comparison-url";
+import {
+    ProjectSectionPanel,
+    useVisitedProjectSections,
+    type ProjectSection,
+} from "./project-section-cache";
 
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 
@@ -70,23 +75,34 @@ interface WorkflowJobResponse {
     job_id: string;
 }
 
-type Section = "overview" | "history" | "visualizers" | "assets" | "documentation" | "workflows";
-
-
+function sectionFromSearchParams(searchParams: URLSearchParams): ProjectSection {
+    const section = searchParams.get("section");
+    if (
+        section === "history"
+        || section === "visualizers"
+        || section === "assets"
+        || section === "documentation"
+        || section === "workflows"
+    ) {
+        return section;
+    }
+    return "overview";
+}
 
 export function ProjectDetailPage({ user }: { user: User | null }) {
     const { projectId } = useParams<{ projectId: string }>();
     const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
     const [project, setProject] = useState<Project | null>(null);
     const [readme, setReadme] = useState<string>("");
     const [loading, setLoading] = useState(true);
-    const [activeSection, setActiveSection] = useState<Section>("overview");
+    const [activeSection, setActiveSection] = useState<ProjectSection>(() => (
+        sectionFromSearchParams(searchParams)
+    ));
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
     const [sidebarHovered, setSidebarHovered] = useState(false);
-    const [searchParams, setSearchParams] = useSearchParams();
     const [commitsBehind, setCommitsBehind] = useState<number>(0);
     const [syncing, setSyncing] = useState(false);
-    const [visualizerLoaded, setVisualizerLoaded] = useState(false);
     const [refreshKey, setRefreshKey] = useState(0);
     const [pathConfigOpen, setPathConfigOpen] = useState(false);
     const [branches, setBranches] = useState<ProjectBranch[]>([]);
@@ -98,12 +114,6 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
     const getDisplayName = (project: Project) => {
         return project.display_name || project.name;
     };
-
-    useEffect(() => {
-        if (activeSection === 'visualizers') {
-            setVisualizerLoaded(true);
-        }
-    }, [activeSection]);
 
     const selectedBranchRef = searchParams.get('branch');
     const currentCommit = searchParams.get('commit');
@@ -117,22 +127,15 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
         [searchParams],
     );
     const comparisonOpen = comparisonIsOpen(comparisonUrl);
+    const comparisonVisible = comparisonOpen && activeSection === "history";
 
     useEffect(() => {
-        const section = searchParams.get("section");
-        if (
-            section === "overview"
-            || section === "history"
-            || section === "visualizers"
-            || section === "assets"
-            || section === "documentation"
-            || section === "workflows"
-        ) {
-            setActiveSection(section);
-        }
+        setActiveSection(sectionFromSearchParams(searchParams));
     }, [searchParams]);
 
-    const handleSectionChange = (section: Section) => {
+    const visitedSections = useVisitedProjectSections(projectId, activeSection);
+
+    const handleSectionChange = (section: ProjectSection) => {
         setActiveSection(section);
         const next = new URLSearchParams(searchParams);
         next.set("section", section);
@@ -337,12 +340,12 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
     }
 
     const navItems = [
-        { id: "overview" as Section, label: "Overview", icon: FileText },
-        { id: "history" as Section, label: "History", icon: History },
-        { id: "visualizers" as Section, label: "Visualizers", icon: Box },
-        { id: "workflows" as Section, label: "Workflows", icon: PlayCircle },
-        { id: "assets" as Section, label: "Assets Portal", icon: FolderOpen },
-        { id: "documentation" as Section, label: "Documentation", icon: FileText },
+        { id: "overview" as ProjectSection, label: "Overview", icon: FileText },
+        { id: "history" as ProjectSection, label: "History", icon: History },
+        { id: "visualizers" as ProjectSection, label: "Visualizers", icon: Box },
+        { id: "workflows" as ProjectSection, label: "Workflows", icon: PlayCircle },
+        { id: "assets" as ProjectSection, label: "Assets Portal", icon: FolderOpen },
+        { id: "documentation" as ProjectSection, label: "Documentation", icon: FileText },
     ];
 
     const handleBackNavigation = () => {
@@ -548,112 +551,120 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                     </nav>
                 </aside>
 
-                <main className={cn("min-h-0 min-w-0 flex-1", activeSection === "visualizers" ? "overflow-hidden" : "overflow-auto p-6")}>
-                    {/* Keyed to the section: a reviewer whose History tab throws
-                        can move to Assets and back to get a fresh attempt,
-                        rather than being stuck with a dead tab until reload.
-                        The viewer and history panels carry their own boundaries
-                        inside this one, so the heavy code fails closer to where
-                        it broke. */}
-                    <ErrorBoundary label="this tab" resetKeys={[activeSection, projectId]}>
-                        {activeSection === "overview" && (
-                            <div className="space-y-6">
-                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                    <span>Last Updated: {project.last_modified}</span>
+                <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
+                    {visitedSections.has("overview") && (
+                        <ProjectSectionPanel
+                            key={`${projectId}:overview`}
+                            active={activeSection === "overview"}
+                        >
+                            <ErrorBoundary label="the project overview" resetKeys={[projectId, activeCommit, refreshKey]}>
+                                <div className="space-y-6">
+                                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                        <span>Last Updated: {project.last_modified}</span>
+                                    </div>
+                                    {readme ? (
+                                        <Suspense fallback={<div className="text-sm text-muted-foreground">Loading README...</div>}>
+                                            <MarkdownContent
+                                                content={readme}
+                                                resolveImageSrc={resolveProjectAssetSrc}
+                                            />
+                                        </Suspense>
+                                    ) : (
+                                        <p className="text-muted-foreground">No README.md found for this project.</p>
+                                    )}
                                 </div>
+                            </ErrorBoundary>
+                        </ProjectSectionPanel>
+                    )}
 
-                                {readme && (
-                                    <Suspense fallback={<div className="text-sm text-muted-foreground">Loading README...</div>}>
-                                        <MarkdownContent
-                                            content={readme}
-                                            resolveImageSrc={resolveProjectAssetSrc}
-                                        />
-                                    </Suspense>
-                                )}
-
-                                {!readme && (
-                                    <p className="text-muted-foreground">No README.md found for this project.</p>
-                                )}
-                            </div>
-                        )}
-
-                        {activeSection === "assets" && (
-                            <div>
-                                <h2 className="text-2xl font-bold mb-6">Assets Portal</h2>
+                    {visitedSections.has("assets") && (
+                        <ProjectSectionPanel
+                            key={`${projectId}:assets`}
+                            active={activeSection === "assets"}
+                        >
+                            <ErrorBoundary label="the assets portal" resetKeys={[projectId, activeCommit, refreshKey]}>
+                                <h2 className="mb-6 text-2xl font-bold">Assets Portal</h2>
                                 {projectId && (
                                     <Suspense fallback={<div className="text-sm text-muted-foreground">Loading assets...</div>}>
                                         <AssetsPortal projectId={projectId} commit={activeCommit} />
                                     </Suspense>
                                 )}
-                            </div>
-                        )}
+                            </ErrorBoundary>
+                        </ProjectSectionPanel>
+                    )}
 
-                        {activeSection === "documentation" && (
-                            <div>
-                                <h2 className="text-2xl font-bold mb-6">Documentation</h2>
+                    {visitedSections.has("documentation") && (
+                        <ProjectSectionPanel
+                            key={`${projectId}:documentation`}
+                            active={activeSection === "documentation"}
+                        >
+                            <ErrorBoundary label="the documentation browser" resetKeys={[projectId, activeCommit, refreshKey]}>
+                                <h2 className="mb-6 text-2xl font-bold">Documentation</h2>
                                 {projectId && (
                                     <Suspense fallback={<div className="text-sm text-muted-foreground">Loading documentation...</div>}>
-                                        <DocumentationBrowser projectId={projectId} commit={activeCommit} key={activeSection} />
+                                        <DocumentationBrowser projectId={projectId} commit={activeCommit} />
                                     </Suspense>
                                 )}
-                            </div>
-                        )}
+                            </ErrorBoundary>
+                        </ProjectSectionPanel>
+                    )}
 
-                        {activeSection === "history" && (
-                            <div>
-                                <h2 className="text-2xl font-bold mb-6">History</h2>
-                                {projectId && (
-                                    <ErrorBoundary label="the history viewer" resetKeys={[projectId, selectedBranchRef, refreshKey]}>
-                                        <Suspense fallback={<div className="text-sm text-muted-foreground">Loading history...</div>}>
-                                            <HistoryViewer
-                                                key={refreshKey}
-                                                projectId={projectId}
-                                                branchRef={selectedBranchRef}
-                                                onViewCommit={handleViewCommit}
-                                                onOpenVisualizer={handleOpenCommitVisualizer}
-                                                canCompareDiffs
-                                                canComment={canMutateProject}
-                                            />
-                                        </Suspense>
+                    {visitedSections.has("history") && (
+                        <ProjectSectionPanel
+                            key={`${projectId}:history`}
+                            active={activeSection === "history"}
+                        >
+                            <h2 className="mb-6 text-2xl font-bold">History</h2>
+                            {projectId && (
+                                <ErrorBoundary label="the history viewer" resetKeys={[projectId, selectedBranchRef, refreshKey]}>
+                                    <Suspense fallback={<div className="text-sm text-muted-foreground">Loading history...</div>}>
+                                        <HistoryViewer
+                                            key={refreshKey}
+                                            projectId={projectId}
+                                            branchRef={selectedBranchRef}
+                                            onViewCommit={handleViewCommit}
+                                            onOpenVisualizer={handleOpenCommitVisualizer}
+                                            canCompareDiffs
+                                            canComment={canMutateProject}
+                                            active={activeSection === "history"}
+                                        />
+                                    </Suspense>
                                 </ErrorBoundary>
                             )}
-                        </div>
+                        </ProjectSectionPanel>
                     )}
 
-                    {visualizerLoaded && ( // Render only if visualizer has been loaded at least once
-                        <div
-                            className={cn(
-                                "h-full flex flex-col",
-                                activeSection !== "visualizers" && "hidden" // Hide if not active
-                            )}
+                    {visitedSections.has("visualizers") && (
+                        <ProjectSectionPanel
+                            key={`${projectId}:visualizers`}
+                            active={activeSection === "visualizers"}
+                            fill
                         >
-                            <div className="flex-1 min-h-0">
-                                {projectId && (
-                                    // Its own boundary because this stays mounted while other
-                                    // tabs are on screen: a viewer crash must not reach the
-                                    // section boundary and take down whatever is being viewed.
-                                    <ErrorBoundary label="the visualizer" resetKeys={[projectId, activeCommit]}>
-                                        <Suspense fallback={<div className="text-sm text-muted-foreground">Loading visualizers...</div>}>
-                                            <Visualizer
-                                                projectId={projectId}
-                                                user={user}
-                                                commit={activeCommit}
-                                                active={!comparisonOpen && activeSection === "visualizers"}
-                                            />
-                                        </Suspense>
-                                    </ErrorBoundary>
-                                )}
-                            </div>
-                        </div>
+                            {projectId && (
+                                <ErrorBoundary label="the visualizer" resetKeys={[projectId, activeCommit]}>
+                                    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading visualizers...</div>}>
+                                        <Visualizer
+                                            projectId={projectId}
+                                            user={user}
+                                            commit={activeCommit}
+                                            active={!comparisonVisible && activeSection === "visualizers"}
+                                        />
+                                    </Suspense>
+                                </ErrorBoundary>
+                            )}
+                        </ProjectSectionPanel>
                     )}
 
-                    {activeSection === "workflows" && (
-                        <div>
-                            <WorkflowsPanel projectId={projectId!} user={user} canRun={canMutateProject} />
-                        </div>
+                    {visitedSections.has("workflows") && (
+                        <ProjectSectionPanel
+                            key={`${projectId}:workflows`}
+                            active={activeSection === "workflows"}
+                        >
+                            <ErrorBoundary label="the workflows panel" resetKeys={[projectId]}>
+                                <WorkflowsPanel projectId={projectId!} user={user} canRun={canMutateProject} />
+                            </ErrorBoundary>
+                        </ProjectSectionPanel>
                     )}
-
-                    </ErrorBoundary>
                 </main>
             </div>
         </div>

--- a/frontend/src/pages/project-section-cache.test.tsx
+++ b/frontend/src/pages/project-section-cache.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useEffect, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    ProjectSectionPanel,
+    useVisitedProjectSections,
+    type ProjectSection,
+} from "./project-section-cache";
+
+function StatefulProbe({
+    name,
+    onMount,
+}: {
+    name: string;
+    onMount: (name: string) => void;
+}) {
+    const [count, setCount] = useState(0);
+    useEffect(() => onMount(name), [name, onMount]);
+    return (
+        <button type="button" onClick={() => setCount((value) => value + 1)}>
+            {name} {count}
+        </button>
+    );
+}
+
+function Harness({
+    projectId,
+    activeSection,
+    onMount,
+}: {
+    projectId: string;
+    activeSection: ProjectSection;
+    onMount: (name: string) => void;
+}) {
+    const visited = useVisitedProjectSections(projectId, activeSection);
+    return (
+        <>
+            {(["overview", "history", "visualizers", "assets", "documentation", "workflows"] as const)
+                .map((section) => visited.has(section) && (
+                    <ProjectSectionPanel
+                        key={`${projectId}:${section}`}
+                        active={activeSection === section}
+                    >
+                        <StatefulProbe name={section} onMount={onMount} />
+                    </ProjectSectionPanel>
+                ))}
+        </>
+    );
+}
+
+describe("project section cache", () => {
+    it("mounts sections lazily and retains their state while hidden", () => {
+        const onMount = vi.fn();
+        const view = render(
+            <Harness projectId="p1" activeSection="overview" onMount={onMount} />,
+        );
+        expect(screen.getByRole("button", { name: "overview 0" })).toBeVisible();
+        expect(screen.queryByText("history 0")).not.toBeInTheDocument();
+
+        view.rerender(
+            <Harness projectId="p1" activeSection="history" onMount={onMount} />,
+        );
+        fireEvent.click(screen.getByRole("button", { name: "history 0" }));
+        expect(screen.getByRole("button", { name: "history 1" })).toBeVisible();
+        expect(screen.getByText("overview 0").closest("section")).toHaveAttribute("hidden");
+
+        view.rerender(
+            <Harness projectId="p1" activeSection="visualizers" onMount={onMount} />,
+        );
+        expect(screen.queryByRole("button", { name: "history 1" })).not.toBeInTheDocument();
+        expect(screen.getByText("history 1").closest("section")).toHaveAttribute("aria-hidden", "true");
+        view.rerender(
+            <Harness projectId="p1" activeSection="history" onMount={onMount} />,
+        );
+        expect(screen.getByRole("button", { name: "history 1" })).toBeVisible();
+        expect(onMount.mock.calls.filter(([name]) => name === "history")).toHaveLength(1);
+    });
+
+    it("discards visited sections and local state when the project changes", () => {
+        const onMount = vi.fn();
+        const view = render(
+            <Harness projectId="p1" activeSection="history" onMount={onMount} />,
+        );
+        fireEvent.click(screen.getByRole("button", { name: "history 0" }));
+
+        view.rerender(
+            <Harness projectId="p2" activeSection="history" onMount={onMount} />,
+        );
+
+        expect(screen.getByRole("button", { name: "history 0" })).toBeVisible();
+        expect(onMount.mock.calls.filter(([name]) => name === "history")).toHaveLength(2);
+    });
+
+    it.each(["assets", "documentation", "workflows"] as const)(
+        "retains local state in the %s section",
+        (section) => {
+            const onMount = vi.fn();
+            const view = render(
+                <Harness projectId="p1" activeSection={section} onMount={onMount} />,
+            );
+            fireEvent.click(screen.getByRole("button", { name: `${section} 0` }));
+
+            view.rerender(
+                <Harness projectId="p1" activeSection="overview" onMount={onMount} />,
+            );
+            view.rerender(
+                <Harness projectId="p1" activeSection={section} onMount={onMount} />,
+            );
+
+            expect(screen.getByRole("button", { name: `${section} 1` })).toBeVisible();
+            expect(onMount.mock.calls.filter(([name]) => name === section)).toHaveLength(1);
+        },
+    );
+});

--- a/frontend/src/pages/project-section-cache.tsx
+++ b/frontend/src/pages/project-section-cache.tsx
@@ -1,0 +1,82 @@
+import {
+    useEffect,
+    useMemo,
+    useState,
+    type ReactNode,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+export type ProjectSection =
+    | "overview"
+    | "history"
+    | "visualizers"
+    | "assets"
+    | "documentation"
+    | "workflows";
+
+type VisitedSectionState = {
+    projectId: string | undefined;
+    sections: ReadonlySet<ProjectSection>;
+};
+
+/**
+ * Lazily retain sections for one project route. The active section is included
+ * synchronously so a URL navigation never waits for an effect before rendering.
+ */
+export function useVisitedProjectSections(
+    projectId: string | undefined,
+    activeSection: ProjectSection,
+): ReadonlySet<ProjectSection> {
+    const [cache, setCache] = useState<VisitedSectionState>(() => ({
+        projectId,
+        sections: new Set([activeSection]),
+    }));
+
+    const visited = useMemo(() => {
+        if (cache.projectId !== projectId) {
+            return new Set<ProjectSection>([activeSection]);
+        }
+        if (cache.sections.has(activeSection)) return cache.sections;
+        return new Set<ProjectSection>([...cache.sections, activeSection]);
+    }, [activeSection, cache, projectId]);
+
+    useEffect(() => {
+        setCache((current) => {
+            if (current.projectId !== projectId) {
+                return { projectId, sections: new Set([activeSection]) };
+            }
+            if (current.sections.has(activeSection)) return current;
+            return {
+                projectId,
+                sections: new Set([...current.sections, activeSection]),
+            };
+        });
+    }, [activeSection, projectId]);
+
+    return visited;
+}
+
+export function ProjectSectionPanel({
+    active,
+    fill = false,
+    children,
+}: {
+    active: boolean;
+    fill?: boolean;
+    children: ReactNode;
+}) {
+    return (
+        <section
+            hidden={!active}
+            aria-hidden={!active || undefined}
+            className={cn(
+                "h-full min-h-0 min-w-0",
+                fill ? "flex flex-col overflow-hidden" : "overflow-auto p-6",
+                !active && "hidden",
+            )}
+        >
+            {children}
+        </section>
+    );
+}


### PR DESCRIPTION
## Summary

Selectively adopts the safe parts of Keybored02's performance work and adds project-scoped lazy caching for the Project Page.

## Changes

- ignores local build and pytest cache artifacts
- calculates commit line statistics with one `git diff --numstat` call per commit
- keeps commit-summary records file-only (no component or net collections)
- guards the Unix-only comparison metrics dependency on Windows
- batches parameter-free comments and catalog initialization DDL
- preserves per-service PostgreSQL schema selection and existing artifact durability behavior
- rearms History summary loading correctly under React StrictMode
- lazily mounts Overview, History, Visualizers, Assets, Documentation, and Workflows on first visit
- retains visited sections while switching within the same project
- resets the section cache when the project changes
- keeps inactive sections hidden from interaction and accessibility
- keeps Visualizer interaction paused while hidden
- keeps workflow monitoring mounted while Workflows is hidden
- suppresses the portalled Design Comparison workspace while History is inactive
- retains the existing Design Comparison URL contract and adds regression coverage for exact added, changed, removed, and multi-sheet item links

## Deliberately excluded

- no connection-level `search_path` pinning
- no removal of per-service schema selection
- no broad `fsync` exception handling
- no component/net History parser or History navigation UI
- no generic `focus=component:C102` parameter or copy-link UI

## Validation

- backend: 520 tests passed with isolated PostgreSQL 17 application and catalog databases
- frontend: 44 files / 341 tests passed
- frontend lint: no errors; one pre-existing Symbol Finder hook dependency warning
- frontend production build: passed
- Remote Symbol Provider panel build: passed
- live Cynthion browser check: History survives a Visualizer round trip and inactive History is absent from the accessibility tree
- diff check: clean
