### PR TITLE
feat(release-studio): R3a Migration 9 schema hardening

### DIFF
--- a/backend/app/services/workspace_schema_migrations.py
+++ b/backend/app/services/workspace_schema_migrations.py
@@ -1012,6 +1012,401 @@ def _release_studio(conn: Any) -> None:
     )
 
 
+def _release_studio_hardening(conn: Any) -> None:
+    """Harden the Release Studio schema introduced by Migration 8.
+
+    Migration 8 remains the historical schema definition.  This migration
+    repairs its already-applied data and constraints in place before later
+    Release Studio writers depend on the stricter contracts.
+    """
+
+    # Drop the Migration 8 outcome CHECK before rewriting legacy values; the
+    # old vocabulary rejects the canonical replacements.
+    conn.execute(
+        "ALTER TABLE ws_release_evaluations "
+        "DROP CONSTRAINT IF EXISTS ws_release_evaluations_outcome_check"
+    )
+    conn.execute(
+        "ALTER TABLE ws_release_evaluations "
+        "DROP CONSTRAINT IF EXISTS ck_ws_release_evaluations_outcome_vocabulary"
+    )
+
+    # Normalize the development vocabulary before installing the new CHECK.
+    conn.execute(
+        """
+        UPDATE ws_release_evaluations
+        SET outcome = CASE outcome
+            WHEN 'warn' THEN 'warning'
+            WHEN 'block' THEN 'blocker'
+            WHEN 'error' THEN 'failure'
+            ELSE outcome
+        END
+        WHERE outcome IN ('warn', 'block', 'error')
+        """
+    )
+
+    # Empty JSON objects were the Migration 8 defaults.  Only exact empty
+    # objects are list-shape mistakes; preserve every non-empty value.
+    # Disable the M8 immutability guard while backfilling published rows;
+    # the replacement guard is installed later in this migration.
+    conn.execute(
+        "ALTER TABLE ws_release_policy_versions "
+        "DISABLE TRIGGER trg_ws_release_policy_versions_guard"
+    )
+    try:
+        conn.execute(
+            """
+            UPDATE ws_release_policy_versions
+            SET rules = '[]'::jsonb
+            WHERE rules = '{}'::jsonb
+            """
+        )
+        conn.execute(
+            """
+            ALTER TABLE ws_release_policy_versions
+                ALTER COLUMN rules SET DEFAULT '[]'::jsonb
+            """
+        )
+        conn.execute(
+            """
+            ALTER TABLE ws_release_policy_versions
+                ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ,
+                ADD COLUMN IF NOT EXISTS published_by TEXT
+            """
+        )
+        # Existing published/retired development rows did not record
+        # publication provenance. Prefer the row's original timestamp and
+        # creator; the documented fallback is stable when the creator was blank.
+        conn.execute(
+            """
+            UPDATE ws_release_policy_versions
+            SET published_at = COALESCE(published_at, created_at, NOW()),
+                published_by = COALESCE(
+                    NULLIF(btrim(published_by), ''),
+                    NULLIF(btrim(created_by), ''),
+                    'release-studio-migration-9'
+                )
+            WHERE status IN ('published', 'retired')
+            """
+        )
+        conn.execute(
+            """
+            UPDATE ws_release_policy_versions
+            SET published_at = NULL,
+                published_by = NULL
+            WHERE status = 'draft'
+              AND (published_at IS NOT NULL OR published_by IS NOT NULL)
+            """
+        )
+    finally:
+        conn.execute(
+            "ALTER TABLE ws_release_policy_versions "
+            "ENABLE TRIGGER trg_ws_release_policy_versions_guard"
+        )
+
+    conn.execute(
+        """
+        UPDATE ws_release_waivers
+        SET evidence = '[]'::jsonb
+        WHERE evidence = '{}'::jsonb
+        """
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_waivers
+            ALTER COLUMN evidence SET DEFAULT '[]'::jsonb
+        """
+    )
+
+    conn.execute(
+        """
+        ALTER TABLE ws_release_evaluations
+            ADD CONSTRAINT ck_ws_release_evaluations_outcome_vocabulary
+            CHECK (outcome IN (
+                'pass', 'warning', 'failure', 'blocker', 'unsupported', 'waived'
+            ))
+        """
+    )
+
+    for table, constraint in (
+        ("ws_release_findings", "ck_ws_release_findings_severity_vocabulary"),
+        ("ws_release_findings", "ck_ws_release_findings_status_vocabulary"),
+        ("ws_release_approvals", "ck_ws_release_approvals_decision_vocabulary"),
+    ):
+        conn.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint}")
+    conn.execute(
+        """
+        ALTER TABLE ws_release_findings
+            ADD CONSTRAINT ck_ws_release_findings_severity_vocabulary
+            CHECK (severity IN ('warning', 'failure', 'blocker'))
+        """
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_findings
+            ADD CONSTRAINT ck_ws_release_findings_status_vocabulary
+            CHECK (status IN ('open', 'waived'))
+        """
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_approvals
+            ADD CONSTRAINT ck_ws_release_approvals_decision_vocabulary
+            CHECK (decision IN ('approved', 'changes_requested', 'emergency_override'))
+        """
+    )
+    conn.execute(
+        "ALTER TABLE ws_release_policy_versions "
+        "DROP CONSTRAINT IF EXISTS ck_ws_release_policy_versions_publication_provenance"
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_policy_versions
+            ADD CONSTRAINT ck_ws_release_policy_versions_publication_provenance
+            CHECK (
+                (
+                    status = 'draft'
+                    AND published_at IS NULL
+                    AND published_by IS NULL
+                )
+                OR (
+                    status IN ('published', 'retired')
+                    AND published_at IS NOT NULL
+                    AND published_by IS NOT NULL
+                    AND btrim(published_by) <> ''
+                )
+            )
+        """
+    )
+    conn.execute(
+        "ALTER TABLE ws_release_records "
+        "DROP CONSTRAINT IF EXISTS ck_ws_release_records_signature_key_pair"
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_records
+            ADD CONSTRAINT ck_ws_release_records_signature_key_pair
+            CHECK (
+                (signature IS NULL AND signing_key_id IS NULL)
+                OR (signature IS NOT NULL AND signing_key_id IS NOT NULL)
+            )
+        """
+    )
+    for constraint in (
+        "ck_ws_release_audit_events_sequence_positive",
+        "ck_ws_release_audit_events_genesis_previous_hash",
+    ):
+        conn.execute(
+            "ALTER TABLE ws_release_audit_events "
+            f"DROP CONSTRAINT IF EXISTS {constraint}"
+        )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_audit_events
+            ADD CONSTRAINT ck_ws_release_audit_events_sequence_positive
+            CHECK (sequence > 0)
+        """
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_audit_events
+            ADD CONSTRAINT ck_ws_release_audit_events_genesis_previous_hash
+            CHECK (
+                (
+                    sequence = 1
+                    AND previous_hash IS NULL
+                )
+                OR (
+                    sequence > 1
+                    AND previous_hash IS NOT NULL
+                    AND btrim(previous_hash) <> ''
+                )
+            )
+        """
+    )
+
+    # Explicit names make the repaired delete policy stable and make it clear
+    # that immutable approval/waiver history must block parent deletion.
+    for table, old_constraint, new_constraint in (
+        (
+            "ws_release_approvals",
+            "ws_release_approvals_project_id_fkey",
+            "fk_ws_release_approvals_project_restrict",
+        ),
+        (
+            "ws_release_approvals",
+            "ws_release_approvals_candidate_id_fkey",
+            "fk_ws_release_approvals_candidate_restrict",
+        ),
+        (
+            "ws_release_approvals",
+            "ws_release_approvals_build_id_fkey",
+            "fk_ws_release_approvals_build_restrict",
+        ),
+        (
+            "ws_release_waivers",
+            "ws_release_waivers_project_id_fkey",
+            "fk_ws_release_waivers_project_restrict",
+        ),
+        (
+            "ws_release_findings",
+            "ws_release_findings_waiver_id_fkey",
+            "fk_ws_release_findings_waiver_restrict",
+        ),
+    ):
+        conn.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {old_constraint}")
+        conn.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {new_constraint}")
+
+    conn.execute(
+        """
+        ALTER TABLE ws_release_approvals
+            ADD CONSTRAINT fk_ws_release_approvals_project_restrict
+            FOREIGN KEY (project_id) REFERENCES ws_projects(id) ON DELETE RESTRICT,
+            ADD CONSTRAINT fk_ws_release_approvals_candidate_restrict
+            FOREIGN KEY (candidate_id) REFERENCES ws_release_candidates(id) ON DELETE RESTRICT,
+            ADD CONSTRAINT fk_ws_release_approvals_build_restrict
+            FOREIGN KEY (build_id) REFERENCES ws_release_builds(id) ON DELETE RESTRICT
+        """
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_waivers
+            ADD CONSTRAINT fk_ws_release_waivers_project_restrict
+            FOREIGN KEY (project_id) REFERENCES ws_projects(id) ON DELETE RESTRICT
+        """
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_findings
+            ADD CONSTRAINT fk_ws_release_findings_waiver_restrict
+            FOREIGN KEY (waiver_id) REFERENCES ws_release_waivers(id) ON DELETE RESTRICT
+        """
+    )
+
+    # A supersession target is part of the same project/configuration stream.
+    # The composite unique constraint is the minimal target key PostgreSQL
+    # requires for the structural foreign key.
+    conn.execute(
+        "ALTER TABLE ws_release_records "
+        "DROP CONSTRAINT IF EXISTS ws_release_records_superseded_by_fkey"
+    )
+    conn.execute(
+        "ALTER TABLE ws_release_records "
+        "DROP CONSTRAINT IF EXISTS fk_ws_release_records_superseded_by_same_config"
+    )
+    conn.execute(
+        "ALTER TABLE ws_release_records "
+        "DROP CONSTRAINT IF EXISTS uq_ws_release_records_project_config_id"
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_records
+            ADD CONSTRAINT uq_ws_release_records_project_config_id
+            UNIQUE (project_id, config_key, id)
+        """
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_records
+            ADD CONSTRAINT fk_ws_release_records_superseded_by_same_config
+            FOREIGN KEY (project_id, config_key, superseded_by)
+            REFERENCES ws_release_records(project_id, config_key, id)
+            ON DELETE RESTRICT
+        """
+    )
+
+    for index in (
+        "idx_ws_release_closure_inputs_candidate",
+        "idx_ws_release_members_build",
+        "idx_ws_release_scope_fingerprints_build",
+        "idx_ws_release_audit_events_project",
+    ):
+        conn.execute(f"DROP INDEX IF EXISTS {index}")
+
+    # Keep publication provenance immutable for every published/retired row;
+    # only the content-preserving published -> retired transition is allowed.
+    conn.execute(
+        """
+        CREATE OR REPLACE FUNCTION ws_release_policy_version_guard()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.status IN ('published', 'retired') THEN
+                    RAISE EXCEPTION
+                        'published or retired policy versions cannot be deleted'
+                        USING ERRCODE = '55000';
+                END IF;
+                RETURN OLD;
+            END IF;
+
+            IF OLD.status = 'published' THEN
+                IF NEW.status = 'retired'
+                   AND NEW.id = OLD.id
+                   AND NEW.policy_id = OLD.policy_id
+                   AND NEW.version = OLD.version
+                   AND NEW.rules IS NOT DISTINCT FROM OLD.rules
+                   AND NEW.content_digest = OLD.content_digest
+                   AND NEW.published_at = OLD.published_at
+                   AND NEW.published_by = OLD.published_by
+                   AND NEW.created_by = OLD.created_by
+                   AND NEW.created_at = OLD.created_at
+                   AND NEW.retired_at IS NOT NULL
+                   AND NEW.retired_by IS NOT NULL
+                   AND btrim(NEW.retired_by) <> ''
+                THEN
+                    RETURN NEW;
+                END IF;
+
+                IF NEW.id = OLD.id
+                   AND NEW.policy_id = OLD.policy_id
+                   AND NEW.version = OLD.version
+                   AND NEW.status = OLD.status
+                   AND NEW.rules IS NOT DISTINCT FROM OLD.rules
+                   AND NEW.content_digest = OLD.content_digest
+                   AND NEW.published_at = OLD.published_at
+                   AND NEW.published_by = OLD.published_by
+                   AND NEW.retired_at IS NOT DISTINCT FROM OLD.retired_at
+                   AND NEW.retired_by IS NOT DISTINCT FROM OLD.retired_by
+                   AND NEW.created_by = OLD.created_by
+                   AND NEW.created_at = OLD.created_at
+                THEN
+                    RETURN NEW;
+                END IF;
+
+                RAISE EXCEPTION
+                    'published policy version content and provenance are immutable; only published to retired is legal'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            IF OLD.status = 'retired' THEN
+                IF NEW.id = OLD.id
+                   AND NEW.policy_id = OLD.policy_id
+                   AND NEW.version = OLD.version
+                   AND NEW.status = OLD.status
+                   AND NEW.rules IS NOT DISTINCT FROM OLD.rules
+                   AND NEW.content_digest = OLD.content_digest
+                   AND NEW.published_at = OLD.published_at
+                   AND NEW.published_by = OLD.published_by
+                   AND NEW.retired_at = OLD.retired_at
+                   AND NEW.retired_by = OLD.retired_by
+                   AND NEW.created_by = OLD.created_by
+                   AND NEW.created_at = OLD.created_at
+                THEN
+                    RETURN NEW;
+                END IF;
+
+                RAISE EXCEPTION
+                    'retired policy versions are immutable'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+
+
 MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (1, "v3_job_foundation", _v3_job_foundation),
     (2, "workspace_read_versions", _workspace_read_versions),
@@ -1021,6 +1416,7 @@ MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (6, "thumbnail_source", _thumbnail_source),
     (7, "generated_thumbnail_default", _generated_thumbnail_default),
     (8, "release_studio", _release_studio),
+    (9, "release_studio_hardening", _release_studio_hardening),
 )
 
 

