### PR TITLE
Release Studio R3: add workspace schema Migration 8

### DIFF
--- a/backend/app/services/workspace_schema_migrations.py
+++ b/backend/app/services/workspace_schema_migrations.py
@@ -317,6 +317,701 @@ def _generated_thumbnail_default(conn: Any) -> None:
     )
 
 
+def _release_studio(conn: Any) -> None:
+    """Add the Release Studio technical and governance records.
+
+    The release schema is deliberately append-oriented.  IDs are TEXT because
+    the service layer owns UUID generation; the migration only supplies safe
+    data-shape defaults and database invariants.
+    """
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_configurations (
+            id              TEXT PRIMARY KEY,
+            project_id      TEXT NOT NULL
+                            REFERENCES ws_projects(id) ON DELETE CASCADE,
+            config_key      TEXT NOT NULL,
+            title           TEXT NOT NULL DEFAULT '',
+            board_rel       TEXT NOT NULL DEFAULT '',
+            schematic_rel   TEXT NOT NULL DEFAULT '',
+            jobset_rel      TEXT NOT NULL DEFAULT '',
+            default_variant TEXT NOT NULL DEFAULT '',
+            created_by      TEXT NOT NULL DEFAULT '',
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_ws_release_configurations_project_key
+                UNIQUE (project_id, config_key)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_candidates (
+            id                     TEXT PRIMARY KEY,
+            project_id             TEXT NOT NULL
+                                   REFERENCES ws_projects(id) ON DELETE CASCADE,
+            repository_id          TEXT NOT NULL
+                                   REFERENCES ws_repositories(id) ON DELETE CASCADE,
+            config_key             TEXT NOT NULL,
+            commit_sha             TEXT NOT NULL,
+            variant                TEXT NOT NULL DEFAULT '',
+            technical_config_digest TEXT NOT NULL,
+            input_closure_digest   TEXT NOT NULL,
+            toolchain_digest       TEXT NOT NULL,
+            generator_build        TEXT NOT NULL,
+            build_key              TEXT NOT NULL,
+            status                 TEXT NOT NULL DEFAULT 'draft'
+                                   CHECK (status IN (
+                                       'draft', 'building', 'built', 'failed',
+                                       'superseded', 'frozen'
+                                   )),
+            hermetic               BOOLEAN NOT NULL DEFAULT TRUE,
+            non_hermetic_reasons  JSONB NOT NULL DEFAULT '[]'::jsonb,
+            authored_overrides    JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_by             TEXT NOT NULL DEFAULT '',
+            created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_ws_release_candidates_build_key
+                UNIQUE (project_id, config_key, build_key)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_closure_inputs (
+            id                 TEXT PRIMARY KEY,
+            candidate_id       TEXT NOT NULL
+                               REFERENCES ws_release_candidates(id) ON DELETE CASCADE,
+            kind               TEXT NOT NULL
+                               CHECK (kind IN (
+                                   'repository', 'submodule', 'lfs', 'toolchain', 'env'
+                               )),
+            path               TEXT NOT NULL,
+            git_object_id      TEXT,
+            mode               TEXT,
+            object_type        TEXT,
+            lfs_oid            TEXT,
+            materialized_digest TEXT,
+            details            JSONB NOT NULL DEFAULT '{}'::jsonb,
+            CONSTRAINT uq_ws_release_closure_inputs_identity
+                UNIQUE (candidate_id, kind, path)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_builds (
+            id                  TEXT PRIMARY KEY,
+            candidate_id        TEXT NOT NULL
+                                REFERENCES ws_release_candidates(id) ON DELETE CASCADE,
+            job_id              TEXT
+                                REFERENCES ws_jobs(id) ON DELETE SET NULL,
+            fence               BIGINT NOT NULL DEFAULT 0,
+            attempt             INTEGER NOT NULL DEFAULT 0,
+            status              TEXT NOT NULL DEFAULT 'queued'
+                                CHECK (status IN (
+                                    'queued', 'running', 'succeeded', 'failed', 'cancelled'
+                                )),
+            manifest_digest     TEXT NOT NULL DEFAULT '',
+            dossier_digest      TEXT NOT NULL DEFAULT '',
+            dossier_artifact_id TEXT
+                                REFERENCES ws_artifacts(id) ON DELETE RESTRICT,
+            evidence_artifact_id TEXT
+                                REFERENCES ws_artifacts(id) ON DELETE RESTRICT,
+            toolchain           JSONB NOT NULL DEFAULT '{}'::jsonb,
+            timings             JSONB NOT NULL DEFAULT '{}'::jsonb,
+            warnings            JSONB NOT NULL DEFAULT '[]'::jsonb,
+            error_code          TEXT NOT NULL DEFAULT '',
+            error_message       TEXT NOT NULL DEFAULT '',
+            started_at          TIMESTAMPTZ,
+            completed_at        TIMESTAMPTZ,
+            created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_members (
+            id                TEXT PRIMARY KEY,
+            build_id          TEXT NOT NULL
+                              REFERENCES ws_release_builds(id) ON DELETE CASCADE,
+            path              TEXT NOT NULL,
+            member_kind       TEXT NOT NULL,
+            media_type        TEXT NOT NULL,
+            size_bytes        BIGINT NOT NULL DEFAULT 0,
+            released_digest   TEXT NOT NULL,
+            source_raw_digest TEXT NOT NULL,
+            canonicalizer     TEXT NOT NULL DEFAULT '',
+            created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_ws_release_members_build_path
+                UNIQUE (build_id, path),
+            CONSTRAINT uq_ws_release_members_id_build
+                UNIQUE (id, build_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_member_domains (
+            member_id TEXT NOT NULL,
+            build_id  TEXT NOT NULL,
+            domain    TEXT NOT NULL
+                      CHECK (domain IN (
+                          'bare_board', 'assembly', 'documentation', 'evidence'
+                      )),
+            CONSTRAINT pk_ws_release_member_domains PRIMARY KEY (member_id, domain),
+            CONSTRAINT fk_ws_release_member_domains_member_build
+                FOREIGN KEY (member_id, build_id)
+                REFERENCES ws_release_members(id, build_id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_evidence (
+            id            TEXT PRIMARY KEY,
+            build_id      TEXT NOT NULL
+                          REFERENCES ws_release_builds(id) ON DELETE CASCADE,
+            kind          TEXT NOT NULL CHECK (kind IN ('drc', 'erc')),
+            report_digest TEXT NOT NULL,
+            counts        JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_scope_fingerprints (
+            build_id   TEXT NOT NULL
+                       REFERENCES ws_release_builds(id) ON DELETE CASCADE,
+            domain     TEXT NOT NULL
+                       CHECK (domain IN (
+                           'bare_board', 'assembly', 'documentation', 'evidence'
+                       )),
+            fingerprint TEXT NOT NULL,
+            inputs     JSONB NOT NULL DEFAULT '{}'::jsonb,
+            fidelity   TEXT NOT NULL
+                       CHECK (fidelity IN ('artifact', 'board', 'semantic')),
+            CONSTRAINT pk_ws_release_scope_fingerprints PRIMARY KEY (build_id, domain)
+        )
+        """
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_policies (
+            id          TEXT PRIMARY KEY,
+            policy_key  TEXT NOT NULL UNIQUE,
+            title       TEXT NOT NULL DEFAULT '',
+            created_by  TEXT NOT NULL DEFAULT '',
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_policy_versions (
+            id          TEXT PRIMARY KEY,
+            policy_id   TEXT NOT NULL
+                        REFERENCES ws_release_policies(id) ON DELETE CASCADE,
+            version     INTEGER NOT NULL CHECK (version > 0),
+            status      TEXT NOT NULL DEFAULT 'draft'
+                        CHECK (status IN ('draft', 'published', 'retired')),
+            rules       JSONB NOT NULL DEFAULT '{}'::jsonb,
+            content_digest TEXT NOT NULL,
+            retired_at  TIMESTAMPTZ,
+            retired_by  TEXT,
+            created_by  TEXT NOT NULL DEFAULT '',
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_ws_release_policy_versions_identity
+                UNIQUE (policy_id, version),
+            CONSTRAINT ck_ws_release_policy_versions_retirement
+                CHECK (
+                    (
+                        status = 'retired'
+                        AND retired_at IS NOT NULL
+                        AND retired_by IS NOT NULL
+                        AND btrim(retired_by) <> ''
+                    )
+                    OR (
+                        status IN ('draft', 'published')
+                        AND retired_at IS NULL
+                        AND retired_by IS NULL
+                    )
+                )
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_evaluations (
+            id                    TEXT PRIMARY KEY,
+            build_id              TEXT NOT NULL
+                                  REFERENCES ws_release_builds(id) ON DELETE CASCADE,
+            policy_binding        JSONB NOT NULL DEFAULT '{}'::jsonb,
+            policy_binding_digest TEXT NOT NULL,
+            outcome               TEXT NOT NULL
+                                  CHECK (outcome IN (
+                                      'pass', 'warn', 'block', 'waived',
+                                      'unsupported', 'error'
+                                  )),
+            counts                JSONB NOT NULL DEFAULT '{}'::jsonb,
+            evaluator_build       TEXT NOT NULL DEFAULT '',
+            created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_ws_release_evaluations_identity
+                UNIQUE (build_id, policy_binding_digest, evaluator_build)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_waivers (
+            id              TEXT PRIMARY KEY,
+            project_id      TEXT NOT NULL
+                            REFERENCES ws_projects(id) ON DELETE CASCADE,
+            config_key      TEXT NOT NULL,
+            rule_id         TEXT NOT NULL,
+            domain          TEXT NOT NULL
+                            CHECK (domain IN (
+                                'bare_board', 'assembly', 'documentation', 'evidence'
+                            )),
+            subject_pattern TEXT NOT NULL,
+            finding_key     TEXT NOT NULL,
+            reason          TEXT NOT NULL,
+            owner           TEXT NOT NULL,
+            approver        TEXT,
+            status          TEXT NOT NULL DEFAULT 'proposed'
+                            CHECK (status IN (
+                                'proposed', 'approved', 'rejected', 'revoked', 'expired'
+                            )),
+            evidence        JSONB NOT NULL DEFAULT '{}'::jsonb,
+            expires_at      TIMESTAMPTZ,
+            approved_at     TIMESTAMPTZ,
+            revoked_at      TIMESTAMPTZ,
+            revoked_reason  TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_findings (
+            id            TEXT PRIMARY KEY,
+            evaluation_id TEXT NOT NULL
+                          REFERENCES ws_release_evaluations(id) ON DELETE CASCADE,
+            rule_id       TEXT NOT NULL,
+            rule_version  TEXT NOT NULL,
+            severity      TEXT NOT NULL,
+            status        TEXT NOT NULL,
+            domain        TEXT NOT NULL
+                          CHECK (domain IN (
+                              'bare_board', 'assembly', 'documentation', 'evidence'
+                          )),
+            subject       TEXT NOT NULL,
+            message       TEXT NOT NULL,
+            observed      JSONB NOT NULL DEFAULT '{}'::jsonb,
+            expected      JSONB NOT NULL DEFAULT '{}'::jsonb,
+            finding_key   TEXT NOT NULL,
+            waiver_id     TEXT
+                          REFERENCES ws_release_waivers(id) ON DELETE SET NULL,
+            created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_approvals (
+            id                             TEXT PRIMARY KEY,
+            project_id                     TEXT NOT NULL
+                                           REFERENCES ws_projects(id) ON DELETE CASCADE,
+            config_key                     TEXT NOT NULL,
+            candidate_id                   TEXT NOT NULL
+                                           REFERENCES ws_release_candidates(id) ON DELETE CASCADE,
+            build_id                       TEXT NOT NULL
+                                           REFERENCES ws_release_builds(id) ON DELETE CASCADE,
+            role                           TEXT NOT NULL,
+            domains                        TEXT[] NOT NULL DEFAULT '{}'::text[],
+            decision                       TEXT NOT NULL,
+            approver                       TEXT NOT NULL,
+            note                           TEXT NOT NULL DEFAULT '',
+            self_approval_override_reason  TEXT,
+            technical_scope_fingerprints   JSONB NOT NULL DEFAULT '{}'::jsonb,
+            policy_binding_digest          TEXT NOT NULL,
+            manifest_digest                TEXT NOT NULL DEFAULT '',
+            carried_from_approval_id       TEXT
+                                           REFERENCES ws_release_approvals(id)
+                                           ON DELETE SET NULL,
+            reauth_context                 JSONB NOT NULL DEFAULT '{}'::jsonb,
+            evaluation_id                 TEXT
+                                           REFERENCES ws_release_evaluations(id)
+                                           ON DELETE SET NULL,
+            created_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_approval_invalidations (
+            id              TEXT PRIMARY KEY,
+            approval_id     TEXT NOT NULL
+                            REFERENCES ws_release_approvals(id) ON DELETE CASCADE,
+            reason          TEXT NOT NULL,
+            stale_component TEXT NOT NULL
+                            CHECK (stale_component IN ('technical', 'policy', 'both')),
+            changed_domains TEXT[] NOT NULL DEFAULT '{}'::text[],
+            created_by      TEXT NOT NULL DEFAULT '',
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+
+    # Signing keys contain public material only.  They are created before
+    # release records so the record's signing_key_id can be a real FK.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_signing_keys (
+            key_id      TEXT PRIMARY KEY,
+            algorithm   TEXT NOT NULL,
+            public_key  TEXT NOT NULL,
+            status      TEXT NOT NULL DEFAULT 'active'
+                        CHECK (status IN ('active', 'superseded', 'revoked')),
+            valid_from  TIMESTAMPTZ NOT NULL,
+            valid_to    TIMESTAMPTZ,
+            created_by  TEXT NOT NULL DEFAULT '',
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT ck_ws_release_signing_keys_validity
+                CHECK (valid_to IS NULL OR valid_to >= valid_from)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_records (
+            id                   TEXT PRIMARY KEY,
+            project_id           TEXT NOT NULL
+                                 REFERENCES ws_projects(id) ON DELETE RESTRICT,
+            config_key           TEXT NOT NULL,
+            candidate_id         TEXT NOT NULL
+                                 REFERENCES ws_release_candidates(id) ON DELETE RESTRICT,
+            build_id             TEXT NOT NULL
+                                 REFERENCES ws_release_builds(id) ON DELETE RESTRICT,
+            release_label        TEXT NOT NULL,
+            document_number      TEXT NOT NULL DEFAULT '',
+            revision             TEXT NOT NULL DEFAULT '',
+            dossier_digest       TEXT NOT NULL,
+            manifest_digest      TEXT NOT NULL,
+            attestation_digest   TEXT NOT NULL,
+            signature            TEXT,
+            signing_key_id       TEXT
+                                 REFERENCES ws_release_signing_keys(key_id) ON DELETE RESTRICT,
+            attestation_artifact_id TEXT
+                                 REFERENCES ws_artifacts(id) ON DELETE RESTRICT,
+            commit_sha           TEXT NOT NULL,
+            variant              TEXT NOT NULL DEFAULT '',
+            released_by          TEXT NOT NULL DEFAULT '',
+            policy_snapshot      JSONB NOT NULL DEFAULT '{}'::jsonb,
+            approval_snapshot    JSONB NOT NULL DEFAULT '{}'::jsonb,
+            superseded_by        TEXT
+                                 REFERENCES ws_release_records(id) ON DELETE RESTRICT,
+            created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_ws_release_records_label
+                UNIQUE (project_id, config_key, release_label),
+            CONSTRAINT ck_ws_release_records_not_self_superseded
+                CHECK (superseded_by IS NULL OR superseded_by <> id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_release_audit_events (
+            id             TEXT PRIMARY KEY,
+            project_id     TEXT NOT NULL
+                           REFERENCES ws_projects(id) ON DELETE RESTRICT,
+            config_key     TEXT NOT NULL,
+            sequence       BIGINT NOT NULL,
+            event_type     TEXT NOT NULL,
+            actor          TEXT NOT NULL,
+            subject_kind   TEXT NOT NULL,
+            subject_id     TEXT NOT NULL,
+            details        JSONB NOT NULL DEFAULT '{}'::jsonb,
+            previous_hash  TEXT,
+            event_hash     TEXT NOT NULL,
+            created_at_iso TEXT NOT NULL,
+            created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_ws_release_audit_events_sequence
+                UNIQUE (project_id, config_key, sequence)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_artifact_release_pins (
+            artifact_id TEXT PRIMARY KEY
+                        REFERENCES ws_artifacts(id) ON DELETE CASCADE,
+            pin_kind    TEXT NOT NULL,
+            pin_ref     TEXT NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+
+    for statement in (
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_candidates_project
+        ON ws_release_candidates(project_id, config_key, created_at DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_candidates_repository
+        ON ws_release_candidates(repository_id, commit_sha)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_closure_inputs_candidate
+        ON ws_release_closure_inputs(candidate_id, kind, path)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_builds_candidate
+        ON ws_release_builds(candidate_id, created_at DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_builds_manifest_digest_nonempty
+        ON ws_release_builds(manifest_digest)
+        WHERE manifest_digest IS NOT NULL AND manifest_digest <> ''
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_members_build
+        ON ws_release_members(build_id, path)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_member_domains_build
+        ON ws_release_member_domains(build_id, domain)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_evidence_build
+        ON ws_release_evidence(build_id, kind)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_scope_fingerprints_build
+        ON ws_release_scope_fingerprints(build_id, domain)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_policy_versions_policy
+        ON ws_release_policy_versions(policy_id, version DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_evaluations_build
+        ON ws_release_evaluations(build_id, created_at DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_waivers_project
+        ON ws_release_waivers(project_id, config_key, status)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_findings_evaluation
+        ON ws_release_findings(evaluation_id, finding_key)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_approvals_build
+        ON ws_release_approvals(build_id, created_at DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_approval_invalidations_approval
+        ON ws_release_approval_invalidations(approval_id, created_at DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_records_project
+        ON ws_release_records(project_id, config_key, created_at DESC)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_release_audit_events_project
+        ON ws_release_audit_events(project_id, config_key, sequence)
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_ws_artifact_release_pins_ref
+        ON ws_artifact_release_pins(pin_kind, pin_ref)
+        """,
+    ):
+        conn.execute(statement)
+
+    conn.execute(
+        """
+        CREATE OR REPLACE FUNCTION ws_release_immutable_history_guard()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            RAISE EXCEPTION '% rows are immutable; append a new history row',
+                TG_TABLE_NAME
+                USING ERRCODE = '55000';
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    conn.execute(
+        """
+        CREATE OR REPLACE FUNCTION ws_release_policy_version_guard()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.status IN ('published', 'retired') THEN
+                    RAISE EXCEPTION
+                        'published or retired policy versions cannot be deleted'
+                        USING ERRCODE = '55000';
+                END IF;
+                RETURN OLD;
+            END IF;
+
+            IF OLD.status = 'published' THEN
+                IF NEW.status = 'retired'
+                   AND NEW.id = OLD.id
+                   AND NEW.policy_id = OLD.policy_id
+                   AND NEW.version = OLD.version
+                   AND NEW.rules IS NOT DISTINCT FROM OLD.rules
+                   AND NEW.content_digest = OLD.content_digest
+                   AND NEW.created_by = OLD.created_by
+                   AND NEW.created_at = OLD.created_at
+                   AND NEW.retired_at IS NOT NULL
+                   AND NEW.retired_by IS NOT NULL
+                   AND btrim(NEW.retired_by) <> ''
+                THEN
+                    RETURN NEW;
+                END IF;
+
+                IF NEW.id = OLD.id
+                   AND NEW.policy_id = OLD.policy_id
+                   AND NEW.version = OLD.version
+                   AND NEW.status = OLD.status
+                   AND NEW.rules IS NOT DISTINCT FROM OLD.rules
+                   AND NEW.content_digest = OLD.content_digest
+                   AND NEW.retired_at IS NOT DISTINCT FROM OLD.retired_at
+                   AND NEW.retired_by IS NOT DISTINCT FROM OLD.retired_by
+                   AND NEW.created_by = OLD.created_by
+                   AND NEW.created_at = OLD.created_at
+                THEN
+                    RETURN NEW;
+                END IF;
+
+                RAISE EXCEPTION
+                    'published policy version content is immutable; only published to retired is legal'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            IF OLD.status = 'retired' THEN
+                IF NEW.id = OLD.id
+                   AND NEW.policy_id = OLD.policy_id
+                   AND NEW.version = OLD.version
+                   AND NEW.status = OLD.status
+                   AND NEW.rules IS NOT DISTINCT FROM OLD.rules
+                   AND NEW.content_digest = OLD.content_digest
+                   AND NEW.retired_at = OLD.retired_at
+                   AND NEW.retired_by = OLD.retired_by
+                   AND NEW.created_by = OLD.created_by
+                   AND NEW.created_at = OLD.created_at
+                THEN
+                    RETURN NEW;
+                END IF;
+
+                RAISE EXCEPTION
+                    'retired policy versions are immutable'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    conn.execute(
+        """
+        CREATE OR REPLACE FUNCTION ws_release_record_guard()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                RAISE EXCEPTION
+                    'release records are immutable; update superseded_by instead'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            IF NEW.id IS DISTINCT FROM OLD.id
+               OR NEW.project_id IS DISTINCT FROM OLD.project_id
+               OR NEW.config_key IS DISTINCT FROM OLD.config_key
+               OR NEW.candidate_id IS DISTINCT FROM OLD.candidate_id
+               OR NEW.build_id IS DISTINCT FROM OLD.build_id
+               OR NEW.release_label IS DISTINCT FROM OLD.release_label
+               OR NEW.document_number IS DISTINCT FROM OLD.document_number
+               OR NEW.revision IS DISTINCT FROM OLD.revision
+               OR NEW.dossier_digest IS DISTINCT FROM OLD.dossier_digest
+               OR NEW.manifest_digest IS DISTINCT FROM OLD.manifest_digest
+               OR NEW.attestation_digest IS DISTINCT FROM OLD.attestation_digest
+               OR NEW.signature IS DISTINCT FROM OLD.signature
+               OR NEW.signing_key_id IS DISTINCT FROM OLD.signing_key_id
+               OR NEW.attestation_artifact_id IS DISTINCT FROM OLD.attestation_artifact_id
+               OR NEW.commit_sha IS DISTINCT FROM OLD.commit_sha
+               OR NEW.variant IS DISTINCT FROM OLD.variant
+               OR NEW.released_by IS DISTINCT FROM OLD.released_by
+               OR NEW.policy_snapshot IS DISTINCT FROM OLD.policy_snapshot
+               OR NEW.approval_snapshot IS DISTINCT FROM OLD.approval_snapshot
+               OR NEW.created_at IS DISTINCT FROM OLD.created_at
+            THEN
+                RAISE EXCEPTION
+                    'release records are immutable except for superseded_by'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+
+    for table, trigger in (
+        ("ws_release_approvals", "trg_ws_release_approvals_immutable"),
+        (
+            "ws_release_approval_invalidations",
+            "trg_ws_release_approval_invalidations_immutable",
+        ),
+        ("ws_release_audit_events", "trg_ws_release_audit_events_immutable"),
+    ):
+        conn.execute(f"DROP TRIGGER IF EXISTS {trigger} ON {table}")
+        conn.execute(
+            f"""
+            CREATE TRIGGER {trigger}
+            BEFORE UPDATE OR DELETE ON {table}
+            FOR EACH ROW
+            EXECUTE FUNCTION ws_release_immutable_history_guard()
+            """
+        )
+
+    conn.execute("DROP TRIGGER IF EXISTS trg_ws_release_waivers_no_delete ON ws_release_waivers")
+    conn.execute(
+        """
+        CREATE TRIGGER trg_ws_release_waivers_no_delete
+        BEFORE DELETE ON ws_release_waivers
+        FOR EACH ROW
+        EXECUTE FUNCTION ws_release_immutable_history_guard()
+        """
+    )
+    conn.execute(
+        "DROP TRIGGER IF EXISTS trg_ws_release_policy_versions_guard ON ws_release_policy_versions"
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER trg_ws_release_policy_versions_guard
+        BEFORE UPDATE OR DELETE ON ws_release_policy_versions
+        FOR EACH ROW
+        EXECUTE FUNCTION ws_release_policy_version_guard()
+        """
+    )
+    conn.execute("DROP TRIGGER IF EXISTS trg_ws_release_records_guard ON ws_release_records")
+    conn.execute(
+        """
+        CREATE TRIGGER trg_ws_release_records_guard
+        BEFORE UPDATE OR DELETE ON ws_release_records
+        FOR EACH ROW
+        EXECUTE FUNCTION ws_release_record_guard()
+        """
+    )
+
+
 MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (1, "v3_job_foundation", _v3_job_foundation),
     (2, "workspace_read_versions", _workspace_read_versions),
@@ -325,6 +1020,7 @@ MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (5, "thumbnail_metadata", _thumbnail_metadata),
     (6, "thumbnail_source", _thumbnail_source),
     (7, "generated_thumbnail_default", _generated_thumbnail_default),
+    (8, "release_studio", _release_studio),
 )
 
 

--- a/backend/tests/test_release_studio_schema_migration.py
+++ b/backend/tests/test_release_studio_schema_migration.py
@@ -1,0 +1,1154 @@
+"""Catalog and mutation coverage for the Release Studio schema migration."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    import psycopg
+    from psycopg.rows import dict_row
+except ImportError:  # pragma: no cover - dependency guard for host-only checks
+    psycopg = None  # type: ignore[assignment]
+    dict_row = None  # type: ignore[assignment]
+
+from app.services.workspace_schema_migrations import (  # noqa: E402
+    MIGRATIONS,
+    _release_studio,
+    apply_workspace_migrations,
+)
+
+
+POSTGRES_URL = os.environ.get("TEST_POSTGRES_URL", "").strip()
+APPLICATION_POSTGRES_URL = os.environ.get("PRISM_DATABASE_URL", "").strip()
+
+
+def _database_identity(url: str) -> tuple[str, str, int | None, str]:
+    parsed = urlsplit(url)
+    return (
+        parsed.username or "",
+        (parsed.hostname or "").lower(),
+        parsed.port,
+        parsed.path.lstrip("/"),
+    )
+
+
+SHARED_APPLICATION_DATABASE = bool(
+    POSTGRES_URL
+    and APPLICATION_POSTGRES_URL
+    and _database_identity(POSTGRES_URL) == _database_identity(APPLICATION_POSTGRES_URL)
+)
+
+
+EXPECTED_COLUMNS: dict[str, set[str]] = {
+    "ws_release_configurations": {
+        "id",
+        "project_id",
+        "config_key",
+        "title",
+        "board_rel",
+        "schematic_rel",
+        "jobset_rel",
+        "default_variant",
+        "created_by",
+        "created_at",
+        "updated_at",
+    },
+    "ws_release_candidates": {
+        "id",
+        "project_id",
+        "repository_id",
+        "config_key",
+        "commit_sha",
+        "variant",
+        "technical_config_digest",
+        "input_closure_digest",
+        "toolchain_digest",
+        "generator_build",
+        "build_key",
+        "status",
+        "hermetic",
+        "non_hermetic_reasons",
+        "authored_overrides",
+        "created_by",
+        "created_at",
+        "updated_at",
+    },
+    "ws_release_closure_inputs": {
+        "id",
+        "candidate_id",
+        "kind",
+        "path",
+        "git_object_id",
+        "mode",
+        "object_type",
+        "lfs_oid",
+        "materialized_digest",
+        "details",
+    },
+    "ws_release_builds": {
+        "id",
+        "candidate_id",
+        "job_id",
+        "fence",
+        "attempt",
+        "status",
+        "manifest_digest",
+        "dossier_digest",
+        "dossier_artifact_id",
+        "evidence_artifact_id",
+        "toolchain",
+        "timings",
+        "warnings",
+        "error_code",
+        "error_message",
+        "started_at",
+        "completed_at",
+        "created_at",
+    },
+    "ws_release_members": {
+        "id",
+        "build_id",
+        "path",
+        "member_kind",
+        "media_type",
+        "size_bytes",
+        "released_digest",
+        "source_raw_digest",
+        "canonicalizer",
+        "created_at",
+    },
+    "ws_release_member_domains": {"member_id", "build_id", "domain"},
+    "ws_release_evidence": {
+        "id",
+        "build_id",
+        "kind",
+        "report_digest",
+        "counts",
+        "created_at",
+    },
+    "ws_release_scope_fingerprints": {
+        "build_id",
+        "domain",
+        "fingerprint",
+        "inputs",
+        "fidelity",
+    },
+    "ws_release_policies": {
+        "id",
+        "policy_key",
+        "title",
+        "created_by",
+        "created_at",
+        "updated_at",
+    },
+    "ws_release_policy_versions": {
+        "id",
+        "policy_id",
+        "version",
+        "status",
+        "rules",
+        "content_digest",
+        "retired_at",
+        "retired_by",
+        "created_by",
+        "created_at",
+    },
+    "ws_release_evaluations": {
+        "id",
+        "build_id",
+        "policy_binding",
+        "policy_binding_digest",
+        "outcome",
+        "counts",
+        "evaluator_build",
+        "created_at",
+    },
+    "ws_release_waivers": {
+        "id",
+        "project_id",
+        "config_key",
+        "rule_id",
+        "domain",
+        "subject_pattern",
+        "finding_key",
+        "reason",
+        "owner",
+        "approver",
+        "status",
+        "evidence",
+        "expires_at",
+        "approved_at",
+        "revoked_at",
+        "revoked_reason",
+        "created_at",
+    },
+    "ws_release_findings": {
+        "id",
+        "evaluation_id",
+        "rule_id",
+        "rule_version",
+        "severity",
+        "status",
+        "domain",
+        "subject",
+        "message",
+        "observed",
+        "expected",
+        "finding_key",
+        "waiver_id",
+        "created_at",
+    },
+    "ws_release_approvals": {
+        "id",
+        "project_id",
+        "config_key",
+        "candidate_id",
+        "build_id",
+        "role",
+        "domains",
+        "decision",
+        "approver",
+        "note",
+        "self_approval_override_reason",
+        "technical_scope_fingerprints",
+        "policy_binding_digest",
+        "manifest_digest",
+        "carried_from_approval_id",
+        "reauth_context",
+        "evaluation_id",
+        "created_at",
+    },
+    "ws_release_approval_invalidations": {
+        "id",
+        "approval_id",
+        "reason",
+        "stale_component",
+        "changed_domains",
+        "created_by",
+        "created_at",
+    },
+    "ws_release_signing_keys": {
+        "key_id",
+        "algorithm",
+        "public_key",
+        "status",
+        "valid_from",
+        "valid_to",
+        "created_by",
+        "created_at",
+    },
+    "ws_release_records": {
+        "id",
+        "project_id",
+        "config_key",
+        "candidate_id",
+        "build_id",
+        "release_label",
+        "document_number",
+        "revision",
+        "dossier_digest",
+        "manifest_digest",
+        "attestation_digest",
+        "signature",
+        "signing_key_id",
+        "attestation_artifact_id",
+        "commit_sha",
+        "variant",
+        "released_by",
+        "policy_snapshot",
+        "approval_snapshot",
+        "superseded_by",
+        "created_at",
+    },
+    "ws_release_audit_events": {
+        "id",
+        "project_id",
+        "config_key",
+        "sequence",
+        "event_type",
+        "actor",
+        "subject_kind",
+        "subject_id",
+        "details",
+        "previous_hash",
+        "event_hash",
+        "created_at_iso",
+        "created_at",
+    },
+    "ws_artifact_release_pins": {"artifact_id", "pin_kind", "pin_ref", "created_at"},
+}
+
+
+EXPECTED_PRIMARY_KEYS = {
+    "ws_release_configurations": ("id",),
+    "ws_release_candidates": ("id",),
+    "ws_release_closure_inputs": ("id",),
+    "ws_release_builds": ("id",),
+    "ws_release_members": ("id",),
+    "ws_release_member_domains": ("member_id", "domain"),
+    "ws_release_evidence": ("id",),
+    "ws_release_scope_fingerprints": ("build_id", "domain"),
+    "ws_release_policies": ("id",),
+    "ws_release_policy_versions": ("id",),
+    "ws_release_evaluations": ("id",),
+    "ws_release_waivers": ("id",),
+    "ws_release_findings": ("id",),
+    "ws_release_approvals": ("id",),
+    "ws_release_approval_invalidations": ("id",),
+    "ws_release_signing_keys": ("key_id",),
+    "ws_release_records": ("id",),
+    "ws_release_audit_events": ("id",),
+    "ws_artifact_release_pins": ("artifact_id",),
+}
+
+
+EXPECTED_UNIQUES = {
+    ("ws_release_configurations", ("project_id", "config_key")),
+    ("ws_release_candidates", ("project_id", "config_key", "build_key")),
+    ("ws_release_closure_inputs", ("candidate_id", "kind", "path")),
+    ("ws_release_members", ("build_id", "path")),
+    ("ws_release_members", ("id", "build_id")),
+    ("ws_release_policies", ("policy_key",)),
+    ("ws_release_policy_versions", ("policy_id", "version")),
+    (
+        "ws_release_evaluations",
+        ("build_id", "policy_binding_digest", "evaluator_build"),
+    ),
+    ("ws_release_records", ("project_id", "config_key", "release_label")),
+}
+
+
+EXPECTED_FKS = {
+    ("ws_release_configurations", ("project_id",), "ws_projects", ("id",), "CASCADE"),
+    ("ws_release_candidates", ("project_id",), "ws_projects", ("id",), "CASCADE"),
+    (
+        "ws_release_candidates",
+        ("repository_id",),
+        "ws_repositories",
+        ("id",),
+        "CASCADE",
+    ),
+    (
+        "ws_release_closure_inputs",
+        ("candidate_id",),
+        "ws_release_candidates",
+        ("id",),
+        "CASCADE",
+    ),
+    ("ws_release_builds", ("candidate_id",), "ws_release_candidates", ("id",), "CASCADE"),
+    ("ws_release_builds", ("job_id",), "ws_jobs", ("id",), "SET NULL"),
+    ("ws_release_builds", ("dossier_artifact_id",), "ws_artifacts", ("id",), "RESTRICT"),
+    (
+        "ws_release_builds",
+        ("evidence_artifact_id",),
+        "ws_artifacts",
+        ("id",),
+        "RESTRICT",
+    ),
+    ("ws_release_members", ("build_id",), "ws_release_builds", ("id",), "CASCADE"),
+    (
+        "ws_release_member_domains",
+        ("member_id", "build_id"),
+        "ws_release_members",
+        ("id", "build_id"),
+        "CASCADE",
+    ),
+    ("ws_release_evidence", ("build_id",), "ws_release_builds", ("id",), "CASCADE"),
+    (
+        "ws_release_scope_fingerprints",
+        ("build_id",),
+        "ws_release_builds",
+        ("id",),
+        "CASCADE",
+    ),
+    (
+        "ws_release_policy_versions",
+        ("policy_id",),
+        "ws_release_policies",
+        ("id",),
+        "CASCADE",
+    ),
+    ("ws_release_evaluations", ("build_id",), "ws_release_builds", ("id",), "CASCADE"),
+    ("ws_release_waivers", ("project_id",), "ws_projects", ("id",), "CASCADE"),
+    (
+        "ws_release_findings",
+        ("evaluation_id",),
+        "ws_release_evaluations",
+        ("id",),
+        "CASCADE",
+    ),
+    (
+        "ws_release_findings",
+        ("waiver_id",),
+        "ws_release_waivers",
+        ("id",),
+        "SET NULL",
+    ),
+    ("ws_release_approvals", ("project_id",), "ws_projects", ("id",), "CASCADE"),
+    (
+        "ws_release_approvals",
+        ("candidate_id",),
+        "ws_release_candidates",
+        ("id",),
+        "CASCADE",
+    ),
+    ("ws_release_approvals", ("build_id",), "ws_release_builds", ("id",), "CASCADE"),
+    (
+        "ws_release_approvals",
+        ("carried_from_approval_id",),
+        "ws_release_approvals",
+        ("id",),
+        "SET NULL",
+    ),
+    (
+        "ws_release_approvals",
+        ("evaluation_id",),
+        "ws_release_evaluations",
+        ("id",),
+        "SET NULL",
+    ),
+    (
+        "ws_release_approval_invalidations",
+        ("approval_id",),
+        "ws_release_approvals",
+        ("id",),
+        "CASCADE",
+    ),
+    ("ws_release_records", ("project_id",), "ws_projects", ("id",), "RESTRICT"),
+    (
+        "ws_release_records",
+        ("candidate_id",),
+        "ws_release_candidates",
+        ("id",),
+        "RESTRICT",
+    ),
+    ("ws_release_records", ("build_id",), "ws_release_builds", ("id",), "RESTRICT"),
+    (
+        "ws_release_records",
+        ("signing_key_id",),
+        "ws_release_signing_keys",
+        ("key_id",),
+        "RESTRICT",
+    ),
+    (
+        "ws_release_records",
+        ("attestation_artifact_id",),
+        "ws_artifacts",
+        ("id",),
+        "RESTRICT",
+    ),
+    (
+        "ws_release_records",
+        ("superseded_by",),
+        "ws_release_records",
+        ("id",),
+        "RESTRICT",
+    ),
+    ("ws_release_audit_events", ("project_id",), "ws_projects", ("id",), "RESTRICT"),
+    (
+        "ws_artifact_release_pins",
+        ("artifact_id",),
+        "ws_artifacts",
+        ("id",),
+        "CASCADE",
+    ),
+}
+
+
+@unittest.skipUnless(
+    POSTGRES_URL,
+    "TEST_POSTGRES_URL is required for Release Studio PostgreSQL schema tests",
+)
+@unittest.skipUnless(
+    psycopg is not None,
+    "psycopg is required for Release Studio PostgreSQL schema tests",
+)
+@unittest.skipIf(
+    SHARED_APPLICATION_DATABASE,
+    "TEST_POSTGRES_URL must not target PRISM_DATABASE_URL",
+)
+class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
+    """Run Migration 8 against a disposable schema in the test database."""
+
+    def setUp(self) -> None:
+        assert psycopg is not None
+        self.schema = f"release_r3_{uuid.uuid4().hex}"
+        dsn = POSTGRES_URL.replace("postgresql+psycopg://", "postgresql://", 1)
+        self.conn = psycopg.connect(dsn, row_factory=dict_row)
+        self.conn.execute(f'CREATE SCHEMA "{self.schema}"')
+        self.conn.execute(f'SET search_path TO "{self.schema}", public')
+        self._create_base_workspace_tables()
+        apply_workspace_migrations(self.conn)
+        self.conn.commit()
+
+        # The ledger makes the normal second application a no-op.  Calling the
+        # migration itself is covered separately to prove its DDL is also
+        # replaceable when a deployment resumes after a partial attempt.
+        apply_workspace_migrations(self.conn)
+        self.conn.commit()
+
+    def tearDown(self) -> None:
+        try:
+            self.conn.rollback()
+            self.conn.execute(f'DROP SCHEMA "{self.schema}" CASCADE')
+            self.conn.commit()
+        finally:
+            self.conn.close()
+
+    def _create_base_workspace_tables(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE ws_repositories (
+                id TEXT PRIMARY KEY
+            );
+            CREATE TABLE ws_folders (
+                id TEXT PRIMARY KEY
+            );
+            CREATE TABLE ws_projects (
+                id TEXT PRIMARY KEY,
+                repo_id TEXT NOT NULL REFERENCES ws_repositories(id)
+            );
+            CREATE TABLE ws_project_portfolio (
+                project_id TEXT PRIMARY KEY REFERENCES ws_projects(id)
+            );
+            CREATE TABLE ws_jobs (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                status TEXT NOT NULL,
+                message TEXT NOT NULL DEFAULT '',
+                percent REAL NOT NULL DEFAULT 0,
+                payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            """,
+            prepare=False,
+        )
+
+    def _assert_rejected(self, sql: str, params: tuple = ()) -> None:
+        savepoint = f"release_probe_{uuid.uuid4().hex}"
+        self.conn.execute(f'SAVEPOINT "{savepoint}"')
+        try:
+            self.conn.execute(sql, params)
+        except Exception:
+            self.conn.execute(f'ROLLBACK TO SAVEPOINT "{savepoint}"')
+            self.conn.execute(f'RELEASE SAVEPOINT "{savepoint}"')
+            return
+        self.conn.execute(f'ROLLBACK TO SAVEPOINT "{savepoint}"')
+        self.conn.execute(f'RELEASE SAVEPOINT "{savepoint}"')
+        self.fail(f"SQL unexpectedly succeeded: {sql}")
+
+    def _constraint_keys(self) -> list[tuple[str, str, tuple[str, ...]]]:
+        rows = self.conn.execute(
+            """
+            SELECT child.relname AS table_name,
+                   c.contype,
+                   array_agg(attribute.attname ORDER BY key_columns.ordinality)
+                       AS columns
+            FROM pg_constraint AS c
+            JOIN pg_class AS child ON child.oid = c.conrelid
+            JOIN pg_namespace AS namespace ON namespace.oid = child.relnamespace
+            CROSS JOIN LATERAL unnest(c.conkey) WITH ORDINALITY
+                AS key_columns(attnum, ordinality)
+            JOIN pg_attribute AS attribute
+              ON attribute.attrelid = child.oid
+             AND attribute.attnum = key_columns.attnum
+            WHERE namespace.nspname = %s
+              AND c.contype IN ('p', 'u')
+            GROUP BY child.relname, c.conname, c.contype
+            """,
+            (self.schema,),
+        ).fetchall()
+        return [
+            (str(row["table_name"]), str(row["contype"]), tuple(row["columns"]))
+            for row in rows
+        ]
+
+    def _foreign_keys(self) -> set[tuple[str, tuple[str, ...], str, tuple[str, ...], str]]:
+        rows = self.conn.execute(
+            """
+            SELECT child.relname AS child_table,
+                   parent.relname AS parent_table,
+                   array_agg(child_attribute.attname ORDER BY child_key.ordinality)
+                       AS child_columns,
+                   array_agg(parent_attribute.attname ORDER BY child_key.ordinality)
+                       AS parent_columns,
+                   c.confdeltype
+            FROM pg_constraint AS c
+            JOIN pg_class AS child ON child.oid = c.conrelid
+            JOIN pg_namespace AS child_namespace
+              ON child_namespace.oid = child.relnamespace
+            JOIN pg_class AS parent ON parent.oid = c.confrelid
+            CROSS JOIN LATERAL unnest(c.conkey) WITH ORDINALITY
+                AS child_key(attnum, ordinality)
+            JOIN pg_attribute AS child_attribute
+              ON child_attribute.attrelid = child.oid
+             AND child_attribute.attnum = child_key.attnum
+            JOIN LATERAL unnest(c.confkey) WITH ORDINALITY
+                AS parent_key(attnum, ordinality)
+              ON parent_key.ordinality = child_key.ordinality
+            JOIN pg_attribute AS parent_attribute
+              ON parent_attribute.attrelid = parent.oid
+             AND parent_attribute.attnum = parent_key.attnum
+            WHERE child_namespace.nspname = %s
+              AND c.contype = 'f'
+            GROUP BY child.relname, parent.relname, c.conname, c.confdeltype
+            """,
+            (self.schema,),
+        ).fetchall()
+        delete_actions = {
+            "a": "NO ACTION",
+            "r": "RESTRICT",
+            "c": "CASCADE",
+            "n": "SET NULL",
+            "d": "SET DEFAULT",
+        }
+        return {
+            (
+                str(row["child_table"]),
+                tuple(row["child_columns"]),
+                str(row["parent_table"]),
+                tuple(row["parent_columns"]),
+                delete_actions[str(row["confdeltype"])],
+            )
+            for row in rows
+        }
+
+    def test_catalog_contains_every_release_table_and_column(self) -> None:
+        rows = self.conn.execute(
+            """
+            SELECT table_name, column_name, data_type, udt_name, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = %s
+              AND table_name = ANY(%s)
+            """,
+            (self.schema, list(EXPECTED_COLUMNS)),
+        ).fetchall()
+        columns: dict[str, set[str]] = {}
+        types: dict[tuple[str, str], tuple[str, str]] = {}
+        nullability: dict[tuple[str, str], str] = {}
+        for row in rows:
+            table = str(row["table_name"])
+            column = str(row["column_name"])
+            columns.setdefault(table, set()).add(column)
+            types[(table, column)] = (str(row["data_type"]), str(row["udt_name"]))
+            nullability[(table, column)] = str(row["is_nullable"])
+
+        self.assertEqual(set(columns), set(EXPECTED_COLUMNS))
+        for table, expected in EXPECTED_COLUMNS.items():
+            self.assertTrue(expected <= columns[table], table)
+        self.assertEqual(columns["ws_release_policies"], EXPECTED_COLUMNS["ws_release_policies"])
+        self.assertNotIn("project_id", columns["ws_release_policies"])
+        self.assertNotIn("config_key", columns["ws_release_policies"])
+        self.assertEqual(
+            nullability[("ws_release_members", "source_raw_digest")],
+            "NO",
+        )
+
+        self.assertEqual(types[("ws_release_candidates", "hermetic")], ("boolean", "bool"))
+        self.assertEqual(
+            types[("ws_release_candidates", "non_hermetic_reasons")],
+            ("jsonb", "jsonb"),
+        )
+        self.assertEqual(types[("ws_release_builds", "fence")], ("bigint", "int8"))
+        self.assertEqual(types[("ws_release_approvals", "domains")], ("ARRAY", "_text"))
+        self.assertEqual(
+            types[("ws_release_audit_events", "created_at_iso")],
+            ("text", "text"),
+        )
+
+    def test_catalog_contains_required_primary_and_unique_constraints(self) -> None:
+        constraints = self._constraint_keys()
+        for table, columns in EXPECTED_PRIMARY_KEYS.items():
+            self.assertIn((table, "p", columns), constraints)
+
+        uniques = {
+            (table, columns)
+            for table, contype, columns in constraints
+            if contype == "u"
+        }
+        self.assertTrue(EXPECTED_UNIQUES <= uniques)
+        self.assertNotIn(
+            ("ws_release_records", ("project_id", "config_key", "dossier_digest")),
+            uniques,
+        )
+
+    def test_catalog_contains_required_foreign_keys_and_delete_actions(self) -> None:
+        foreign_keys = self._foreign_keys()
+        self.assertTrue(EXPECTED_FKS <= foreign_keys)
+        self.assertNotIn(
+            (
+                "ws_release_member_domains",
+                ("build_id",),
+                "ws_release_builds",
+                ("id",),
+                "CASCADE",
+            ),
+            foreign_keys,
+        )
+        self.assertFalse(
+            any(child == "ws_release_policies" for child, *_ in foreign_keys),
+            "organization policies must not be project-scoped",
+        )
+
+        index = self.conn.execute(
+            """
+            SELECT index_class.relname AS index_name,
+                   pg_index.indisunique AS is_unique,
+                   pg_index.indpred IS NOT NULL AS is_partial,
+                   pg_get_indexdef(pg_index.indexrelid) AS definition
+            FROM pg_index
+            JOIN pg_class AS table_class ON table_class.oid = pg_index.indrelid
+            JOIN pg_class AS index_class ON index_class.oid = pg_index.indexrelid
+            JOIN pg_namespace AS namespace ON namespace.oid = table_class.relnamespace
+            WHERE namespace.nspname = %s
+              AND table_class.relname = 'ws_release_builds'
+              AND index_class.relname = 'idx_ws_release_builds_manifest_digest_nonempty'
+            """,
+            (self.schema,),
+        ).fetchone()
+        self.assertIsNotNone(index)
+        assert index is not None
+        self.assertFalse(index["is_unique"])
+        self.assertTrue(index["is_partial"])
+        self.assertIn("manifest_digest", str(index["definition"]))
+        self.assertIn("<> ''", str(index["definition"]))
+
+    def test_trigger_definitions_are_present_and_recreated_safely(self) -> None:
+        _release_studio(self.conn)
+        _release_studio(self.conn)
+        self.conn.commit()
+
+        rows = self.conn.execute(
+            """
+            SELECT trigger_name, pg_get_triggerdef(pg_trigger.oid) AS definition
+            FROM information_schema.triggers
+            JOIN pg_trigger
+              ON pg_trigger.tgname = information_schema.triggers.trigger_name
+            JOIN pg_class
+              ON pg_class.oid = pg_trigger.tgrelid
+            JOIN pg_namespace
+              ON pg_namespace.oid = pg_class.relnamespace
+            WHERE information_schema.triggers.trigger_schema = %s
+              AND pg_namespace.nspname = %s
+              AND NOT pg_trigger.tgisinternal
+            """,
+            (self.schema, self.schema),
+        ).fetchall()
+        definitions = {str(row["trigger_name"]): str(row["definition"]) for row in rows}
+
+        self.assertIn("trg_ws_release_waivers_no_delete", definitions)
+        self.assertIn("BEFORE DELETE", definitions["trg_ws_release_waivers_no_delete"])
+        self.assertNotIn("BEFORE UPDATE", definitions["trg_ws_release_waivers_no_delete"])
+        for trigger in (
+            "trg_ws_release_approvals_immutable",
+            "trg_ws_release_approval_invalidations_immutable",
+            "trg_ws_release_audit_events_immutable",
+        ):
+            self.assertIn(trigger, definitions)
+            self.assertIn("BEFORE DELETE OR UPDATE", definitions[trigger])
+        self.assertIn("trg_ws_release_policy_versions_guard", definitions)
+        self.assertIn("trg_ws_release_records_guard", definitions)
+
+    def _seed_release_graph(self) -> dict[str, str]:
+        suffix = uuid.uuid4().hex
+        ids = {
+            "project": f"project-{suffix}",
+            "repository": f"repository-{suffix}",
+            "job": f"job-{suffix}",
+            "candidate": f"candidate-{suffix}",
+            "build": f"build-{suffix}",
+            "evaluation": f"evaluation-{suffix}",
+            "waiver": f"waiver-{suffix}",
+            "approval": f"approval-{suffix}",
+            "invalidation": f"invalidation-{suffix}",
+            "audit": f"audit-{suffix}",
+            "artifact_dossier": f"artifact-dossier-{suffix}",
+            "artifact_evidence": f"artifact-evidence-{suffix}",
+            "artifact_attestation": f"artifact-attestation-{suffix}",
+            "key": f"key-{suffix}",
+        }
+        self.conn.execute("INSERT INTO ws_repositories(id) VALUES (%s)", (ids["repository"],))
+        self.conn.execute(
+            "INSERT INTO ws_projects(id, repo_id) VALUES (%s, %s)",
+            (ids["project"], ids["repository"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_jobs(id, kind, status)
+            VALUES (%s, 'release-build', 'queued')
+            """,
+            (ids["job"],),
+        )
+        for artifact_id, kind in (
+            (ids["artifact_dossier"], "release-dossier"),
+            (ids["artifact_evidence"], "release-evidence"),
+            (ids["artifact_attestation"], "release-attestation"),
+        ):
+            self.conn.execute(
+                """
+                INSERT INTO ws_artifacts(id, kind, artifact_key, digest, object_path)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (artifact_id, kind, artifact_id, f"digest-{artifact_id}", f"objects/{artifact_id}"),
+            )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_candidates(
+                id, project_id, repository_id, config_key, commit_sha, variant,
+                technical_config_digest, input_closure_digest, toolchain_digest,
+                generator_build, build_key, status
+            )
+            VALUES (%s, %s, %s, 'default', 'commit-1', 'standard',
+                    'technical-1', 'closure-1', 'toolchain-1', 'generator-1',
+                    %s, 'built')
+            """,
+            (ids["candidate"], ids["project"], ids["repository"], f"build-key-{suffix}"),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_builds(
+                id, candidate_id, job_id, status, manifest_digest, dossier_digest,
+                dossier_artifact_id, evidence_artifact_id
+            )
+            VALUES (%s, %s, %s, 'succeeded', 'manifest-1', 'dossier-1', %s, %s)
+            """,
+            (
+                ids["build"],
+                ids["candidate"],
+                ids["job"],
+                ids["artifact_dossier"],
+                ids["artifact_evidence"],
+            ),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_evaluations(
+                id, build_id, policy_binding, policy_binding_digest,
+                outcome, evaluator_build
+            )
+            VALUES (%s, %s, '{"policy":"v1"}', 'policy-binding-1', 'pass', 'evaluator-1')
+            """,
+            (ids["evaluation"], ids["build"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_waivers(
+                id, project_id, config_key, rule_id, domain, subject_pattern,
+                finding_key, reason, owner
+            )
+            VALUES (%s, %s, 'default', 'rule-1', 'bare_board', '*',
+                    'finding-1', 'temporary lab exception', 'owner@example.test')
+            """,
+            (ids["waiver"], ids["project"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_approvals(
+                id, project_id, config_key, candidate_id, build_id, role,
+                domains, decision, approver, policy_binding_digest, evaluation_id
+            )
+            VALUES (%s, %s, 'default', %s, %s, 'engineering',
+                    ARRAY['bare_board']::text[], 'approved', 'approver@example.test',
+                    'policy-binding-1', %s)
+            """,
+            (ids["approval"], ids["project"], ids["candidate"], ids["build"], ids["evaluation"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_approval_invalidations(
+                id, approval_id, reason, stale_component, changed_domains, created_by
+            )
+            VALUES (%s, %s, 'scope changed', 'technical',
+                    ARRAY['bare_board']::text[], 'system@example.test')
+            """,
+            (ids["invalidation"], ids["approval"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_audit_events(
+                id, project_id, config_key, sequence, event_type, actor,
+                subject_kind, subject_id, previous_hash, event_hash, created_at_iso
+            )
+            VALUES (%s, %s, 'default', 1, 'approval.created', 'system@example.test',
+                    'approval', %s, NULL, 'event-hash-1', '2026-01-01T00:00:00Z')
+            """,
+            (ids["audit"], ids["project"], ids["approval"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_signing_keys(
+                key_id, algorithm, public_key, valid_from, created_by
+            )
+            VALUES (%s, 'ed25519', 'public-key-material', NOW(), 'security@example.test')
+            """,
+            (ids["key"],),
+        )
+        return ids
+
+    def test_checks_and_mutation_boundaries_hold_in_real_postgres(self) -> None:
+        ids = self._seed_release_graph()
+
+        candidate_values = (
+            f"candidate-invalid-{uuid.uuid4().hex}",
+            ids["project"],
+            ids["repository"],
+            f"invalid-build-key-{uuid.uuid4().hex}",
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_candidates(
+                id, project_id, repository_id, config_key, commit_sha,
+                technical_config_digest, input_closure_digest, toolchain_digest,
+                generator_build, build_key, status
+            )
+            VALUES (%s, %s, %s, 'default', 'commit-invalid', 'technical',
+                    'closure', 'toolchain', 'generator', %s, 'released')
+            """,
+            candidate_values,
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_closure_inputs(id, candidate_id, kind, path)
+            VALUES (%s, %s, 'unknown', 'repo')
+            """,
+            (f"closure-invalid-{uuid.uuid4().hex}", ids["candidate"]),
+        )
+        member_id = f"member-{uuid.uuid4().hex}"
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_members(
+                id, build_id, path, member_kind, media_type, released_digest
+            )
+            VALUES (%s, %s, 'board.kicad_pcb', 'board', 'application/octet-stream', 'released')
+            """,
+            (f"member-no-raw-{uuid.uuid4().hex}", ids["build"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_members(
+                id, build_id, path, member_kind, media_type,
+                released_digest, source_raw_digest
+            )
+            VALUES (%s, %s, 'board.kicad_pcb', 'board', 'application/octet-stream',
+                    'released', 'raw')
+            """,
+            (member_id, ids["build"]),
+        )
+        other_build_id = f"build-other-{uuid.uuid4().hex}"
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_builds(id, candidate_id, status)
+            VALUES (%s, %s, 'queued')
+            """,
+            (other_build_id, ids["candidate"]),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_member_domains(member_id, build_id, domain)
+            VALUES (%s, %s, 'bare_board')
+            """,
+            (member_id, other_build_id),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_member_domains(member_id, build_id, domain)
+            VALUES (%s, %s, 'bare_board')
+            """,
+            (member_id, ids["build"]),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_builds(id, candidate_id, status)
+            VALUES (%s, %s, 'released')
+            """,
+            (f"build-invalid-{uuid.uuid4().hex}", ids["candidate"]),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_evaluations(
+                id, build_id, policy_binding_digest, outcome
+            )
+            VALUES (%s, %s, %s, 'released')
+            """,
+            (f"evaluation-invalid-{uuid.uuid4().hex}", ids["build"], f"digest-{uuid.uuid4().hex}"),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_approval_invalidations(
+                id, approval_id, reason, stale_component
+            )
+            VALUES (%s, %s, 'bad component', 'released')
+            """,
+            (f"invalidation-invalid-{uuid.uuid4().hex}", ids["approval"]),
+        )
+
+        # Waivers are lifecycle records: updates remain available to R15, but
+        # deleting history is a database error.
+        self.conn.execute(
+            """
+            UPDATE ws_release_waivers
+            SET status = 'approved', approver = 'approver@example.test', approved_at = NOW()
+            WHERE id = %s
+            """,
+            (ids["waiver"],),
+        )
+        waiver = self.conn.execute(
+            "SELECT status FROM ws_release_waivers WHERE id = %s",
+            (ids["waiver"],),
+        ).fetchone()
+        self.assertEqual(waiver["status"], "approved")
+        self._assert_rejected(
+            "DELETE FROM ws_release_waivers WHERE id = %s",
+            (ids["waiver"],),
+        )
+
+        self._assert_rejected(
+            "UPDATE ws_release_approvals SET note = 'changed' WHERE id = %s",
+            (ids["approval"],),
+        )
+        self._assert_rejected(
+            "DELETE FROM ws_release_approvals WHERE id = %s",
+            (ids["approval"],),
+        )
+        self._assert_rejected(
+            "UPDATE ws_release_approval_invalidations SET reason = 'changed' WHERE id = %s",
+            (ids["invalidation"],),
+        )
+        self._assert_rejected(
+            "DELETE FROM ws_release_approval_invalidations WHERE id = %s",
+            (ids["invalidation"],),
+        )
+        self._assert_rejected(
+            "UPDATE ws_release_audit_events SET event_type = 'changed' WHERE id = %s",
+            (ids["audit"],),
+        )
+        self._assert_rejected(
+            "DELETE FROM ws_release_audit_events WHERE id = %s",
+            (ids["audit"],),
+        )
+
+    def test_published_policy_content_is_frozen_but_retirement_is_legal(self) -> None:
+        ids = self._seed_release_graph()
+        policy_id = f"policy-{uuid.uuid4().hex}"
+        version_id = f"policy-version-{uuid.uuid4().hex}"
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_policies(id, policy_key, title)
+            VALUES (%s, 'quality', 'Quality policy')
+            """,
+            (policy_id,),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_policy_versions(
+                id, policy_id, version, rules, content_digest, created_by
+            )
+            VALUES (%s, %s, 1, '{"rules":["drc"]}', 'content-1', 'policy@example.test')
+            """,
+            (version_id, policy_id),
+        )
+        self.conn.execute(
+            """
+            UPDATE ws_release_policy_versions
+            SET status = 'published'
+            WHERE id = %s
+            """,
+            (version_id,),
+        )
+        self._assert_rejected(
+            "UPDATE ws_release_policy_versions SET rules = '{\"rules\":[\"erc\"]}' WHERE id = %s",
+            (version_id,),
+        )
+        self._assert_rejected(
+            "UPDATE ws_release_policy_versions SET content_digest = 'content-2' WHERE id = %s",
+            (version_id,),
+        )
+        self._assert_rejected(
+            "UPDATE ws_release_policy_versions SET status = 'retired' WHERE id = %s",
+            (version_id,),
+        )
+        self.conn.execute(
+            """
+            UPDATE ws_release_policy_versions
+            SET status = 'retired', retired_at = NOW(), retired_by = 'policy@example.test'
+            WHERE id = %s
+            """,
+            (version_id,),
+        )
+        row = self.conn.execute(
+            "SELECT status, retired_by FROM ws_release_policy_versions WHERE id = %s",
+            (version_id,),
+        ).fetchone()
+        self.assertEqual((row["status"], row["retired_by"]), ("retired", "policy@example.test"))
+
+    def test_release_record_allows_only_superseded_by_update_and_duplicate_dossier(self) -> None:
+        ids = self._seed_release_graph()
+        first_id = f"release-first-{uuid.uuid4().hex}"
+        second_id = f"release-second-{uuid.uuid4().hex}"
+        insert = """
+            INSERT INTO ws_release_records(
+                id, project_id, config_key, candidate_id, build_id, release_label,
+                dossier_digest, manifest_digest, attestation_digest, signing_key_id,
+                attestation_artifact_id, commit_sha, released_by
+            )
+            VALUES (%s, %s, 'default', %s, %s, %s, 'same-dossier',
+                    'manifest-1', 'attestation-1', %s, %s, 'commit-1', 'release@example.test')
+        """
+        record_params = (
+            ids["project"],
+            ids["candidate"],
+            ids["build"],
+            ids["key"],
+            ids["artifact_attestation"],
+        )
+        self.conn.execute(insert, (first_id, record_params[0], record_params[1], record_params[2], "v1", record_params[3], record_params[4]))
+        # The dossier digest is intentionally duplicated; only the release label
+        # is unique for a project/configuration.
+        self.conn.execute(insert, (second_id, record_params[0], record_params[1], record_params[2], "v2", record_params[3], record_params[4]))
+        self.conn.execute(
+            "UPDATE ws_release_records SET superseded_by = %s WHERE id = %s",
+            (second_id, first_id),
+        )
+        row = self.conn.execute(
+            "SELECT superseded_by FROM ws_release_records WHERE id = %s",
+            (first_id,),
+        ).fetchone()
+        self.assertEqual(row["superseded_by"], second_id)
+        self._assert_rejected(
+            "UPDATE ws_release_records SET release_label = 'v1-changed' WHERE id = %s",
+            (first_id,),
+        )
+        self._assert_rejected(
+            "DELETE FROM ws_release_records WHERE id = %s",
+            (first_id,),
+        )
+
+
+class ReleaseStudioMigrationLadderTests(unittest.TestCase):
+    def test_migration_8_is_named_and_follows_migrations_1_to_7(self) -> None:
+        self.assertEqual(
+            [(version, name) for version, name, _ in MIGRATIONS],
+            [
+                (1, "v3_job_foundation"),
+                (2, "workspace_read_versions"),
+                (3, "git_read_cache"),
+                (4, "webgpu_ready_metadata"),
+                (5, "thumbnail_metadata"),
+                (6, "thumbnail_source"),
+                (7, "generated_thumbnail_default"),
+                (8, "release_studio"),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/release-studio/R3.md
+++ b/docs/release-studio/R3.md
@@ -1,0 +1,129 @@
+# Release Studio R3: workspace schema Migration 8
+
+R3 adds the Release Studio technical and governance records to the existing
+workspace schema. It is schema-only: UUID generation, policy evaluation,
+retention, signing, APIs, and lifecycle business rules remain service-layer
+work for later chunks.
+
+## Table inventory
+
+All identifiers are `TEXT`; the service layer supplies UUID values. Timestamp
+columns are `TIMESTAMPTZ`, normally with `DEFAULT NOW()`. JSON fields use
+`JSONB` with an empty object or array default where an empty value is a useful
+database-safe state. Optional artifact IDs, job IDs, waiver lifecycle times,
+and other values that do not exist at row creation remain nullable rather than
+being fabricated by the migration.
+
+### Technical records
+
+| Table | Purpose and important columns |
+| --- | --- |
+| `ws_release_configurations` | Project/configuration identity, title, board/schematic/jobset paths, default variant, creator, and timestamps. Unique on `(project_id, config_key)`. |
+| `ws_release_candidates` | Immutable-input candidate identity: project/repository, config, commit, variant, technical/input/toolchain digests, generator build, build key, status, hermeticity, non-hermetic reasons, authored overrides, creator, and timestamps. Status is `draft`, `building`, `built`, `failed`, `superseded`, or `frozen`; there is no `released` status. Unique on `(project_id, config_key, build_key)`. |
+| `ws_release_closure_inputs` | Candidate closure members with kind, path, Git/object/LFS/materialized digests, mode/object type, and details. Kind is `repository`, `submodule`, `lfs`, `toolchain`, or `env`; unique on `(candidate_id, kind, path)`. |
+| `ws_release_builds` | Build attempt/job fence and status, manifest/dossier digests, dossier/evidence artifact references, toolchain/timing/warning JSON, errors, lifecycle timestamps, and creation time. Status is `queued`, `running`, `succeeded`, `failed`, or `cancelled`. |
+| `ws_release_members` | Released dossier member path, kind, media type, size, released digest, required `source_raw_digest`, canonicalizer, and creation time. Unique on `(build_id, path)` and `(id, build_id)`. |
+| `ws_release_member_domains` | Domain projection for a member. Primary key is `(member_id, domain)`; `domain` is `bare_board`, `assembly`, `documentation`, or `evidence`. The composite FK `(member_id, build_id)` prevents a member from build A being labeled as belonging to build B. |
+| `ws_release_evidence` | DRC/ERC report digest, counts, build, and creation time. Kind is `drc` or `erc`. |
+| `ws_release_scope_fingerprints` | Build/domain scope fingerprint and inputs, with fidelity `artifact`, `board`, or `semantic`. Primary key is `(build_id, domain)`; there is no policy input in this technical fingerprint table. |
+
+### Governance records
+
+| Table | Purpose and important columns |
+| --- | --- |
+| `ws_release_policies` | Organization-level policy identity: globally unique `policy_key`, id, title, creator, and creation/update metadata. It has no `project_id` or `config_key`; project overlays remain outside this stored organization identity. |
+| `ws_release_policy_versions` | Policy version relation, positive version number, status, rules, content digest, retirement actor/time, creator, and creation time. Unique on `(policy_id, version)`; status is `draft`, `published`, or `retired`. |
+| `ws_release_evaluations` | Build evaluation with policy binding JSON, binding digest, rev-4 outcome (`pass`, `warn`, `block`, `waived`, `unsupported`, or `error`), counts, evaluator build, and creation time. Unique on `(build_id, policy_binding_digest, evaluator_build)`. |
+| `ws_release_waivers` | Project/config rule waiver identity, domain, subject/finding key, reason, owner/approver, lifecycle status (`proposed`, `approved`, `rejected`, `revoked`, or `expired`), evidence, lifecycle timestamps/reason, and creation time. Updates are allowed for future lifecycle logic; deletes are rejected. |
+| `ws_release_findings` | Evaluation finding rule/version, severity/status/domain, subject/message, observed/expected JSON, finding key, optional waiver, and creation time. |
+| `ws_release_approvals` | Project/config candidate/build approval, role/domains/decision, approver/note, self-approval override reason, technical scope fingerprints, policy binding digest, diagnostic manifest digest, carried-from approval, re-auth context, optional evaluation, and creation time. Rows are immutable. |
+| `ws_release_approval_invalidations` | Append-only invalidation row with approval, reason, stale component (`technical`, `policy`, or `both`), changed domains, creator, and creation time. |
+| `ws_release_signing_keys` | Public signing material only: key id, algorithm, public key, status (`active`, `superseded`, or `revoked`), validity interval, creator, and creation time. |
+| `ws_release_records` | Release label/document identity, candidate/build, dossier/manifest/attestation digests, signature and signing key, attestation artifact, commit/variant/releaser, policy/approval snapshots, optional `superseded_by`, and creation time. Unique only on `(project_id, config_key, release_label)`. There is deliberately no uniqueness constraint on `(project_id, config_key, dossier_digest)`. |
+| `ws_release_audit_events` | Hash-chain event identity, project/config sequence, event/actor/subject details, JSON details, previous/event hashes, ISO timestamp text, and timestamp. Unique on `(project_id, config_key, sequence)` and immutable. |
+| `ws_artifact_release_pins` | One release pin per artifact, with pin kind/reference and creation time. `artifact_id` is both the primary key and a cascading FK to `ws_artifacts`. |
+
+## Invariants and triggers
+
+- Candidate status is a closed CHECK set and intentionally excludes `released`.
+- Closure-input kinds, build statuses, evidence kinds, evaluator outcomes,
+  waiver statuses, release domains, scope fidelity, stale components, signing
+  key statuses, and policy-version statuses are all database CHECK constraints.
+- Published policy versions freeze `rules` and `content_digest`. A published
+  row can only make the coherent transition to `retired` while setting a
+  non-empty `retired_by` and `retired_at`. Published/retired rows cannot be
+  deleted; retired rows cannot be changed.
+- Waiver UPDATE is intentionally available for lifecycle transitions. The
+  `BEFORE DELETE` guard rejects deletion so R15 can audit status changes without
+  rewriting the schema.
+- Approval, approval-invalidation, and audit-event rows have deterministic
+  `BEFORE UPDATE OR DELETE` guards. New invalidation rows represent stale
+  approvals; an approval row itself is never mutated.
+- Release records reject DELETE and reject every UPDATE that changes anything
+  other than `superseded_by`. The self-reference is also prevented by a CHECK.
+- Trigger functions are created with `CREATE OR REPLACE FUNCTION`; triggers
+  are dropped and recreated by deterministic names on each direct migration
+  replay. This makes a resumed/partial DDL attempt safe to rerun.
+- `policy_binding_digest` remains in evaluation/approval governance records;
+  it is not added to technical scope fingerprints or manifest structures.
+
+## Foreign-key policy
+
+Technical artifacts follow their owning build/candidate with `CASCADE`:
+closure inputs, builds, members, member domains, evidence, scope fingerprints,
+and evaluations. A build's `job_id` uses `SET NULL` because the job may be
+retained or removed independently. Dossier/evidence/attestation artifacts use
+`RESTRICT` so release evidence cannot lose its referenced artifact.
+
+Project/configuration/candidate/repository ownership references use explicit
+actions. Governance history is protected: release records and audit events use
+`RESTRICT`, approval and invalidation history cannot be removed through a
+parent cascade, and signing keys use `RESTRICT` so an old release remains
+verifiable. The record `signing_key_id` explicitly references
+`ws_release_signing_keys(key_id)`. The artifact pin uses the required
+`CASCADE` action. The member-domain composite FK is the sole member/build
+relationship for that table and uses `CASCADE`.
+
+## Idempotency and migration boundary
+
+Migration 8 is appended as `(8, "release_studio", _release_studio)` after the
+unchanged migrations 1–7. It uses `CREATE TABLE IF NOT EXISTS`, explicit
+`CREATE INDEX IF NOT EXISTS`, replaceable functions, and safe trigger
+recreation. The workspace migration ledger prevents normal startup from
+replaying an already recorded version; direct replay is also covered by the
+focused PostgreSQL test.
+
+The migration expects the existing workspace service to have created the base
+`ws_projects`, `ws_repositories`, `ws_jobs`, and `ws_artifacts` tables, as do
+migrations 1–7. No ORM, release API, retention rule, cryptographic operation,
+policy DSL, or R10 member service is introduced here.
+
+## Validation
+
+The focused test uses a disposable PostgreSQL schema and must not point at the
+application database:
+
+```sh
+TEST_POSTGRES_URL=postgresql://.../release_r3_test \
+PRISM_DATABASE_URL= \
+python -m unittest tests.test_release_studio_schema_migration -v
+```
+
+It inspects `information_schema` and `pg_catalog`, applies the workspace
+ladder through Migration 8 twice, directly replays Migration 8, checks every
+table/column/PK/unique/FK/action/index/trigger, and probes the CHECK and
+mutation boundaries. The isolated run completed with:
+
+```text
+Ran 8 tests in 1.874s
+OK
+```
+
+Static checks:
+
+```sh
+git diff --check
+python -m compileall -q \
+  backend/app/services/workspace_schema_migrations.py \
+  backend/tests/test_release_studio_schema_migration.py
+```


### PR DESCRIPTION
## Summary

- Add workspace schema Migration 8 for Release Studio technical and governance records.
- Add catalog/information_schema and real-PostgreSQL mutation coverage.
- Document the table inventory, FK policy, invariants, trigger boundaries, and idempotency.

Key boundaries include global organization policy identity, published-policy freeze with legal published-to-retired transition, immutable approvals/audit/invalidation history, lifecycle-updatable but non-deletable waivers, same-build member domains with required raw provenance, and superseded_by-only release-record updates. There is intentionally no unique constraint on `(project_id, config_key, dossier_digest)`.

## Validation

- `git diff --check`: passed.
- Python compileall for the migration and focused test: passed.
- Host focused/migration unit coverage: 16 tests passed; 7 expected PostgreSQL skips.
- Focused isolated real-PostgreSQL suite: 8 tests passed.
- Existing component-catalog PostgreSQL integration: 8 tests passed.
- Accepted commit: `c8b2d61500ebb3dabb36e5d3f39f6ba395572fea`.

Draft for review; no merge performed.
