### PR TITLE
fix(release-studio): R00a bake executor identity

### DIFF
--- a/.github/workflows/dev-quality-gate.yml
+++ b/.github/workflows/dev-quality-gate.yml
@@ -266,42 +266,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
 
-    env:
-      PRISM_RELEASE_EXECUTOR_IMAGE: kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c
-
     steps:
       - name: Check out source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Build backend image from pinned KiCad runtime
+      - name: Build backend image from Dockerfile KiCad default
         run: >-
-          docker build --pull
+          docker build
           --platform linux/amd64
-          --build-arg "KICAD_BASE_IMAGE=$PRISM_RELEASE_EXECUTOR_IMAGE"
           --build-arg KICAD_BASE_PLATFORM=linux/amd64
           --tag release-studio-live-kicad:ci
           --file backend/Dockerfile
           .
 
-      - name: Run Release Studio live KiCad test
+      - name: Run Release Studio live KiCad tests
         run: |
           set -euo pipefail
+          BAKED_IMAGE="$(docker run --rm --entrypoint /bin/cat release-studio-live-kicad:ci /etc/prism/kicad-base-image | tr -d '\r\n')"
+          if [[ ! "$BAKED_IMAGE" =~ @sha256:[0-9a-f]{64}$ ]]; then
+            echo "baked KiCad base image must end with @sha256:<64 lowercase hex>; got: ${BAKED_IMAGE}" >&2
+            exit 1
+          fi
+          export PRISM_RELEASE_EXECUTOR_IMAGE="$BAKED_IMAGE"
+          echo "PRISM_RELEASE_EXECUTOR_IMAGE=${PRISM_RELEASE_EXECUTOR_IMAGE}"
+
           docker run --rm \
             --platform linux/amd64 \
-            --env "PRISM_RELEASE_EXECUTOR_IMAGE=$PRISM_RELEASE_EXECUTOR_IMAGE" \
+            --env "PRISM_RELEASE_EXECUTOR_IMAGE=${PRISM_RELEASE_EXECUTOR_IMAGE}" \
             --entrypoint /app/venv/bin/python \
             release-studio-live-kicad:ci \
-            -m unittest tests.test_release_studio_live_ci -v 2>&1 | tee live-result.log
-
-          if grep -Eiq 'skipped' live-result.log; then
-            echo "Release Studio live test was skipped; the KiCad live gate must run." >&2
-            exit 1
-          fi
-
-          if ! grep -Eq 'Ran [1-9][0-9]* tests? in ' live-result.log; then
-            echo "Release Studio live test ran zero tests or did not report a unittest summary." >&2
-            exit 1
-          fi
+            -m tests.release_studio_live_runner
 
   quality-gate:
     name: Quality gate

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,11 @@ COPY frontend/ .
 RUN npm run build:panel
 
 FROM --platform=${KICAD_BASE_PLATFORM} ${KICAD_BASE_IMAGE} AS prism-runtime
+# Redeclare so the value that satisfied FROM is available in this stage and can
+# be baked into the image as the Release Studio executor identity.
+ARG KICAD_BASE_IMAGE
 ARG KICAD_LIBRARY_UTILS_REF=7124a92887b2280f85cfe2d5abb216062978d5e1
+LABEL prism.release.kicad_base_image="${KICAD_BASE_IMAGE}"
 
 # Prevent interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive
@@ -90,6 +94,12 @@ RUN cd /opt/kicad-prism-viewer && npm run build
 COPY backend/ .
 COPY scripts/ scripts/
 COPY --from=remote-provider-panel /panel/dist/remote_provider/ /app/app/static/remote_provider/
+
+# Stable on-disk identity for toolchain_digest / live CI. Written late so the
+# expensive layers above stay cacheable when only executor identity changes.
+RUN mkdir -p /etc/prism \
+    && printf '%s\n' "${KICAD_BASE_IMAGE}" > /etc/prism/kicad-base-image \
+    && chmod 0644 /etc/prism/kicad-base-image
 
 # Expose backend port
 EXPOSE 8000