--- a/backend/tests/test_release_studio_schema_migration.py
+++ b/backend/tests/test_release_studio_schema_migration.py
@@ -22,6 +22,7 @@ except ImportError:  # pragma: no cover - dependency guard for host-only checks
 from app.services.workspace_schema_migrations import (  # noqa: E402
     MIGRATIONS,
     _release_studio,
+    _release_studio_hardening,
     apply_workspace_migrations,
 )
 
@@ -158,6 +159,8 @@ EXPECTED_COLUMNS: dict[str, set[str]] = {
         "content_digest",
         "retired_at",
         "retired_by",
+        "published_at",
+        "published_by",
         "created_by",
         "created_at",
     },
@@ -323,6 +326,7 @@ EXPECTED_UNIQUES = {
         ("build_id", "policy_binding_digest", "evaluator_build"),
     ),
     ("ws_release_records", ("project_id", "config_key", "release_label")),
+    ("ws_release_records", ("project_id", "config_key", "id")),
 }
 
 
@@ -377,7 +381,7 @@ EXPECTED_FKS = {
         "CASCADE",
     ),
     ("ws_release_evaluations", ("build_id",), "ws_release_builds", ("id",), "CASCADE"),
-    ("ws_release_waivers", ("project_id",), "ws_projects", ("id",), "CASCADE"),
+    ("ws_release_waivers", ("project_id",), "ws_projects", ("id",), "RESTRICT"),
     (
         "ws_release_findings",
         ("evaluation_id",),
@@ -390,17 +394,17 @@ EXPECTED_FKS = {
         ("waiver_id",),
         "ws_release_waivers",
         ("id",),
-        "SET NULL",
+        "RESTRICT",
     ),
-    ("ws_release_approvals", ("project_id",), "ws_projects", ("id",), "CASCADE"),
+    ("ws_release_approvals", ("project_id",), "ws_projects", ("id",), "RESTRICT"),
     (
         "ws_release_approvals",
         ("candidate_id",),
         "ws_release_candidates",
         ("id",),
-        "CASCADE",
+        "RESTRICT",
     ),
-    ("ws_release_approvals", ("build_id",), "ws_release_builds", ("id",), "CASCADE"),
+    ("ws_release_approvals", ("build_id",), "ws_release_builds", ("id",), "RESTRICT"),
     (
         "ws_release_approvals",
         ("carried_from_approval_id",),
@@ -447,9 +451,9 @@ EXPECTED_FKS = {
     ),
     (
         "ws_release_records",
-        ("superseded_by",),
+        ("project_id", "config_key", "superseded_by"),
         "ws_release_records",
-        ("id",),
+        ("project_id", "config_key", "id"),
         "RESTRICT",
     ),
     ("ws_release_audit_events", ("project_id",), "ws_projects", ("id",), "RESTRICT"),
@@ -476,7 +480,7 @@ EXPECTED_FKS = {
     "TEST_POSTGRES_URL must not target PRISM_DATABASE_URL",
 )
 class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
-    """Run Migration 8 against a disposable schema in the test database."""
+    """Run Migrations 8 and 9 against a disposable test schema."""
 
     def setUp(self) -> None:
         assert psycopg is not None
@@ -490,8 +494,8 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
         self.conn.commit()
 
         # The ledger makes the normal second application a no-op.  Calling the
-        # migration itself is covered separately to prove its DDL is also
-        # replaceable when a deployment resumes after a partial attempt.
+        # hardening migration itself is covered separately to prove its DDL is
+        # also replaceable when a deployment resumes after a partial attempt.
         apply_workspace_migrations(self.conn)
         self.conn.commit()
 
@@ -664,6 +668,46 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             types[("ws_release_audit_events", "created_at_iso")],
             ("text", "text"),
         )
+        self.assertEqual(
+            types[("ws_release_policy_versions", "published_at")],
+            ("timestamp with time zone", "timestamptz"),
+        )
+        self.assertEqual(
+            types[("ws_release_policy_versions", "published_by")],
+            ("text", "text"),
+        )
+        self.assertEqual(
+            nullability[("ws_release_policy_versions", "published_at")],
+            "YES",
+        )
+        self.assertEqual(
+            nullability[("ws_release_policy_versions", "published_by")],
+            "YES",
+        )
+
+        defaults = self.conn.execute(
+            """
+            SELECT table_class.relname AS table_name,
+                   attribute.attname AS column_name,
+                   pg_get_expr(defaults.adbin, defaults.adrelid) AS default_expr
+            FROM pg_attribute AS attribute
+            JOIN pg_class AS table_class ON table_class.oid = attribute.attrelid
+            JOIN pg_namespace AS namespace ON namespace.oid = table_class.relnamespace
+            JOIN pg_attrdef AS defaults
+              ON defaults.adrelid = attribute.attrelid
+             AND defaults.adnum = attribute.attnum
+            WHERE namespace.nspname = %s
+              AND table_class.relname IN ('ws_release_policy_versions', 'ws_release_waivers')
+              AND attribute.attname IN ('rules', 'evidence')
+            """,
+            (self.schema,),
+        ).fetchall()
+        default_by_column = {
+            (str(row["table_name"]), str(row["column_name"])): str(row["default_expr"])
+            for row in defaults
+        }
+        self.assertIn("'[]'::jsonb", default_by_column[("ws_release_policy_versions", "rules")])
+        self.assertIn("'[]'::jsonb", default_by_column[("ws_release_waivers", "evidence")])
 
     def test_catalog_contains_required_primary_and_unique_constraints(self) -> None:
         constraints = self._constraint_keys()
@@ -699,6 +743,86 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             "organization policies must not be project-scoped",
         )
 
