### PR TITLE
feat(release-studio): R1 jobset model and hermetic closures

### DIFF
--- a/backend/app/release_studio/__init__.py
+++ b/backend/app/release_studio/__init__.py
@@ -1,0 +1,1 @@
+"""Release Studio package."""

--- a/backend/app/release_studio/jobset.py
+++ b/backend/app/release_studio/jobset.py
@@ -1,0 +1,260 @@
+"""Release Studio jobset model, output closures, and hermetic step types."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+# Stable Prism Workflow output ids from assets/Outputs.kicad_jobset.
+WORKFLOW_OUTPUT_IDS: dict[str, str] = {
+    "design": "28dab1d3-7bf2-4d8a-9723-bcdd14e1d814",
+    "manufacturing": "9e5c254b-cb26-4a49-beea-fa7af8a62903",
+    "render": "81c80ad4-e8b9-4c9a-8bed-df7864fdefc6",
+}
+
+# Step types that never invoke an arbitrary external process. Hermeticity of a
+# release output still also requires every referenced input to resolve into the
+# closure or a pinned toolchain resource (R2b); R1 only classifies step types.
+HERMETIC_STEP_TYPES: frozenset[str] = frozenset(
+    {
+        "sch_export_plot_pdf",
+        "sch_export_bom",
+        "sch_export_netlist",
+        "pcb_export_gerbers",
+        "pcb_export_drill",
+        "pcb_export_pos",
+        "pcb_export_pdf",
+        "pcb_export_3d",
+        "pcb_export_ipcd356",
+        "pcb_export_odb",
+        "pcb_drc",
+        "pcb_render",
+        "sch_erc",
+    }
+)
+
+
+@dataclass(frozen=True)
+class JobsetJob:
+    id: str
+    type: str
+    description: str = ""
+    settings: Mapping[str, Any] = field(default_factory=dict)
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class JobsetOutput:
+    id: str
+    type: str
+    description: str = ""
+    only: tuple[str, ...] = ()
+    settings: Mapping[str, Any] = field(default_factory=dict)
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class JobsetModel:
+    jobs: tuple[JobsetJob, ...]
+    outputs: tuple[JobsetOutput, ...]
+    meta: Mapping[str, Any] = field(default_factory=dict)
+    path: Path | None = None
+
+    def job_by_id(self) -> dict[str, JobsetJob]:
+        return {job.id: job for job in self.jobs}
+
+    def output_by_id(self) -> dict[str, JobsetOutput]:
+        return {output.id: output for output in self.outputs}
+
+
+@dataclass(frozen=True)
+class NonHermeticReason:
+    step_id: str
+    step_type: str
+    message: str
+
+
+@dataclass(frozen=True)
+class OutputClosure:
+    output_id: str
+    jobs: tuple[JobsetJob, ...]
+    hermetic: bool
+    non_hermetic_reasons: tuple[NonHermeticReason, ...]
+
+
+def load_jobset(path: Path | str) -> JobsetModel:
+    """Parse a `.kicad_jobset` into a typed model."""
+
+    jobset_path = Path(path)
+    payload = json.loads(jobset_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"jobset root must be an object: {jobset_path}")
+
+    jobs_raw = payload.get("jobs")
+    outputs_raw = payload.get("outputs")
+    if not isinstance(jobs_raw, list):
+        raise ValueError(f"jobset jobs must be a list: {jobset_path}")
+    if not isinstance(outputs_raw, list):
+        raise ValueError(f"jobset outputs must be a list: {jobset_path}")
+
+    jobs: list[JobsetJob] = []
+    seen_job_ids: set[str] = set()
+    for index, entry in enumerate(jobs_raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"jobset jobs[{index}] must be an object")
+        job_id = _require_text(entry.get("id"), f"jobs[{index}].id")
+        job_type = _require_text(entry.get("type"), f"jobs[{index}].type")
+        if job_id in seen_job_ids:
+            raise ValueError(f"duplicate job id {job_id!r}")
+        seen_job_ids.add(job_id)
+        description = entry.get("description") or ""
+        if not isinstance(description, str):
+            raise ValueError(f"jobs[{index}].description must be a string")
+        settings = entry.get("settings") or {}
+        if not isinstance(settings, dict):
+            raise ValueError(f"jobs[{index}].settings must be an object")
+        jobs.append(
+            JobsetJob(
+                id=job_id,
+                type=job_type,
+                description=description,
+                settings=settings,
+                raw=entry,
+            )
+        )
+
+    outputs: list[JobsetOutput] = []
+    seen_output_ids: set[str] = set()
+    for index, entry in enumerate(outputs_raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"jobset outputs[{index}] must be an object")
+        output_id = _require_text(entry.get("id"), f"outputs[{index}].id")
+        output_type = _require_text(entry.get("type"), f"outputs[{index}].type")
+        if output_id in seen_output_ids:
+            raise ValueError(f"duplicate output id {output_id!r}")
+        seen_output_ids.add(output_id)
+        description = entry.get("description") or ""
+        if not isinstance(description, str):
+            raise ValueError(f"outputs[{index}].description must be a string")
+        only_raw = entry.get("only") or []
+        if not isinstance(only_raw, list) or not all(
+            isinstance(item, str) and item for item in only_raw
+        ):
+            raise ValueError(f"outputs[{index}].only must be a list of non-empty strings")
+        settings = entry.get("settings") or {}
+        if not isinstance(settings, dict):
+            raise ValueError(f"outputs[{index}].settings must be an object")
+        outputs.append(
+            JobsetOutput(
+                id=output_id,
+                type=output_type,
+                description=description,
+                only=tuple(only_raw),
+                settings=settings,
+                raw=entry,
+            )
+        )
+
+    meta = payload.get("meta") or {}
+    if not isinstance(meta, dict):
+        raise ValueError("jobset meta must be an object")
+
+    return JobsetModel(
+        jobs=tuple(jobs),
+        outputs=tuple(outputs),
+        meta=meta,
+        path=jobset_path,
+    )
+
+
+def step_closure_for_output(model: JobsetModel, output_id: str) -> tuple[JobsetJob, ...]:
+    """Return jobs selected by an output, recursively expanding nested outputs.
+
+    Expansion follows each output's ``only`` list. Job ids resolve to jobs;
+    output ids resolve to that nested output's closure. Cycles and unknown ids
+    raise ``ValueError``.
+    """
+
+    jobs_by_id = model.job_by_id()
+    outputs_by_id = model.output_by_id()
+    if output_id not in outputs_by_id:
+        raise ValueError(f"unknown jobset output id: {output_id!r}")
+
+    ordered: list[JobsetJob] = []
+    seen_jobs: set[str] = set()
+    visiting_outputs: set[str] = set()
+
+    def visit_output(current_output_id: str) -> None:
+        if current_output_id in visiting_outputs:
+            raise ValueError(
+                f"cyclic jobset output closure involving {current_output_id!r}"
+            )
+        output = outputs_by_id.get(current_output_id)
+        if output is None:
+            raise ValueError(f"unknown jobset output id: {current_output_id!r}")
+        visiting_outputs.add(current_output_id)
+        for reference in output.only:
+            if reference in outputs_by_id:
+                visit_output(reference)
+                continue
+            job = jobs_by_id.get(reference)
+            if job is None:
+                raise ValueError(
+                    f"output {current_output_id!r} references unknown id {reference!r}"
+                )
+            if job.id in seen_jobs:
+                continue
+            seen_jobs.add(job.id)
+            ordered.append(job)
+        visiting_outputs.remove(current_output_id)
+
+    visit_output(output_id)
+    return tuple(ordered)
+
+
+def classify_output_hermetic(
+    model: JobsetModel,
+    output_id: str,
+    *,
+    hermetic_step_types: Iterable[str] = HERMETIC_STEP_TYPES,
+) -> OutputClosure:
+    """Classify whether an output's recursively selected steps are hermetic."""
+
+    allowed = frozenset(hermetic_step_types)
+    jobs = step_closure_for_output(model, output_id)
+    reasons: list[NonHermeticReason] = []
+    for job in jobs:
+        if job.type not in allowed:
+            reasons.append(
+                NonHermeticReason(
+                    step_id=job.id,
+                    step_type=job.type,
+                    message=(
+                        f"step type {job.type!r} is outside HERMETIC_STEP_TYPES"
+                    ),
+                )
+            )
+    return OutputClosure(
+        output_id=output_id,
+        jobs=jobs,
+        hermetic=not reasons,
+        non_hermetic_reasons=tuple(reasons),
+    )
+
+
+def workflow_output_id(workflow_type: str) -> str:
+    """Map a Prism workflow name onto the reference jobset output id."""
+
+    try:
+        return WORKFLOW_OUTPUT_IDS[workflow_type]
+    except KeyError as exc:
+        raise ValueError(f"Unknown workflow type: {workflow_type}") from exc
+
+
+def _require_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -736,11 +736,7 @@ def run_semantic_index_job_v3(context: JobContext) -> JobResult:
     )
 
 
