### PR TITLE
feat(release-studio): extract generic jobset execution

### DIFF
--- a/backend/app/services/kicad_jobset_service.py
+++ b/backend/app/services/kicad_jobset_service.py
@@ -1,0 +1,226 @@
+"""Execute KiCad jobset outputs with explicit output routing.
+
+The service owns the KiCad CLI seam and the legacy repository synchronization
+behavior. Callers choose whether generated files remain as an artifact in the
+working tree or are synchronized through the existing repository workflow.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal
+
+from git import Repo
+
+from app.services.job_runtime import JobContext
+
+
+JobsetRouting = Literal["artifact", "repository"]
+RepositoryFactory = Callable[[str], Repo]
+TimestampFactory = Callable[[], datetime.datetime]
+
+
+@dataclass(frozen=True)
+class JobsetOutputMetadata:
+    """The execution identity needed by later artifact consumers.
+
+    This is intentionally in-memory metadata. R2 does not create a persistence
+    record or inventory generated files.
+    """
+
+    project_path: str
+    jobset_path: str
+    jobset_file: str
+    project_file: str
+    output_id: str
+    routing: JobsetRouting
+
+
+@dataclass(frozen=True)
+class JobsetExecutionResult:
+    """The result of one KiCad jobset execution and its selected route."""
+
+    output: JobsetOutputMetadata
+    argv: tuple[str, ...]
+    generated_commit: str = ""
+    warnings: tuple[str, ...] = ()
+
+
+def find_kicad_cli_path() -> str:
+    """Return the KiCad CLI path using the existing Prism lookup convention."""
+
+    mac_path = "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+    if os.path.exists(mac_path):
+        return mac_path
+    return "kicad-cli"
+
+
+def jobset_file_argument(project_path: str | Path, jobset_path: str | Path) -> str:
+    """Return the jobset argument exactly as the legacy workflow did."""
+
+    project_root_abs = os.path.abspath(os.fspath(project_path))
+    jobset_abs = os.path.abspath(os.fspath(jobset_path))
+    try:
+        if os.path.commonpath([project_root_abs, jobset_abs]) == project_root_abs:
+            return os.path.relpath(jobset_abs, project_root_abs)
+    except ValueError:
+        pass
+    return os.fspath(jobset_path)
+
+
+def execute_kicad_jobset(
+    context: JobContext,
+    *,
+    project_path: str | Path,
+    jobset_path: str | Path,
+    project_file: str,
+    output_id: str,
+    workflow_type: str,
+    author: str = "anonymous",
+    routing: JobsetRouting = "repository",
+    cli_path: str | None = None,
+    repository_factory: RepositoryFactory | None = None,
+    timestamp_factory: TimestampFactory | None = None,
+) -> JobsetExecutionResult:
+    """Run one KiCad jobset output and route its generated files.
+
+    ``repository`` routing retains the pre-R2 add/commit/push behavior. The
+    ``artifact`` route deliberately does not construct a Git repository or run
+    any Git mutation; the generated files remain available under the project
+    path for a later artifact consumer.
+    """
+
+    if routing not in {"artifact", "repository"}:
+        raise ValueError(f"Unknown jobset routing: {routing}")
+
+    project_path_text = os.fspath(project_path)
+    jobset_path_text = os.fspath(jobset_path)
+    jobset_file = jobset_file_argument(project_path_text, jobset_path_text)
+    command = [
+        cli_path or find_kicad_cli_path(),
+        "jobset",
+        "run",
+        "-f",
+        jobset_file,
+        "--output",
+        output_id,
+        project_file,
+    ]
+    output = JobsetOutputMetadata(
+        project_path=project_path_text,
+        jobset_path=jobset_path_text,
+        jobset_file=jobset_file,
+        project_file=project_file,
+        output_id=output_id,
+        routing=routing,
+    )
+
+    print(f"Running: {shlex.join(command)}", flush=True)
+    context.progress(
+        stage="run-jobset",
+        message=f"Generating {workflow_type} outputs",
+        percent=15,
+        force=True,
+    )
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=project_path_text,
+        text=True,
+        bufsize=1,
+    )
+    if process.stdout is not None:
+        for line in process.stdout:
+            line = line.rstrip()
+            if line:
+                print(line, flush=True)
+    return_code = process.wait()
+    if return_code != 0:
+        raise RuntimeError(f"KiCad workflow exited with code {return_code}")
+
+    context.check_cancelled()
+    generated_commit = ""
+    warnings: list[str] = []
+    if routing == "repository":
+        context.progress(
+            stage="git-sync",
+            message="Synchronizing generated outputs",
+            percent=90,
+            force=True,
+        )
+        generated_commit, warnings = _sync_repository(
+            project_path_text,
+            workflow_type=workflow_type,
+            author=author,
+            repository_factory=repository_factory,
+            timestamp_factory=timestamp_factory,
+            context=context,
+        )
+
+    return JobsetExecutionResult(
+        output=output,
+        argv=tuple(command),
+        generated_commit=generated_commit,
+        warnings=tuple(warnings),
+    )
+
+
+def _sync_repository(
+    project_path: str,
+    *,
+    workflow_type: str,
+    author: str,
+    repository_factory: RepositoryFactory | None,
+    timestamp_factory: TimestampFactory | None,
+    context: JobContext,
+) -> tuple[str, list[str]]:
+    """Preserve the legacy generated-output commit and push sequence."""
+
+    warnings: list[str] = []
+    generated_commit = ""
+    try:
+        repository_constructor = (
+            repository_factory if repository_factory is not None else Repo
+        )
+        repo = repository_constructor(project_path)
+        if repo.is_dirty(untracked_files=True):
+            repo.git.add(".")
+            now_factory = (
+                timestamp_factory
+                if timestamp_factory is not None
+                else datetime.datetime.now
+            )
+            now = now_factory()
+            timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
+            commit_message = (
+                f"Generated {workflow_type} outputs - {timestamp} by {author}"
+            )
+            repo.git.commit(
+                m=commit_message,
+                author="KiCAD Prism <prism@example.com>",
+            )
+            generated_commit = str(repo.head.commit.hexsha)
+            context.check_cancelled()
+            # Share the import path's environment rather than rolling a second
+            # one: this keeps the existing GitHub token rewrite and strict
+            # host-key behavior for repository-routed workflow output.
+            from app.services.project_import_service import git_env
+
+            push_info = repo.remote(name="origin").push(env=git_env())
+            for info in push_info:
+                if info.flags & info.ERROR:
+                    raise RuntimeError(f"Push failed: {info.summary}")
+            print(f"Generated commit {generated_commit} pushed successfully", flush=True)
+        else:
+            print("No generated changes detected to commit", flush=True)
+    except Exception as error:
+        warning = f"Git sync warning: {error}"
+        warnings.append(warning)
+        print(warning, flush=True)
+    return generated_commit, warnings

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,7 +1,6 @@
 import os
 import hashlib
 import json
-import shlex
 import time
 import shutil
 import datetime
@@ -12,7 +11,7 @@ from urllib.parse import quote
 from git import Repo
 from pydantic import BaseModel
 
-from app.services import path_config_service, semantic_index_service
+from app.services import kicad_jobset_service, path_config_service, semantic_index_service
 from app.services.workspace_service import workspace
 from app.services.job_artifact_service import job_artifacts
 from app.services.job_runtime import JobContext, JobResult
@@ -425,11 +424,9 @@ def get_job_status(job_id: str):
 
 # Workflow Jobs
 def _find_cli_path():
-    # Check standard Mac path first
-    mac_path = "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
-    if os.path.exists(mac_path):
-        return mac_path
-    return "kicad-cli" # Fallback to PATH
+    """Keep the legacy lookup seam while delegating to the jobset service."""
+
+    return kicad_jobset_service.find_kicad_cli_path()
 
 def start_workflow_job(
     project_id: str,
@@ -774,98 +771,29 @@ def run_kicad_workflow_job_v3(context: JobContext) -> JobResult:
     if not jobset_path:
         raise ValueError(f"{configured_jobset} not found in project root")
 
-    try:
-        project_root_abs = os.path.abspath(project.path)
-        jobset_abs = os.path.abspath(jobset_path)
-        jobset_file = (
-            os.path.relpath(jobset_abs, project_root_abs)
-            if os.path.commonpath([project_root_abs, jobset_abs]) == project_root_abs
-            else jobset_path
-        )
-    except ValueError:
-        jobset_file = jobset_path
-
-    command = [
-        _find_cli_path(),
-        "jobset",
-        "run",
-        "-f",
-        jobset_file,
-        "--output",
-        output_id,
-        pro_file,
-    ]
-    print(f"Running: {shlex.join(command)}", flush=True)
-    context.progress(
-        stage="run-jobset",
-        message=f"Generating {workflow_type} outputs",
-        percent=15,
-        force=True,
+    execution = kicad_jobset_service.execute_kicad_jobset(
+        context,
+        project_path=project.path,
+        jobset_path=jobset_path,
+        project_file=pro_file,
+        output_id=output_id,
+        workflow_type=workflow_type,
+        author=author,
+        routing="repository",
+        cli_path=_find_cli_path(),
+        # Keep the old project_service.Repo patch seam for the legacy handler
+        # while the generic service remains independently testable.
+        repository_factory=Repo,
+        timestamp_factory=datetime.datetime.now,
     )
-    process = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        cwd=project.path,
-        text=True,
-        bufsize=1,
-    )
-    if process.stdout is not None:
-        for line in process.stdout:
-            line = line.rstrip()
-            if line:
-                print(line, flush=True)
-    return_code = process.wait()
-    if return_code != 0:
-        raise RuntimeError(f"KiCad workflow exited with code {return_code}")
-
-    context.check_cancelled()
-    context.progress(
-        stage="git-sync",
-        message="Synchronizing generated outputs",
-        percent=90,
-        force=True,
-    )
-    warnings: list[str] = []
-    generated_commit = ""
-    try:
-        repo = Repo(project.path)
-        if repo.is_dirty(untracked_files=True):
-            repo.git.add(".")
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            commit_message = (
-                f"Generated {workflow_type} outputs - {timestamp} by {author}"
-            )
-            repo.git.commit(
-                m=commit_message,
-                author="KiCAD Prism <prism@example.com>",
-            )
-            generated_commit = str(repo.head.commit.hexsha)
-            context.check_cancelled()
-            # Share the import path's environment rather than rolling a second
-            # one: this push previously had neither the GITHUB_TOKEN rewrite nor
-            # the strict host-key check that every other remote operation uses.
-            from app.services.project_import_service import git_env
-
-            push_info = repo.remote(name="origin").push(env=git_env())
-            for info in push_info:
-                if info.flags & info.ERROR:
-                    raise RuntimeError(f"Push failed: {info.summary}")
-            print(f"Generated commit {generated_commit} pushed successfully", flush=True)
-        else:
-            print("No generated changes detected to commit", flush=True)
-    except Exception as error:
-        warning = f"Git sync warning: {error}"
-        warnings.append(warning)
-        print(warning, flush=True)
 
     return JobResult(
         message="Workflow completed successfully",
         details={
             "project_id": project_id,
             "workflow_type": workflow_type,
-            "generated_commit": generated_commit,
-            "warnings": warnings,
+            "generated_commit": execution.generated_commit,
+            "warnings": list(execution.warnings),
         },
     )
 

--- a/backend/tests/test_kicad_jobset_service.py
+++ b/backend/tests/test_kicad_jobset_service.py
@@ -1,0 +1,242 @@
+"""Characterization tests for the generic KiCad jobset execution seam."""
+
+from __future__ import annotations
+
+import datetime
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from app.services import kicad_jobset_service, project_import_service, project_service
+from app.services.job_runtime import JobResult
+
+
+class KicadJobsetServiceTests(unittest.TestCase):
+    def _context(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            check_cancelled=mock.Mock(),
+            progress=mock.Mock(),
+        )
+
+    def _process(self) -> mock.Mock:
+        process = mock.Mock()
+        process.stdout = ["first line\n", "second line\n"]
+        process.wait.return_value = 0
+        return process
+
+    def _repository(self) -> mock.Mock:
+        repository = mock.Mock()
+        repository.is_dirty.return_value = True
+        repository.head.commit.hexsha = "generated-sha"
+        repository.remote.return_value.push.return_value = [
+            SimpleNamespace(flags=0, ERROR=1)
+        ]
+        return repository
+
+    def test_repository_route_characterizes_argv_and_commit_message(self) -> None:
+        context = self._context()
+        process = self._process()
+        repository = self._repository()
+        fixed_time = datetime.datetime(2026, 8, 11, 12, 13, 14)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            project_path = Path(temporary)
+            jobset_path = project_path / "Outputs.kicad_jobset"
+            jobset_path.write_text("{}", encoding="utf-8")
+
+            with (
+                mock.patch.object(
+                    kicad_jobset_service.subprocess,
+                    "Popen",
+                    return_value=process,
+                ) as popen,
+                mock.patch.object(
+                    project_import_service,
+                    "git_env",
+                    return_value={"GIT_TERMINAL_PROMPT": "0"},
+                ) as git_env,
+            ):
+                result = kicad_jobset_service.execute_kicad_jobset(
+                    context,
+                    project_path=project_path,
+                    jobset_path=jobset_path,
+                    project_file="board.kicad_pro",
+                    output_id="output-id",
+                    workflow_type="manufacturing",
+                    author="designer@example.com",
+                    routing="repository",
+                    cli_path="kicad-cli",
+                    repository_factory=lambda _path: repository,
+                    timestamp_factory=lambda: fixed_time,
+                )
+
+        expected_argv = [
+            "kicad-cli",
+            "jobset",
+            "run",
+            "-f",
+            "Outputs.kicad_jobset",
+            "--output",
+            "output-id",
+            "board.kicad_pro",
+        ]
+        self.assertEqual(popen.call_args.args[0], expected_argv)
+        self.assertEqual(
+            popen.call_args.kwargs,
+            {
+                "stdout": kicad_jobset_service.subprocess.PIPE,
+                "stderr": kicad_jobset_service.subprocess.STDOUT,
+                "cwd": str(project_path),
+                "text": True,
+                "bufsize": 1,
+            },
+        )
+        repository.git.add.assert_called_once_with(".")
+        repository.git.commit.assert_called_once_with(
+            m=(
+                "Generated manufacturing outputs - "
+                "2026-08-11 12:13:14 by designer@example.com"
+            ),
+            author="KiCAD Prism <prism@example.com>",
+        )
+        repository.remote.assert_called_once_with(name="origin")
+        repository.remote.return_value.push.assert_called_once_with(
+            env={"GIT_TERMINAL_PROMPT": "0"}
+        )
+        git_env.assert_called_once_with()
+        self.assertEqual(result.generated_commit, "generated-sha")
+        self.assertEqual(result.warnings, ())
+        self.assertEqual(result.argv, tuple(expected_argv))
+        self.assertEqual(
+            result.output,
+            kicad_jobset_service.JobsetOutputMetadata(
+                project_path=str(project_path),
+                jobset_path=str(jobset_path),
+                jobset_file="Outputs.kicad_jobset",
+                project_file="board.kicad_pro",
+                output_id="output-id",
+                routing="repository",
+            ),
+        )
+
+    def test_artifact_route_does_not_construct_or_mutate_a_repository(self) -> None:
+        context = self._context()
+        process = self._process()
+        repository_factory = mock.Mock(side_effect=AssertionError("Git was used"))
+
+        with tempfile.TemporaryDirectory() as temporary:
+            project_path = Path(temporary)
+            jobset_path = project_path / "Outputs.kicad_jobset"
+            jobset_path.write_text("{}", encoding="utf-8")
+            with mock.patch.object(
+                kicad_jobset_service.subprocess,
+                "Popen",
+                return_value=process,
+            ):
+                result = kicad_jobset_service.execute_kicad_jobset(
+                    context,
+                    project_path=project_path,
+                    jobset_path=jobset_path,
+                    project_file="board.kicad_pro",
+                    output_id="artifact-output",
+                    workflow_type="design",
+                    routing="artifact",
+                    cli_path="kicad-cli",
+                    repository_factory=repository_factory,
+                )
+
+        repository_factory.assert_not_called()
+        self.assertEqual(result.output.routing, "artifact")
+        self.assertEqual(result.generated_commit, "")
+        self.assertEqual(result.warnings, ())
+        self.assertEqual(
+            [call.kwargs["stage"] for call in context.progress.call_args_list],
+            ["run-jobset"],
+        )
+
+    def test_legacy_handler_keeps_the_pre_change_job_result_shape(self) -> None:
+        process = self._process()
+        repository = self._repository()
+        progress_updates: list[dict[str, object]] = []
+        fixed_time = datetime.datetime(2026, 8, 11, 12, 13, 14)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            project_root = Path(temporary)
+            (project_root / "board.kicad_pro").write_text("", encoding="utf-8")
+            jobset = project_root / "Outputs.kicad_jobset"
+            jobset.write_text("{}", encoding="utf-8")
+            context = SimpleNamespace(
+                payload={
+                    "project_id": "project-1",
+                    "workflow_type": "design",
+                    "author": "designer@example.com",
+                },
+                check_cancelled=mock.Mock(),
+                progress=lambda **values: progress_updates.append(values),
+            )
+            project = SimpleNamespace(path=str(project_root))
+
+            with (
+                mock.patch.object(
+                    project_service.workspace,
+                    "get_project_by_id",
+                    return_value={"id": "project-1"},
+                ),
+                mock.patch.object(
+                    project_service,
+                    "_workspace_row_to_project",
+                    return_value=project,
+                ),
+                mock.patch.object(
+                    project_service.path_config_service,
+                    "get_path_config",
+                    return_value=SimpleNamespace(jobset="Outputs.kicad_jobset"),
+                ),
+                mock.patch.object(
+                    project_service.path_config_service,
+                    "resolve_paths",
+                    return_value=SimpleNamespace(jobset_path=str(jobset)),
+                ),
+                mock.patch.object(
+                    project_service,
+                    "_find_cli_path",
+                    return_value="kicad-cli",
+                ),
+                mock.patch.object(
+                    project_service.subprocess,
+                    "Popen",
+                    return_value=process,
+                ),
+                mock.patch.object(project_service, "Repo", return_value=repository),
+                mock.patch.object(
+                    project_import_service,
+                    "git_env",
+                    return_value={"GIT_TERMINAL_PROMPT": "0"},
+                ),
+                mock.patch.object(
+                    project_service.datetime,
+                    "datetime",
+                    SimpleNamespace(now=lambda: fixed_time),
+                ),
+            ):
+                result = project_service.run_kicad_workflow_job_v3(context)
+
+        self.assertEqual(
+            result,
+            JobResult(
+                message="Workflow completed successfully",
+                details={
+                    "project_id": "project-1",
+                    "workflow_type": "design",
+                    "generated_commit": "generated-sha",
+                    "warnings": [],
+                },
+            ),
+        )
+        self.assertEqual(progress_updates[-1]["stage"], "git-sync")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/release-studio/R2.md
+++ b/docs/release-studio/R2.md
@@ -1,0 +1,40 @@
+# Release Studio R2: generic KiCad jobset execution
+
+R2 extracts the KiCad jobset process from the legacy `kicad_workflow` handler
+into `backend/app/services/kicad_jobset_service.py`. The service owns the
+existing `kicad-cli jobset run` command seam, streamed output, cancellation
+checks, and explicit output routing.
+
+## Routing contract
+
+The service accepts two typed routes:
+
+- `repository` retains the existing Prism Workflow behavior: if generated
+  files make the repository dirty, it stages `.`, commits with the existing
+  timestamped message and fixed Prism author, checks the job lease, and pushes
+  `origin` using the existing Git environment. Git synchronization failures
+  remain warnings in the returned execution result, as they were in the legacy
+  handler.
+- `artifact` runs the same KiCad jobset command but does not construct a Git
+  repository and performs no add, stage, commit, or push operation. Generated
+  files remain in the project path. The in-memory `JobsetOutputMetadata` records
+  only the project path, jobset path/argument, project file, output id, and
+  route; R2 adds no persistence or file inventory.
+
+`run_kicad_workflow_job_v3` uses `repository` routing and maps the generic
+execution result back to the pre-R2 `JobResult` message and details shape. The
+three output ids continue to come from
+`app.release_studio.jobset.WORKFLOW_OUTPUT_IDS`; R2 does not alter R1 output
+selection or closure evaluation.
+
+## Characterization
+
+`backend/tests/test_kicad_jobset_service.py` pins the legacy contract for:
+
+- the exact argv and `Popen` options;
+- the generated commit message and Prism author;
+- the legacy handler's `JobResult` shape; and
+- the artifact route's no-Git guarantee.
+
+R2 deliberately does not implement input closure capture (R2b), board
+projections (R5), output canonicalization, or artifact persistence.


### PR DESCRIPTION
## Summary

R2 extracts the KiCad jobset execution seam from the legacy `kicad_workflow`
handler into a typed `kicad_jobset_service`. The legacy handler now delegates
to the service with repository routing and maps the result back to the exact
pre-change `JobResult` shape.

## Why this matters

Release Studio callers need to run a selected KiCad jobset output without
turning generated files into a repository commit. Before R2, execution and
repository synchronization were inseparable, so an artifact-oriented caller
would have to risk staging, committing, and pushing generated design output.

## Root cause and fix

The old handler combined command construction, streamed process output,
cancellation checks, and Git synchronization in one project service function.
R2 moves those concerns into `backend/app/services/kicad_jobset_service.py` and
adds explicit `repository` and `artifact` routing. Repository routing retains
the existing add/commit/push sequence, timestamped commit message, fixed Prism
author, warning behavior, and Git environment. Artifact routing does not
construct a repository or perform add/stage/commit/push operations, and returns
in-memory output identity metadata without adding persistence.

R1's `WORKFLOW_OUTPUT_IDS` remains authoritative and the legacy
`run_kicad_workflow_job_v3` continues to select the same output IDs.

## Acceptance coverage

- Exact `kicad-cli jobset run` argv and `Popen` options are characterized.
- The generated commit message and fixed author are characterized.
- The legacy handler's `JobResult` message/details shape is characterized.
- Artifact routing is tested to avoid repository construction and Git mutation.
- `backend/tests/test_project_service_v3_jobs.py` remains unchanged.

## Validation

- PASS: `tests.test_release_studio_jobset` — 4 tests.
- PASS: `python3 -m compileall -q backend/app backend/tests`.
- PASS: `git diff --cached --check` before commit.
- Host limitation: the available Python runtime lacks the backend requirements,
  so the focused R2 and unchanged v3 job tests cannot import `GitPython`; full
  discovery reached 229 tests but reported 51 dependency/import errors. CI's
  backend installation is required for the runtime suite.

## Scope and residual risk

This PR intentionally does not implement R2b input closure capture, R5 board
projections, artifact persistence, canonicalization, or later Release Studio
chunks. Runtime behavior still depends on the configured KiCad CLI and the
existing backend Git environment; live KiCad execution was not available in
the host shell.