+        constraint_rows = self.conn.execute(
+            """
+            SELECT c.conname,
+                   c.contype,
+                   pg_get_constraintdef(c.oid) AS definition
+            FROM pg_constraint AS c
+            JOIN pg_class AS table_class ON table_class.oid = c.conrelid
+            JOIN pg_namespace AS namespace ON namespace.oid = table_class.relnamespace
+            WHERE namespace.nspname = %s
+              AND table_class.relname = ANY(%s)
+            """,
+            (
+                self.schema,
+                [
+                    "ws_release_evaluations",
+                    "ws_release_findings",
+                    "ws_release_approvals",
+                    "ws_release_policy_versions",
+                    "ws_release_records",
+                    "ws_release_audit_events",
+                    "ws_release_waivers",
+                ],
+            ),
+        ).fetchall()
+        constraint_definitions = {
+            str(row["conname"]): str(row["definition"]) for row in constraint_rows
+        }
+        for constraint in (
+            "ck_ws_release_evaluations_outcome_vocabulary",
+            "ck_ws_release_findings_severity_vocabulary",
+            "ck_ws_release_findings_status_vocabulary",
+            "ck_ws_release_approvals_decision_vocabulary",
+            "ck_ws_release_policy_versions_publication_provenance",
+            "ck_ws_release_records_signature_key_pair",
+            "ck_ws_release_audit_events_sequence_positive",
+            "ck_ws_release_audit_events_genesis_previous_hash",
+            "fk_ws_release_approvals_project_restrict",
+            "fk_ws_release_approvals_candidate_restrict",
+            "fk_ws_release_approvals_build_restrict",
+            "fk_ws_release_waivers_project_restrict",
+            "fk_ws_release_findings_waiver_restrict",
+            "fk_ws_release_records_superseded_by_same_config",
+            "uq_ws_release_records_project_config_id",
+        ):
+            self.assertIn(constraint, constraint_definitions)
+        self.assertIn("sequence > 0", constraint_definitions["ck_ws_release_audit_events_sequence_positive"])
+        self.assertIn(
+            "previous_hash",
+            constraint_definitions["ck_ws_release_audit_events_genesis_previous_hash"],
+        )
+        self.assertNotIn("ws_release_evaluations_outcome_check", constraint_definitions)
+        self.assertNotIn("ws_release_records_superseded_by_fkey", constraint_definitions)
+
+        indexes = self.conn.execute(
+            """
+            SELECT index_class.relname AS index_name
+            FROM pg_index
+            JOIN pg_class AS table_class ON table_class.oid = pg_index.indrelid
+            JOIN pg_class AS index_class ON index_class.oid = pg_index.indexrelid
+            JOIN pg_namespace AS namespace ON namespace.oid = table_class.relnamespace
+            WHERE namespace.nspname = %s
+              AND index_class.relname = ANY(%s)
+            """,
+            (
+                self.schema,
+                [
+                    "idx_ws_release_closure_inputs_candidate",
+                    "idx_ws_release_members_build",
+                    "idx_ws_release_scope_fingerprints_build",
+                    "idx_ws_release_audit_events_project",
+                    "idx_ws_release_member_domains_build",
+                ],
+            ),
+        ).fetchall()
+        index_names = {str(row["index_name"]) for row in indexes}
+        self.assertEqual(
+            index_names,
+            {"idx_ws_release_member_domains_build"},
+        )
+
         index = self.conn.execute(
             """
             SELECT index_class.relname AS index_name,
@@ -723,8 +847,8 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
         self.assertIn("<> ''", str(index["definition"]))
 
     def test_trigger_definitions_are_present_and_recreated_safely(self) -> None:
-        _release_studio(self.conn)
-        _release_studio(self.conn)
+        _release_studio_hardening(self.conn)
+        _release_studio_hardening(self.conn)
         self.conn.commit()
 
         rows = self.conn.execute(
@@ -894,6 +1018,40 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
         )
         return ids
 
+    def _insert_release_record(
+        self,
+        ids: dict[str, str],
+        release_id: str,
+        release_label: str,
+        *,
+        config_key: str = "default",
+        signature: str | None = "signature-1",
+        signing_key_id: str | None = None,
+        use_default_signing_key: bool = True,
+    ) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_records(
+                id, project_id, config_key, candidate_id, build_id, release_label,
+                dossier_digest, manifest_digest, attestation_digest, signature,
+                signing_key_id, attestation_artifact_id, commit_sha, released_by
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 'same-dossier', 'manifest-1',
+                    'attestation-1', %s, %s, %s, 'commit-1', 'release@example.test')
+            """,
+            (
+                release_id,
+                ids["project"],
+                config_key,
+                ids["candidate"],
+                ids["build"],
+                release_label,
+                signature,
+                ids["key"] if use_default_signing_key else signing_key_id,
+                ids["artifact_attestation"],
+            ),
+        )
+
     def test_checks_and_mutation_boundaries_hold_in_real_postgres(self) -> None:
         ids = self._seed_release_graph()
 