-_WORKFLOW_OUTPUT_IDS = {
-    "design": "28dab1d3-7bf2-4d8a-9723-bcdd14e1d814",
-    "manufacturing": "9e5c254b-cb26-4a49-beea-fa7af8a62903",
-    "render": "81c80ad4-e8b9-4c9a-8bed-df7864fdefc6",
-}
+from app.release_studio.jobset import WORKFLOW_OUTPUT_IDS as _WORKFLOW_OUTPUT_IDS
 
 
 def run_kicad_workflow_job_v3(context: JobContext) -> JobResult:

--- a/backend/tests/test_release_studio_jobset.py
+++ b/backend/tests/test_release_studio_jobset.py
@@ -1,0 +1,156 @@
+"""Tests for the Release Studio jobset model and hermetic output closures."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.release_studio.jobset import (
+    HERMETIC_STEP_TYPES,
+    WORKFLOW_OUTPUT_IDS,
+    classify_output_hermetic,
+    load_jobset,
+    step_closure_for_output,
+    workflow_output_id,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REFERENCE_JOBSET = REPO_ROOT / "assets" / "Outputs.kicad_jobset"
+
+
+class ReleaseStudioJobsetTests(unittest.TestCase):
+    def test_workflow_output_ids_match_reference_jobset_and_legacy_mapping(self) -> None:
+        model = load_jobset(REFERENCE_JOBSET)
+        output_ids = {output.id for output in model.outputs}
+        self.assertEqual(
+            WORKFLOW_OUTPUT_IDS,
+            {
+                "design": "28dab1d3-7bf2-4d8a-9723-bcdd14e1d814",
+                "manufacturing": "9e5c254b-cb26-4a49-beea-fa7af8a62903",
+                "render": "81c80ad4-e8b9-4c9a-8bed-df7864fdefc6",
+            },
+        )
+        for workflow_type, output_id in WORKFLOW_OUTPUT_IDS.items():
+            self.assertIn(output_id, output_ids)
+            self.assertEqual(workflow_output_id(workflow_type), output_id)
+
+        project_service_source = (
+            REPO_ROOT / "backend" / "app" / "services" / "project_service.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "from app.release_studio.jobset import WORKFLOW_OUTPUT_IDS as _WORKFLOW_OUTPUT_IDS",
+            project_service_source,
+        )
+        self.assertNotIn(
+            '"design": "28dab1d3-7bf2-4d8a-9723-bcdd14e1d814"',
+            project_service_source,
+        )
+
+    def test_reference_outputs_are_hermetic_despite_unreferenced_special_execute(
+        self,
+    ) -> None:
+        model = load_jobset(REFERENCE_JOBSET)
+        special_ids = {job.id for job in model.jobs if job.type == "special_execute"}
+        self.assertEqual(special_ids, {"676cbc40-2829-462c-a885-27563c1e4396"})
+        self.assertNotIn("special_execute", HERMETIC_STEP_TYPES)
+
+        for output_id in WORKFLOW_OUTPUT_IDS.values():
+            closure = classify_output_hermetic(model, output_id)
+            self.assertTrue(closure.hermetic, output_id)
+            self.assertEqual(closure.non_hermetic_reasons, ())
+            closed_ids = {job.id for job in closure.jobs}
+            self.assertTrue(closed_ids.isdisjoint(special_ids), output_id)
+            self.assertEqual(
+                [job.id for job in closure.jobs],
+                list(model.output_by_id()[output_id].only),
+            )
+
+    def test_output_whose_closure_includes_special_execute_is_flagged(self) -> None:
+        payload = {
+            "jobs": [
+                {
+                    "id": "safe-job",
+                    "type": "pcb_export_gerbers",
+                    "settings": {},
+                },
+                {
+                    "id": "unsafe-job",
+                    "type": "special_execute",
+                    "settings": {"command": "echo hi"},
+                },
+            ],
+            "outputs": [
+                {
+                    "id": "nested-safe",
+                    "type": "folder",
+                    "only": ["safe-job"],
+                    "settings": {},
+                },
+                {
+                    "id": "with-special",
+                    "type": "folder",
+                    "only": ["nested-safe", "unsafe-job"],
+                    "settings": {},
+                },
+            ],
+            "meta": {"version": 1},
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "sample.kicad_jobset"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            model = load_jobset(path)
+
+            nested = classify_output_hermetic(model, "nested-safe")
+            self.assertTrue(nested.hermetic)
+            self.assertEqual([job.id for job in nested.jobs], ["safe-job"])
+
+            flagged = classify_output_hermetic(model, "with-special")
+            self.assertFalse(flagged.hermetic)
+            self.assertEqual(
+                [job.id for job in flagged.jobs],
+                ["safe-job", "unsafe-job"],
+            )
+            self.assertEqual(len(flagged.non_hermetic_reasons), 1)
+            reason = flagged.non_hermetic_reasons[0]
+            self.assertEqual(reason.step_id, "unsafe-job")
+            self.assertEqual(reason.step_type, "special_execute")
+
+            # Recursive expansion must visit nested outputs before sibling jobs.
+            self.assertEqual(
+                [job.id for job in step_closure_for_output(model, "with-special")],
+                ["safe-job", "unsafe-job"],
+            )
+
+    def test_unknown_and_cyclic_closures_raise(self) -> None:
+        payload = {
+            "jobs": [{"id": "job-a", "type": "pcb_drc", "settings": {}}],
+            "outputs": [
+                {
+                    "id": "out-a",
+                    "type": "folder",
+                    "only": ["out-b"],
+                    "settings": {},
+                },
+                {
+                    "id": "out-b",
+                    "type": "folder",
+                    "only": ["out-a"],
+                    "settings": {},
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "cycle.kicad_jobset"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            model = load_jobset(path)
+            with self.assertRaisesRegex(ValueError, "cyclic"):
+                step_closure_for_output(model, "out-a")
+            with self.assertRaisesRegex(ValueError, "unknown jobset output"):
+                step_closure_for_output(model, "missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/release-studio/R1.md
+++ b/docs/release-studio/R1.md
@@ -1,0 +1,50 @@
+# Release Studio R1: jobset model and hermetic step closures
+
+R1 introduces a typed `.kicad_jobset` model and evaluates hermeticity over the
+**recursively selected output closure**, not over jobs that merely exist in the
+file.
+
+## Owned surface
+
+| Path | Role |
+| --- | --- |
+| `backend/app/release_studio/jobset.py` | Parse jobset, `step_closure_for_output`, `HERMETIC_STEP_TYPES`, `classify_output_hermetic` |
+| `backend/app/services/project_service.py` | Imports `WORKFLOW_OUTPUT_IDS` instead of duplicating the three UUIDs |
+| `backend/tests/test_release_studio_jobset.py` | Acceptance tests |
+| `docs/release-studio/R1.md` | This note |
+
+## Workflow output ids
+
+`WORKFLOW_OUTPUT_IDS` reproduces today's Prism Workflow mapping against
+`assets/Outputs.kicad_jobset`:
+
+| Workflow | Output id | Description |
+| --- | --- | --- |
+| `design` | `28dab1d3-7bf2-4d8a-9723-bcdd14e1d814` | Design-Outputs |
+| `manufacturing` | `9e5c254b-cb26-4a49-beea-fa7af8a62903` | Manufacturing-Outputs |
+| `render` | `81c80ad4-e8b9-4c9a-8bed-df7864fdefc6` | Renders |
+
+## Closures and hermeticity
+
+`step_closure_for_output(model, output_id)` walks each output's `only` list:
+
+- a job id contributes that job once (first occurrence wins order);
+- an output id expands that nested output's closure;
+- unknown ids and cycles raise.
+
+`HERMETIC_STEP_TYPES` is the set of KiCad step types that never run an arbitrary
+external process. `special_execute` is intentionally excluded. R1 classifies an
+output as hermetic iff every job in its closure has a hermetic step type.
+Full input-path hermeticity (host libraries, LFS, env) arrives in R2b.
+
+The reference jobset contains a `special_execute` iBoM job that is **not**
+referenced by any of the three workflow outputs, so those outputs remain
+hermetic. An output whose recursive `only` includes that step is flagged with a
+`NonHermeticReason`.
+
+## Validation
+
+```sh
+cd backend
+python -m unittest tests.test_release_studio_jobset -v
+```


### PR DESCRIPTION
## Summary
- Add typed `.kicad_jobset` model with recursive `step_closure_for_output` and `HERMETIC_STEP_TYPES`.
- Flag outputs whose closure includes non-hermetic steps (e.g. `special_execute`); reference Workflow outputs stay hermetic because the iBoM step is unreferenced.
- Share `WORKFLOW_OUTPUT_IDS` from `app.release_studio.jobset` into `project_service`.

## Test plan
- [x] `cd backend && python -m unittest tests.test_release_studio_jobset -v` → `Ran 4 tests ... OK`
- [ ] CI quality gate on `feature/release-studio`