### PR TITLE
CI: gate Release Studio on pinned KiCad runtime

### DIFF
--- a/.github/workflows/dev-quality-gate.yml
+++ b/.github/workflows/dev-quality-gate.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - dev
       - main
+      - feature/release-studio
   push:
     branches:
       - dev
       - main
+      - feature/release-studio
   workflow_dispatch:
 
 permissions:
@@ -259,6 +261,48 @@ jobs:
             echo "  $scheme: compose configuration is valid"
           done
 
+  kicad-live:
+    name: Release Studio live KiCad
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    env:
+      PRISM_RELEASE_EXECUTOR_IMAGE: kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Build backend image from pinned KiCad runtime
+        run: >-
+          docker build --pull
+          --platform linux/amd64
+          --build-arg "KICAD_BASE_IMAGE=$PRISM_RELEASE_EXECUTOR_IMAGE"
+          --build-arg KICAD_BASE_PLATFORM=linux/amd64
+          --tag release-studio-live-kicad:ci
+          --file backend/Dockerfile
+          .
+
+      - name: Run Release Studio live KiCad test
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --platform linux/amd64 \
+            --env "PRISM_RELEASE_EXECUTOR_IMAGE=$PRISM_RELEASE_EXECUTOR_IMAGE" \
+            --entrypoint /app/venv/bin/python \
+            release-studio-live-kicad:ci \
+            -m unittest tests.test_release_studio_live_ci -v 2>&1 | tee live-result.log
+
+          if grep -Eiq 'skipped' live-result.log; then
+            echo "Release Studio live test was skipped; the KiCad live gate must run." >&2
+            exit 1
+          fi
+
+          if ! grep -Eq 'Ran [1-9][0-9]* tests? in ' live-result.log; then
+            echo "Release Studio live test ran zero tests or did not report a unittest summary." >&2
+            exit 1
+          fi
+
   quality-gate:
     name: Quality gate
     if: ${{ always() }}
@@ -267,6 +311,7 @@ jobs:
       - backend
       - semantic-viewer
       - deployment-config
+      - kicad-live
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -277,8 +322,10 @@ jobs:
           BACKEND_RESULT: ${{ needs.backend.result }}
           VIEWER_RESULT: ${{ needs.semantic-viewer.result }}
           DEPLOYMENT_RESULT: ${{ needs.deployment-config.result }}
+          KICAD_LIVE_RESULT: ${{ needs.kicad-live.result }}
         run: |
           test "$FRONTEND_RESULT" = "success"
           test "$BACKEND_RESULT" = "success"
           test "$VIEWER_RESULT" = "success"
           test "$DEPLOYMENT_RESULT" = "success"
+          test "$KICAD_LIVE_RESULT" = "success"

--- a/backend/tests/test_release_studio_live_ci.py
+++ b/backend/tests/test_release_studio_live_ci.py
@@ -16,6 +16,10 @@ EXECUTOR_IMAGE_ENV = "PRISM_RELEASE_EXECUTOR_IMAGE"
 
 
 class ReleaseStudioLiveCiTests(unittest.TestCase):
+    @unittest.skipUnless(
+        EXECUTOR_IMAGE_ENV in os.environ,
+        "PRISM_RELEASE_EXECUTOR_IMAGE is required for the live executor test",
+    )
     def test_pinned_executor_has_kicad_cli_10_0_4(self) -> None:
         """Run the real CLI and require the exact CI executor identity."""
         self.assertEqual(

--- a/backend/tests/test_release_studio_live_ci.py
+++ b/backend/tests/test_release_studio_live_ci.py
@@ -1,0 +1,56 @@
+"""Focused Release Studio CI coverage for the pinned KiCad executor."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import unittest
+
+
+EXPECTED_KICAD_IMAGE = (
+    "kicad/kicad:10.0.4@"
+    "sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c"
+)
+EXECUTOR_IMAGE_ENV = "PRISM_RELEASE_EXECUTOR_IMAGE"
+
+
+class ReleaseStudioLiveCiTests(unittest.TestCase):
+    def test_pinned_executor_has_kicad_cli_10_0_4(self) -> None:
+        """Run the real CLI and require the exact CI executor identity."""
+        self.assertEqual(
+            os.environ.get(EXECUTOR_IMAGE_ENV),
+            EXPECTED_KICAD_IMAGE,
+            msg=(
+                f"{EXECUTOR_IMAGE_ENV} must contain the exact pinned KiCad "
+                "image reference"
+            ),
+        )
+
+        try:
+            result = subprocess.run(
+                ["kicad-cli", "--version"],
+                check=False,
+                capture_output=True,
+                text=True,
+                shell=False,
+                timeout=30,
+            )
+        except FileNotFoundError:
+            self.fail("kicad-cli is required for the Release Studio live gate")
+
+        output = f"{result.stdout}\n{result.stderr}"
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"kicad-cli --version failed:\n{output}",
+        )
+        self.assertRegex(
+            output,
+            re.compile(r"(?<![0-9.])10\.0\.4(?![0-9.])"),
+            msg=f"expected KiCad 10.0.4, got:\n{output}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/release-studio/R00.md
+++ b/docs/release-studio/R00.md
@@ -1,0 +1,28 @@
+# Release Studio R00: CI quality gate
+
+R00 makes the existing quality gate run for pull requests and pushes targeting
+`feature/release-studio`, and adds a required live KiCad check.
+
+## Pinned executor
+
+The live job builds the repository backend image with this exact KiCad base
+reference, matching `backend/Dockerfile` and `docker-compose.yml`:
+
+`kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c`
+
+The job passes the full image reference to the focused test as
+`PRISM_RELEASE_EXECUTOR_IMAGE`. Its `@sha256:` suffix is the stable
+Release-Studio-specific identity reserved for future `toolchain_digest` work.
+
+## No-skip enforcement
+
+`backend/tests/test_release_studio_live_ci.py` requires the exact
+`PRISM_RELEASE_EXECUTOR_IMAGE` value, invokes `kicad-cli --version` with an
+argument list (no shell interpolation), and requires KiCad `10.0.4`.
+The workflow then fails if unittest reports `skipped` or does not report at
+least one executed test (`Ran [1-9][0-9]* tests? in ...`). The final
+`quality-gate` job runs with `always()` and explicitly requires
+`needs.kicad-live.result == success`, so a skipped or failed live job cannot
+produce a green aggregate gate.
+
+R00 does not add release fixtures, services, schemas, APIs, or UI.


### PR DESCRIPTION
R00 adds feature/release-studio quality-gate triggers, a backend-image live KiCad test using the exact pinned KiCad 10.0.4 digest, strict no-skip and nonzero-test enforcement, and an aggregate success requirement. Container validation passed with Ran 1 test and OK. Commit: 8e6c046e47e321e86fba5131222ad3143a6a0ab6.