@@ -1036,6 +1194,236 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             (ids["audit"],),
         )
 
+    def test_parent_deletions_are_blocked_by_restrict_history_fks(self) -> None:
+        ids = self._seed_release_graph()
+        for statement, value in (
+            ("DELETE FROM ws_projects WHERE id = %s", ids["project"]),
+            ("DELETE FROM ws_release_candidates WHERE id = %s", ids["candidate"]),
+            ("DELETE FROM ws_release_builds WHERE id = %s", ids["build"]),
+        ):
+            self._assert_rejected(statement, (value,))
+
+        finding_id = f"finding-waiver-{uuid.uuid4().hex}"
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_findings(
+                id, evaluation_id, rule_id, rule_version, severity, status,
+                domain, subject, message, finding_key, waiver_id
+            )
+            VALUES (%s, %s, 'rule-1', '1', 'warning', 'open', 'bare_board',
+                    'board', 'waived finding', %s, %s)
+            """,
+            (finding_id, ids["evaluation"], finding_id, ids["waiver"]),
+        )
+        self._assert_rejected(
+            "DELETE FROM ws_release_waivers WHERE id = %s",
+            (ids["waiver"],),
+        )
+
+    def test_stage_one_vocabularies_accept_canonical_values(self) -> None:
+        ids = self._seed_release_graph()
+        for index, outcome in enumerate(
+            ("warning", "failure", "blocker", "unsupported", "waived"),
+            start=1,
+        ):
+            evaluation_id = f"evaluation-vocabulary-{index}-{uuid.uuid4().hex}"
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_evaluations(
+                    id, build_id, policy_binding_digest, outcome, evaluator_build
+                )
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (
+                    evaluation_id,
+                    ids["build"],
+                    f"vocabulary-digest-{index}-{uuid.uuid4().hex}",
+                    outcome,
+                    f"vocabulary-evaluator-{index}",
+                ),
+            )
+
+        for outcome in ("warn", "block", "error"):
+            self._assert_rejected(
+                """
+                INSERT INTO ws_release_evaluations(
+                    id, build_id, policy_binding_digest, outcome, evaluator_build
+                )
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (
+                    f"evaluation-legacy-{outcome}-{uuid.uuid4().hex}",
+                    ids["build"],
+                    f"legacy-digest-{outcome}-{uuid.uuid4().hex}",
+                    outcome,
+                    f"legacy-evaluator-{outcome}",
+                ),
+            )
+
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_findings(
+                id, evaluation_id, rule_id, rule_version, severity, status,
+                domain, subject, message, finding_key
+            )
+            VALUES (%s, %s, 'rule-canonical', '1', 'blocker', 'waived',
+                    'evidence', 'report', 'canonical finding', %s)
+            """,
+            (
+                f"finding-canonical-{uuid.uuid4().hex}",
+                ids["evaluation"],
+                f"finding-key-{uuid.uuid4().hex}",
+            ),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_findings(
+                id, evaluation_id, rule_id, rule_version, severity, status,
+                domain, subject, message, finding_key
+            )
+            VALUES (%s, %s, 'rule-invalid', '1', 'warn', 'open',
+                    'evidence', 'report', 'invalid finding', %s)
+            """,
+            (
+                f"finding-invalid-severity-{uuid.uuid4().hex}",
+                f"finding-key-{uuid.uuid4().hex}",
+            ),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_findings(
+                id, evaluation_id, rule_id, rule_version, severity, status,
+                domain, subject, message, finding_key
+            )
+            VALUES (%s, %s, 'rule-invalid', '1', 'warning', 'active',
+                    'evidence', 'report', 'invalid finding', %s)
+            """,
+            (
+                f"finding-invalid-status-{uuid.uuid4().hex}",
+                f"finding-key-{uuid.uuid4().hex}",
+            ),
+        )
+
+        for index, decision in enumerate(("changes_requested", "emergency_override"), start=1):
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_approvals(
+                    id, project_id, config_key, candidate_id, build_id, role,
+                    decision, approver, policy_binding_digest
+                )
+                VALUES (%s, %s, 'default', %s, %s, 'engineering', %s,
+                        'approver@example.test', %s)
+                """,
+                (
+                    f"approval-vocabulary-{index}-{uuid.uuid4().hex}",
+                    ids["project"],
+                    ids["candidate"],
+                    ids["build"],
+                    decision,
+                    f"approval-digest-{index}-{uuid.uuid4().hex}",
+                ),
+            )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_approvals(
+                id, project_id, config_key, candidate_id, build_id, role,
+                decision, approver, policy_binding_digest
+            )
+            VALUES (%s, %s, 'default', %s, %s, 'engineering', 'pending',
+                    'approver@example.test', %s)
+            """,
+            (
+                f"approval-invalid-{uuid.uuid4().hex}",
+                ids["project"],
+                ids["candidate"],
+                ids["build"],
+                f"approval-invalid-digest-{uuid.uuid4().hex}",
+            ),
+        )
+
+    def test_release_signature_key_pair_and_audit_genesis_checks(self) -> None:
+        ids = self._seed_release_graph()
+        self._insert_release_record(
+            ids,
+            f"release-no-signature-{uuid.uuid4().hex}",
+            "unsigned",
+            signature=None,
+            use_default_signing_key=False,
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_records(
+                id, project_id, config_key, candidate_id, build_id, release_label,
+                dossier_digest, manifest_digest, attestation_digest, signature,
+                attestation_artifact_id, commit_sha, released_by
+            )
+            VALUES (%s, %s, 'default', %s, %s, 'signature-only', 'dossier',
+                    'manifest', 'attestation', 'signature', %s, 'commit', 'release')
+            """,
+            (
+                f"release-signature-only-{uuid.uuid4().hex}",
+                ids["project"],
+                ids["candidate"],
+                ids["build"],
+                ids["artifact_attestation"],
+            ),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_records(
+                id, project_id, config_key, candidate_id, build_id, release_label,
+                dossier_digest, manifest_digest, attestation_digest, signing_key_id,
+                attestation_artifact_id, commit_sha, released_by
+            )
+            VALUES (%s, %s, 'default', %s, %s, 'key-only', 'dossier',
+                    'manifest', 'attestation', %s, %s, 'commit', 'release')
+            """,
+            (
+                f"release-key-only-{uuid.uuid4().hex}",
+                ids["project"],
+                ids["candidate"],
+                ids["build"],
+                ids["key"],
+                ids["artifact_attestation"],
+            ),
+        )
+        self._insert_release_record(
+            ids,
+            f"release-signed-{uuid.uuid4().hex}",
+            "signed",
+        )
+
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_audit_events(
+                id, project_id, config_key, sequence, event_type, actor,
+                subject_kind, subject_id, previous_hash, event_hash, created_at_iso
+            )
+            VALUES (%s, %s, 'default', 2, 'release.created', 'system@example.test',
+                    'release', %s, 'event-hash-1', 'event-hash-2', '2026-01-01T00:00:01Z')
+            """,
+            (f"audit-second-{uuid.uuid4().hex}", ids["project"], ids["audit"]),
+        )
+        for sequence, previous_hash in ((0, None), (1, "not-genesis"), (2, None), (2, "")):
+            self._assert_rejected(
+                """
+                INSERT INTO ws_release_audit_events(
+                    id, project_id, config_key, sequence, event_type, actor,
+                    subject_kind, subject_id, previous_hash, event_hash, created_at_iso
+                )
+                VALUES (%s, %s, 'other', %s, 'invalid', 'system', 'release',
+                        %s, %s, %s, '2026-01-01T00:00:02Z')
+                """,
+                (
+                    f"audit-invalid-{sequence}-{uuid.uuid4().hex}",
+                    ids["project"],
+                    sequence,
+                    ids["audit"],
+                    previous_hash,
+                    f"invalid-hash-{uuid.uuid4().hex}",
+                ),
+            )
+
     def test_published_policy_content_is_frozen_but_retirement_is_legal(self) -> None:
         ids = self._seed_release_graph()
         policy_id = f"policy-{uuid.uuid4().hex}"