--- a/backend/tests/release_studio_live_runner.py
+++ b/backend/tests/release_studio_live_runner.py
@@ -1,0 +1,46 @@
+"""Strict unittest runner for Release Studio live executor gates.
+
+Exits nonzero when zero tests ran, any test was skipped, or any test failed
+or errored. R0 appends its fixture module to LIVE_MODULES after rebase onto
+the baked-identity contract.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+
+
+LIVE_MODULES: tuple[str, ...] = (
+    "tests.test_release_studio_live_ci",
+    # "tests.test_release_studio_fixtures",  # R0
+)
+
+
+def run_live_modules(module_names: tuple[str, ...] = LIVE_MODULES) -> int:
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    for module_name in module_names:
+        suite.addTests(loader.loadTestsFromName(module_name))
+
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.testsRun < 1:
+        print("Release Studio live runner executed zero tests", file=sys.stderr)
+        return 1
+    if result.skipped:
+        print(
+            f"Release Studio live runner forbids skips ({len(result.skipped)} skipped)",
+            file=sys.stderr,
+        )
+        return 1
+    if result.failures or result.errors:
+        return 1
+    return 0
+
+
+def main() -> int:
+    return run_live_modules()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_release_studio_live_ci.py
+++ b/backend/tests/test_release_studio_live_ci.py
@@ -6,13 +6,33 @@ import os
 import re
 import subprocess
 import unittest
+from pathlib import Path
 
 
-EXPECTED_KICAD_IMAGE = (
-    "kicad/kicad:10.0.4@"
-    "sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c"
-)
 EXECUTOR_IMAGE_ENV = "PRISM_RELEASE_EXECUTOR_IMAGE"
+BAKED_KICAD_BASE_IMAGE_PATH = Path("/etc/prism/kicad-base-image")
+_DIGEST_SUFFIX = re.compile(r"@sha256:([0-9a-f]{64})$")
+
+
+def _read_baked_kicad_base_image() -> str:
+    try:
+        raw = BAKED_KICAD_BASE_IMAGE_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise AssertionError(
+            f"missing baked KiCad base image identity at {BAKED_KICAD_BASE_IMAGE_PATH}"
+        ) from exc
+    value = raw.strip()
+    if not value:
+        raise AssertionError(
+            f"baked KiCad base image identity at {BAKED_KICAD_BASE_IMAGE_PATH} is empty"
+        )
+    match = _DIGEST_SUFFIX.search(value)
+    if match is None:
+        raise AssertionError(
+            "baked KiCad base image must end with @sha256:<64 lowercase hex>; "
+            f"got {value!r}"
+        )
+    return value
 
 
 class ReleaseStudioLiveCiTests(unittest.TestCase):
@@ -21,13 +41,15 @@ class ReleaseStudioLiveCiTests(unittest.TestCase):
         "PRISM_RELEASE_EXECUTOR_IMAGE is required for the live executor test",
     )
     def test_pinned_executor_has_kicad_cli_10_0_4(self) -> None:
-        """Run the real CLI and require the exact CI executor identity."""
+        """Require baked image identity, matching env, and KiCad 10.0.4."""
+        baked = _read_baked_kicad_base_image()
+        runtime = os.environ.get(EXECUTOR_IMAGE_ENV, "")
         self.assertEqual(
-            os.environ.get(EXECUTOR_IMAGE_ENV),
-            EXPECTED_KICAD_IMAGE,
+            runtime,
+            baked,
             msg=(
-                f"{EXECUTOR_IMAGE_ENV} must contain the exact pinned KiCad "
-                "image reference"
+                f"{EXECUTOR_IMAGE_ENV} must match the baked identity at "
+                f"{BAKED_KICAD_BASE_IMAGE_PATH}"
             ),
         )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
       context: .
       dockerfile: backend/Dockerfile
       args:
-        KICAD_BASE_IMAGE: ${KICAD_BASE_IMAGE:-kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c}
+        # KICAD_BASE_IMAGE defaults live only in backend/Dockerfile. Override
+        # with: docker compose build --build-arg KICAD_BASE_IMAGE=...
         KICAD_BASE_PLATFORM: ${KICAD_BASE_PLATFORM:-linux/amd64}
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: kicad-prism-backend
@@ -131,7 +132,6 @@ services:
       context: .
       dockerfile: backend/Dockerfile
       args:
-        KICAD_BASE_IMAGE: ${KICAD_BASE_IMAGE:-kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c}
         KICAD_BASE_PLATFORM: ${KICAD_BASE_PLATFORM:-linux/amd64}
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: kicad-prism-catalog-worker
@@ -194,7 +194,6 @@ services:
       context: .
       dockerfile: backend/Dockerfile
       args:
-        KICAD_BASE_IMAGE: ${KICAD_BASE_IMAGE:-kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c}
         KICAD_BASE_PLATFORM: ${KICAD_BASE_PLATFORM:-linux/amd64}
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     container_name: kicad-prism-worker

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -94,9 +94,11 @@ KICAD_BASE_PLATFORM=linux/amd64
 DOCKER_PLATFORM=linux/amd64
 ```
 
-The repository default also pins `KICAD_BASE_IMAGE` to the selected stable KiCad
-AMD64 manifest digest. The public source-build and release targets are Linux
-AMD64.
+The repository default pins `KICAD_BASE_IMAGE` in `backend/Dockerfile` to the
+selected stable KiCad AMD64 manifest digest. Compose does not duplicate that
+default; override at build time with
+`docker compose build --build-arg KICAD_BASE_IMAGE=...`. The public
+source-build and release targets are Linux AMD64.
 
 ## Project-level `.prism.json`
 

--- a/docs/PUBLIC_DEMO_PLAN.md
+++ b/docs/PUBLIC_DEMO_PLAN.md
@@ -332,8 +332,9 @@ Edit `.env`. The demo-critical values (see §4 for the full rationale — **do n
 skip that section, the defaults are unsafe for public hosting**):
 
 ```env
-# --- Platform: switch off the local ARM base image ---
-KICAD_BASE_IMAGE=kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c
+# --- Platform: use the Dockerfile AMD64 KiCad default ---
+# Exact digest lives only in backend/Dockerfile. Override at build time with:
+#   docker compose build --build-arg KICAD_BASE_IMAGE=...
 KICAD_BASE_PLATFORM=linux/amd64
 DOCKER_PLATFORM=linux/amd64
 

--- a/docs/release-studio/R00.md
+++ b/docs/release-studio/R00.md
@@ -1,28 +1,48 @@
-# Release Studio R00: CI quality gate
+# Release Studio R00 / R00a: CI quality gate and executor identity
 
 R00 makes the existing quality gate run for pull requests and pushes targeting
-`feature/release-studio`, and adds a required live KiCad check.
+`feature/release-studio`, and adds a required live KiCad check. R00a makes the
+pinned KiCad base image a single Dockerfile default and bakes the actual
+build-arg into the image so live CI verifies the container it is running in.
 
 ## Pinned executor
 
-The live job builds the repository backend image with this exact KiCad base
-reference, matching `backend/Dockerfile` and `docker-compose.yml`:
+The exact digest default lives only in `backend/Dockerfile` as
+`ARG KICAD_BASE_IMAGE=...@sha256:<64 lowercase hex>`. Compose no longer
+duplicates that default; operators may still override with
+`docker compose build --build-arg KICAD_BASE_IMAGE=...`.
 
-`kicad/kicad:10.0.4@sha256:ee71e88396f8563168eb1ef282cda9ff2670fe86a677c63dd78b35e3d464454c`
+The runtime stage redeclares `ARG KICAD_BASE_IMAGE` and writes the value used
+by `FROM` to `/etc/prism/kicad-base-image` (and an optional image label). That
+on-disk identity is the Release Studio executor reference reserved for future
+`toolchain_digest` work.
 
-The job passes the full image reference to the focused test as
-`PRISM_RELEASE_EXECUTOR_IMAGE`. Its `@sha256:` suffix is the stable
-Release-Studio-specific identity reserved for future `toolchain_digest` work.
+The live job builds from the Dockerfile default (no workflow digest literal,
+no `--pull`), reads the baked file from the built image, exports
+`PRISM_RELEASE_EXECUTOR_IMAGE` from that value, and runs
+`python -m tests.release_studio_live_runner`.
 
-## No-skip enforcement
+## Live test contract
 
-`backend/tests/test_release_studio_live_ci.py` requires the exact
-`PRISM_RELEASE_EXECUTOR_IMAGE` value, invokes `kicad-cli --version` with an
-argument list (no shell interpolation), and requires KiCad `10.0.4`.
-The workflow then fails if unittest reports `skipped` or does not report at
-least one executed test (`Ran [1-9][0-9]* tests? in ...`). The final
-`quality-gate` job runs with `always()` and explicitly requires
-`needs.kicad-live.result == success`, so a skipped or failed live job cannot
-produce a green aggregate gate.
+`backend/tests/test_release_studio_live_ci.py` reads the baked file, requires a
+trailing `@sha256:<64 lowercase hex>`, compares `PRISM_RELEASE_EXECUTOR_IMAGE`
+to that baked value, invokes `kicad-cli --version` with an argument list (no
+shell interpolation), and requires KiCad `10.0.4`.
 
-R00 does not add release fixtures, services, schemas, APIs, or UI.
+`backend/tests/release_studio_live_runner.py` fails the job on zero tests, any
+skip, any failure, or any error. R0 appends its fixture module to
+`LIVE_MODULES` after rebasing onto this baked-identity contract.
+
+## Required on core branches
+
+The live gate remains required on `feature/release-studio`, `dev`, and `main`
+via `quality-gate` (`always()` + `needs.kicad-live.result == success`). That is
+an intentional core-runtime invariant: every merge path proves the pinned
+executor still boots and reports KiCad `10.0.4`.
+
+Tradeoff: unrelated PRs to `dev`/`main` pay a full AMD64 backend image build
+on the critical path and are blocked if the pinned base image registry is
+unavailable. Availability of Docker Hub (or a mirror of the pinned digest) is
+therefore part of the merge SLA for those branches.
+
+R00/R00a do not add release fixtures, services, schemas, APIs, or UI.


### PR DESCRIPTION
## Summary
- Single-source `KICAD_BASE_IMAGE` digest default in `backend/Dockerfile`; remove Compose/workflow digest duplicates.
- Bake the actual FROM build-arg to `/etc/prism/kicad-base-image` (+ label); live CI reads it and exports `PRISM_RELEASE_EXECUTOR_IMAGE`.
- Add `tests.release_studio_live_runner` (nonzero on zero/skip/fail/error); keep the live gate required on `feature/release-studio`, `dev`, and `main`.

## Test plan
- [x] Local `docker build` + `python -m tests.release_studio_live_runner` against baked identity → OK
- [x] Repo digest grep finds the pin only in `backend/Dockerfile`
- [ ] CI quality gate on `feature/release-studio`