@@ -1056,10 +1444,16 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             """,
             (version_id, policy_id),
         )
+        self._assert_rejected(
+            "UPDATE ws_release_policy_versions SET status = 'published' WHERE id = %s",
+            (version_id,),
+        )
         self.conn.execute(
             """
             UPDATE ws_release_policy_versions
-            SET status = 'published'
+            SET status = 'published',
+                published_at = TIMESTAMPTZ '2026-01-02 00:00:00+00',
+                published_by = 'publisher@example.test'
             WHERE id = %s
             """,
             (version_id,),
@@ -1070,6 +1464,10 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
         )
         self._assert_rejected(
             "UPDATE ws_release_policy_versions SET content_digest = 'content-2' WHERE id = %s",
+            (version_id,),
+        )
+        self._assert_rejected(
+            "UPDATE ws_release_policy_versions SET published_by = 'other@example.test' WHERE id = %s",
             (version_id,),
         )
         self._assert_rejected(
@@ -1093,27 +1491,17 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
     def test_release_record_allows_only_superseded_by_update_and_duplicate_dossier(self) -> None:
         ids = self._seed_release_graph()
         first_id = f"release-first-{uuid.uuid4().hex}"
+        cross_config_id = f"release-cross-config-{uuid.uuid4().hex}"
         second_id = f"release-second-{uuid.uuid4().hex}"
-        insert = """
-            INSERT INTO ws_release_records(
-                id, project_id, config_key, candidate_id, build_id, release_label,
-                dossier_digest, manifest_digest, attestation_digest, signing_key_id,
-                attestation_artifact_id, commit_sha, released_by
-            )
-            VALUES (%s, %s, 'default', %s, %s, %s, 'same-dossier',
-                    'manifest-1', 'attestation-1', %s, %s, 'commit-1', 'release@example.test')
-        """
-        record_params = (
-            ids["project"],
-            ids["candidate"],
-            ids["build"],
-            ids["key"],
-            ids["artifact_attestation"],
-        )
-        self.conn.execute(insert, (first_id, record_params[0], record_params[1], record_params[2], "v1", record_params[3], record_params[4]))
+        self._insert_release_record(ids, first_id, "v1")
         # The dossier digest is intentionally duplicated; only the release label
         # is unique for a project/configuration.
-        self.conn.execute(insert, (second_id, record_params[0], record_params[1], record_params[2], "v2", record_params[3], record_params[4]))
+        self._insert_release_record(ids, cross_config_id, "v-cross", config_key="other")
+        self._assert_rejected(
+            "UPDATE ws_release_records SET superseded_by = %s WHERE id = %s",
+            (cross_config_id, first_id),
+        )
+        self._insert_release_record(ids, second_id, "v2")
         self.conn.execute(
             "UPDATE ws_release_records SET superseded_by = %s WHERE id = %s",
             (second_id, first_id),
@@ -1132,9 +1520,137 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             (first_id,),
         )
 
+    def test_v8_rows_upgrade_old_defaults_and_vocabulary(self) -> None:
+        legacy_schema = f"release_r3_v8_{uuid.uuid4().hex}"
+        self.conn.execute(f'CREATE SCHEMA "{legacy_schema}"')
+        try:
+            self.conn.execute(f'SET search_path TO "{legacy_schema}", public')
+            self._create_base_workspace_tables()
+            for version, _, migration in MIGRATIONS:
+                if version <= 8:
+                    migration(self.conn)
+
+            suffix = uuid.uuid4().hex
+            repository_id = f"legacy-repository-{suffix}"
+            project_id = f"legacy-project-{suffix}"
+            candidate_id = f"legacy-candidate-{suffix}"
+            build_id = f"legacy-build-{suffix}"
+            evaluation_id = f"legacy-evaluation-{suffix}"
+            waiver_id = f"legacy-waiver-{suffix}"
+            policy_id = f"legacy-policy-{suffix}"
+            published_version_id = f"legacy-published-version-{suffix}"
+            preserved_version_id = f"legacy-preserved-version-{suffix}"
+            created_at = "2026-01-03 00:00:00+00"
+
+            self.conn.execute(
+                "INSERT INTO ws_repositories(id) VALUES (%s)",
+                (repository_id,),
+            )
+            self.conn.execute(
+                "INSERT INTO ws_projects(id, repo_id) VALUES (%s, %s)",
+                (project_id, repository_id),
+            )
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_candidates(
+                    id, project_id, repository_id, config_key, commit_sha,
+                    technical_config_digest, input_closure_digest, toolchain_digest,
+                    generator_build, build_key, status
+                )
+                VALUES (%s, %s, %s, 'default', 'legacy-commit', 'technical',
+                        'closure', 'toolchain', 'generator', %s, 'built')
+                """,
+                (candidate_id, project_id, repository_id, f"legacy-build-key-{suffix}"),
+            )
+            self.conn.execute(
+                "INSERT INTO ws_release_builds(id, candidate_id, status) VALUES (%s, %s, 'succeeded')",
+                (build_id, candidate_id),
+            )
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_evaluations(
+                    id, build_id, policy_binding_digest, outcome
+                )
+                VALUES (%s, %s, 'legacy-policy-binding', 'warn')
+                """,
+                (evaluation_id, build_id),
+            )
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_waivers(
+                    id, project_id, config_key, rule_id, domain, subject_pattern,
+                    finding_key, reason, owner
+                )
+                VALUES (%s, %s, 'default', 'legacy-rule', 'bare_board', '*',
+                        'legacy-finding', 'legacy waiver', 'legacy-owner')
+                """,
+                (waiver_id, project_id),
+            )
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_policies(id, policy_key, title)
+                VALUES (%s, %s, 'Legacy policy')
+                """,
+                (policy_id, f"legacy-policy-key-{suffix}"),
+            )
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_policy_versions(
+                    id, policy_id, version, status, content_digest,
+                    created_by, created_at
+                )
+                VALUES (%s, %s, 1, 'published', 'legacy-content', '', %s)
+                """,
+                (published_version_id, policy_id, created_at),
+            )
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_policy_versions(
+                    id, policy_id, version, rules, content_digest, created_by
+                )
+                VALUES (%s, %s, 2, '{"keep":["object"]}', 'preserved-content', 'legacy-owner')
+                """,
+                (preserved_version_id, policy_id),
+            )
+
+            _release_studio_hardening(self.conn)
+            _release_studio_hardening(self.conn)
+
+            evaluation = self.conn.execute(
+                "SELECT outcome FROM ws_release_evaluations WHERE id = %s",
+                (evaluation_id,),
+            ).fetchone()
+            self.assertEqual(evaluation["outcome"], "warning")
+            waiver = self.conn.execute(
+                "SELECT evidence FROM ws_release_waivers WHERE id = %s",
+                (waiver_id,),
+            ).fetchone()
+            self.assertEqual(waiver["evidence"], [])
+            versions = self.conn.execute(
+                """
+                SELECT id, rules, published_at, published_by
+                FROM ws_release_policy_versions
+                WHERE id IN (%s, %s)
+                ORDER BY id
+                """,
+                (published_version_id, preserved_version_id),
+            ).fetchall()
+            by_id = {row["id"]: row for row in versions}
+            self.assertEqual(by_id[preserved_version_id]["rules"], {"keep": ["object"]})
+            self.assertEqual(by_id[published_version_id]["published_by"], "release-studio-migration-9")
+            self.assertEqual(
+                by_id[published_version_id]["published_at"].isoformat(),
+                "2026-01-03T00:00:00+00:00",
+            )
+        finally:
+            self.conn.rollback()
+            self.conn.execute(f'SET search_path TO "{self.schema}", public')
+            self.conn.execute(f'DROP SCHEMA IF EXISTS "{legacy_schema}" CASCADE')
+            self.conn.commit()
+
 
 class ReleaseStudioMigrationLadderTests(unittest.TestCase):
-    def test_migration_8_is_named_and_follows_migrations_1_to_7(self) -> None:
+    def test_migration_9_is_named_and_follows_migrations_1_to_8(self) -> None:
         self.assertEqual(
             [(version, name) for version, name, _ in MIGRATIONS],
             [
@@ -1146,6 +1662,7 @@ class ReleaseStudioMigrationLadderTests(unittest.TestCase):
                 (6, "thumbnail_source"),
                 (7, "generated_thumbnail_default"),
                 (8, "release_studio"),
+                (9, "release_studio_hardening"),
             ],
         )
 

--- a/docs/release-studio/R3.md
+++ b/docs/release-studio/R3.md
@@ -127,3 +127,7 @@ python -m compileall -q \
   backend/app/services/workspace_schema_migrations.py \
   backend/tests/test_release_studio_schema_migration.py
 ```
+
+Migration 9 hardening for already-upgraded R3 databases is documented in
+[`R3a.md`](R3a.md). It tightens the historical M8 contracts before production
+writers land; the M8 definitions above remain unchanged as historical state.

--- a/docs/release-studio/R3a.md
+++ b/docs/release-studio/R3a.md
@@ -1,0 +1,84 @@
+# Release Studio R3a: Migration 9 schema hardening
+
+R3a appends Migration 9, `release_studio_hardening`, to repair databases that
+already applied Migration 8. Migration 8 remains historical state; fresh
+databases still run M8 and then M9. The migration is safe to replay directly.
+
+## Stage 1 vocabulary
+
+The database now deliberately accepts only these evaluator and approval
+values:
+
+| Column | Vocabulary |
+| --- | --- |
+| `ws_release_evaluations.outcome` | `pass`, `warning`, `failure`, `blocker`, `unsupported`, `waived` |
+| `ws_release_findings.severity` | `warning`, `failure`, `blocker` |
+| `ws_release_findings.status` | `open`, `waived` |
+| `ws_release_approvals.decision` | `approved`, `changes_requested`, `emergency_override` |
+
+Migration 9 converts the old development-only evaluation values
+`warn` → `warning`, `block` → `blocker`, and `error` → `failure` before adding
+the canonical CHECK. The old aggregate vocabulary is not retained.
+
+## Data-shape and provenance contracts
+
+`rules` and `evidence` use `[]::jsonb` as their defaults. Existing exact empty
+objects are converted to empty arrays; non-empty JSON is preserved.
+
+Policy versions gain nullable `published_at` and `published_by`. Draft rows
+must leave both NULL. Published and retired rows must have a timestamp and a
+nonblank actor. Existing published/retired rows are backfilled from
+`created_at` and `created_by`; a blank creator uses the deterministic actor
+`release-studio-migration-9`. Once published, provenance and content are
+immutable. The only lifecycle transition is a content-preserving
+`published` → `retired` update with valid retirement metadata.
+
+Release signatures remain optional until the later signing migration, but
+`signature` and `signing_key_id` must be both NULL or both present.
+
+## History and relationship protections
+
+Approval project/candidate/build references, waiver project references, and
+finding waiver references are explicit `RESTRICT` foreign keys with stable
+names. This prevents a parent cascade from attempting to delete immutable
+history. Release supersession uses a composite foreign key over
+`(project_id, config_key, superseded_by)` to the target's
+`(project_id, config_key, id)`, preserving `RESTRICT` and the no-self check.
+
+Audit sequence numbers are positive and scoped by `(project_id, config_key)`.
+Sequence 1 is the genesis event and requires `previous_hash IS NULL`; later
+events require a nonblank previous hash. Canonical hashing represents that
+genesis value as JSON `null`, never as an empty string.
+
+The redundant leading-key indexes on closure inputs, members, scope
+fingerprints, and audit events are removed. The member-domain build index is
+retained because its leading key is not supplied by a standalone constraint.
+
+All existing immutability guarantees remain: approvals, approval invalidations,
+and audit events cannot be updated or deleted; waivers cannot be deleted but
+remain lifecycle-updateable; and release records may update only
+`superseded_by`.
+
+## Validation
+
+`backend/tests/test_release_studio_schema_migration.py` applies a disposable
+PostgreSQL schema through M9, replays M9 directly, inspects
+`information_schema`/`pg_catalog`, checks v8-shaped upgrade data, and probes
+the FK, CHECK, provenance, supersession, signature, audit, and trigger
+boundaries. It uses `TEST_POSTGRES_URL` only and skips when that isolated URL
+is not provided or aliases `PRISM_DATABASE_URL`.
+
+Migration ordering that the upgrade path depends on:
+
+1. Drop the Migration 8 evaluation outcome CHECK before rewriting
+   `warn|block|error` to the canonical vocabulary.
+2. Disable `trg_ws_release_policy_versions_guard` while normalizing `rules` and
+   backfilling `published_at`/`published_by` on published/retired rows, then
+   re-enable it before installing the replacement guard function.
+
+Isolated acceptance run:
+
+```text
+Ran 12 tests in 1.966s
+OK
+```


### PR DESCRIPTION
## Summary
- Append Migration 9 (`release_studio_hardening`) without rewriting Migration 8.
- Tighten history FKs to `RESTRICT`, freeze Stage 1 vocabularies, add publication provenance, signature/key pairing, audit genesis rules, composite same-config supersession, and drop four redundant indexes.
- Cover fresh M8→M9, old-v8-data upgrade, and direct M9 replay with 12 PostgreSQL tests against `kicad_prism_catalog_test`.

## Test plan
- [x] `TEST_POSTGRES_URL=postgresql://postgres:kicad-prism-local@postgres:5432/kicad_prism_catalog_test PRISM_DATABASE_URL= python -m unittest tests.test_release_studio_schema_migration -v` → `Ran 12 tests ... OK`
- [x] CI quality gate on `feature/release-studio`
- [x] Confirm Migration 8 DDL is unchanged and only Migration 9 mutates live contracts