### PR TITLE
fix(release-studio): align job-set selection with KiCad 10.0.4

### DIFF
--- a/backend/app/release_studio/jobset.py
+++ b/backend/app/release_studio/jobset.py
@@ -4,36 +4,79 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Iterable, Mapping
 
 
-# Stable Prism Workflow output ids from assets/Outputs.kicad_jobset.
-WORKFLOW_OUTPUT_IDS: dict[str, str] = {
-    "design": "28dab1d3-7bf2-4d8a-9723-bcdd14e1d814",
-    "manufacturing": "9e5c254b-cb26-4a49-beea-fa7af8a62903",
-    "render": "81c80ad4-e8b9-4c9a-8bed-df7864fdefc6",
-}
+# Stable Prism Workflow output ids from assets/Outputs.kicad_jobset.  Keep this
+# public mapping immutable: project_service intentionally aliases this object.
+WORKFLOW_OUTPUT_IDS: Mapping[str, str] = MappingProxyType(
+    {
+        "design": "28dab1d3-7bf2-4d8a-9723-bcdd14e1d814",
+        "manufacturing": "9e5c254b-cb26-4a49-beea-fa7af8a62903",
+        "render": "81c80ad4-e8b9-4c9a-8bed-df7864fdefc6",
+    }
+)
 
-# Step types that never invoke an arbitrary external process. Hermeticity of a
-# release output still also requires every referenced input to resolve into the
-# closure or a pinned toolchain resource (R2b); R1 only classifies step types.
+
+class StepTypeStatus(str, Enum):
+    """R1 status for a KiCad job type in the pinned toolchain."""
+
+    HERMETIC = "hermetic"
+    NON_HERMETIC = "non_hermetic"
+    UNSUPPORTED = "unsupported"
+
+
+# KiCad 10.0.4's common/jobs REGISTER_JOB and REGISTER_DEPRECATED_JOB entries
+# (tag f7414d419cae5df2d00e7eaacb16fc0e803799bc).  These types do not invoke an
+# arbitrary external process themselves.  R2b still has to prove that their
+# file and library inputs are inside the release closure or pinned toolchain.
 HERMETIC_STEP_TYPES: frozenset[str] = frozenset(
     {
-        "sch_export_plot_pdf",
-        "sch_export_bom",
-        "sch_export_netlist",
-        "pcb_export_gerbers",
-        "pcb_export_drill",
-        "pcb_export_pos",
-        "pcb_export_pdf",
+        "pcb_drc",
         "pcb_export_3d",
+        "pcb_export_drill",
+        "pcb_export_dxf",
+        "pcb_export_gencad",
+        "pcb_export_gerbers",
+        "pcb_export_hpgl",
+        "pcb_export_ipc2581",
         "pcb_export_ipcd356",
         "pcb_export_odb",
-        "pcb_drc",
+        "pcb_export_pdf",
+        "pcb_export_pos",
+        "pcb_export_ps",
+        "pcb_export_stats",
+        "pcb_export_svg",
         "pcb_render",
         "sch_erc",
+        "sch_export_bom",
+        "sch_export_netlist",
+        "sch_export_plot_dxf",
+        "sch_export_plot_hpgl",
+        "sch_export_plot_pdf",
+        "sch_export_plot_ps",
+        "sch_export_plot_svg",
     }
+)
+
+
+# This is deliberately a typed registry, not an allowlist inferred from the
+# reference jobset.  A type absent from this mapping is unsupported for the
+# pinned KiCad 10.0.4 executor and must never become hermetic by default.
+KICAD_10_0_4_STEP_TYPE_STATUS: Mapping[str, StepTypeStatus] = MappingProxyType(
+    {
+        **{step_type: StepTypeStatus.HERMETIC for step_type in HERMETIC_STEP_TYPES},
+        "special_copyfiles": StepTypeStatus.NON_HERMETIC,
+        "special_execute": StepTypeStatus.NON_HERMETIC,
+    }
+)
+
+
+KICAD_10_0_4_JOB_TYPES: frozenset[str] = frozenset(
+    KICAD_10_0_4_STEP_TYPE_STATUS
 )
 
 
@@ -78,11 +121,45 @@ class NonHermeticReason:
 
 
 @dataclass(frozen=True)
+class UnsupportedReason:
+    """A job or destination reference Prism cannot safely classify."""
+
+    step_id: str | None
+    step_type: str | None
+    message: str
+    reference: str | None = None
+
+
+@dataclass(frozen=True)
+class StepTypeClassification:
+    """The typed R1 classification of one job type."""
+
+    step_type: str
+    status: StepTypeStatus
+    message: str
+
+    @property
+    def reason(self) -> str:
+        """Compatibility spelling for consumers that call this a reason."""
+
+        return self.message
+
+
+@dataclass(frozen=True)
 class OutputClosure:
     output_id: str
     jobs: tuple[JobsetJob, ...]
     hermetic: bool
     non_hermetic_reasons: tuple[NonHermeticReason, ...]
+    status: StepTypeStatus = StepTypeStatus.HERMETIC
+    unsupported_reasons: tuple[UnsupportedReason, ...] = ()
+    unresolved_references: tuple[str, ...] = ()
+
+    @property
+    def classification(self) -> StepTypeStatus:
+        """Return the status consumed by later release gates."""
+
+        return self.status
 
 
 def load_jobset(path: Path | str) -> JobsetModel:
@@ -171,48 +248,17 @@ def load_jobset(path: Path | str) -> JobsetModel:
 
 
 def step_closure_for_output(model: JobsetModel, output_id: str) -> tuple[JobsetJob, ...]:
-    """Return jobs selected by an output, recursively expanding nested outputs.
+    """Return jobs selected by a KiCad destination.
 
-    Expansion follows each output's ``only`` list. Job ids resolve to jobs;
-    output ids resolve to that nested output's closure. Cycles and unknown ids
-    raise ``ValueError``.
+    KiCad 10.0.4 treats ``only`` as a flat list of job ids.  Missing or empty
+    ``only`` means every job, while an unknown id is skipped.  Prism mirrors
+    that execution selection here; :func:`classify_output_hermetic` separately
+    records skipped ids as ``unsupported`` so they cannot silently make a
+    release appear hermetic.
     """
 
-    jobs_by_id = model.job_by_id()
-    outputs_by_id = model.output_by_id()
-    if output_id not in outputs_by_id:
-        raise ValueError(f"unknown jobset output id: {output_id!r}")
-
-    ordered: list[JobsetJob] = []
-    seen_jobs: set[str] = set()
-    visiting_outputs: set[str] = set()
-
-    def visit_output(current_output_id: str) -> None:
-        if current_output_id in visiting_outputs:
-            raise ValueError(
-                f"cyclic jobset output closure involving {current_output_id!r}"
-            )
-        output = outputs_by_id.get(current_output_id)
-        if output is None:
-            raise ValueError(f"unknown jobset output id: {current_output_id!r}")
-        visiting_outputs.add(current_output_id)
-        for reference in output.only:
-            if reference in outputs_by_id:
-                visit_output(reference)
-                continue
-            job = jobs_by_id.get(reference)
-            if job is None:
-                raise ValueError(
-                    f"output {current_output_id!r} references unknown id {reference!r}"
-                )
-            if job.id in seen_jobs:
-                continue
-            seen_jobs.add(job.id)
-            ordered.append(job)
-        visiting_outputs.remove(current_output_id)
-
-    visit_output(output_id)
-    return tuple(ordered)
+    jobs, _ = _selected_jobs_for_output(model, output_id)
+    return jobs
 
 
 def classify_output_hermetic(
@@ -221,28 +267,127 @@ def classify_output_hermetic(
     *,
     hermetic_step_types: Iterable[str] = HERMETIC_STEP_TYPES,
 ) -> OutputClosure:
-    """Classify whether an output's recursively selected steps are hermetic."""
+    """Classify an output without conflating unsafe and unsupported inputs."""
 
     allowed = frozenset(hermetic_step_types)
-    jobs = step_closure_for_output(model, output_id)
+    jobs, unresolved_references = _selected_jobs_for_output(model, output_id)
     reasons: list[NonHermeticReason] = []
+    unsupported_reasons: list[UnsupportedReason] = [
+        UnsupportedReason(
+            step_id=None,
+            step_type=None,
+            reference=reference,
+            message=(
+                f"output {output_id!r} references unknown job id {reference!r}; "
+                "KiCad skips it, but Release Studio fails closed"
+            ),
+        )
+        for reference in unresolved_references
+    ]
     for job in jobs:
-        if job.type not in allowed:
+        classification = classify_step_type(job.type)
+        if classification.status is StepTypeStatus.UNSUPPORTED:
+            unsupported_reasons.append(
+                UnsupportedReason(
+                    step_id=job.id,
+                    step_type=job.type,
+                    message=classification.message,
+                )
+            )
+        elif classification.status is StepTypeStatus.NON_HERMETIC:
+            reasons.append(
+                NonHermeticReason(
+                    step_id=job.id,
+                    step_type=job.type,
+                    message=classification.message,
+                )
+            )
+        elif job.type not in allowed:
+            # Keep the old injectable allowlist seam for characterization and
+            # callers that intentionally narrow the safe set.  It can never
+            # expand the KiCad registry or turn special/unknown types safe.
             reasons.append(
                 NonHermeticReason(
                     step_id=job.id,
                     step_type=job.type,
                     message=(
-                        f"step type {job.type!r} is outside HERMETIC_STEP_TYPES"
+                        f"step type {job.type!r} is outside the supplied "
+                        "hermetic_step_types"
                     ),
                 )
             )
+
+    if unsupported_reasons:
+        status = StepTypeStatus.UNSUPPORTED
+    elif reasons:
+        status = StepTypeStatus.NON_HERMETIC
+    else:
+        status = StepTypeStatus.HERMETIC
+
     return OutputClosure(
         output_id=output_id,
         jobs=jobs,
-        hermetic=not reasons,
+        hermetic=status is StepTypeStatus.HERMETIC,
         non_hermetic_reasons=tuple(reasons),
+        status=status,
+        unsupported_reasons=tuple(unsupported_reasons),
+        unresolved_references=unresolved_references,
     )
+
+
+def classify_step_type(step_type: str) -> StepTypeClassification:
+    """Classify one KiCad 10.0.4 job type for downstream release gates."""
+
+    status = KICAD_10_0_4_STEP_TYPE_STATUS.get(
+        step_type, StepTypeStatus.UNSUPPORTED
+    )
+    if status is StepTypeStatus.HERMETIC:
+        message = f"step type {step_type!r} is process-free in KiCad 10.0.4"
+    elif status is StepTypeStatus.NON_HERMETIC:
+        if step_type == "special_execute":
+            message = (
+                "step type 'special_execute' invokes an arbitrary external command"
+            )
+        else:
+            message = (
+                "step type 'special_copyfiles' may read arbitrary input paths; "
+                "R2b must prove those paths before it can be hermetic"
+            )
+    else:
+        message = (
+            f"step type {step_type!r} is not registered by the pinned KiCad "
+            "10.0.4 job registry"
+        )
+    return StepTypeClassification(step_type=step_type, status=status, message=message)
+
+
+def _selected_jobs_for_output(
+    model: JobsetModel, output_id: str
+) -> tuple[tuple[JobsetJob, ...], tuple[str, ...]]:
+    """Return KiCad-compatible selected jobs and unresolved ``only`` ids."""
+
+    outputs_by_id = model.output_by_id()
+    output = outputs_by_id.get(output_id)
+    if output is None:
+        raise ValueError(f"unknown jobset output id: {output_id!r}")
+
+    # This is KiCad's explicit default in JOBSET::GetJobsForDestination: an
+    # omitted or empty `only` list runs every job, including special jobs.
+    if not output.only:
+        return model.jobs, ()
+
+    jobs_by_id = model.job_by_id()
+    selected: list[JobsetJob] = []
+    unresolved: list[str] = []
+    for reference in output.only:
+        # Jobs take precedence by construction. Output ids are not execution
+        # references in KiCad and must never trigger invented recursion.
+        job = jobs_by_id.get(reference)
+        if job is None:
+            unresolved.append(reference)
+            continue
+        selected.append(job)
+    return tuple(selected), tuple(unresolved)
 
 
 def workflow_output_id(workflow_type: str) -> str:

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 from git import Repo
 from pydantic import BaseModel
 
+from app.release_studio.jobset import WORKFLOW_OUTPUT_IDS as _WORKFLOW_OUTPUT_IDS
 from app.services import kicad_jobset_service, path_config_service, semantic_index_service
 from app.services.workspace_service import workspace
 from app.services.job_artifact_service import job_artifacts
@@ -731,9 +732,6 @@ def run_semantic_index_job_v3(context: JobContext) -> JobResult:
             "generator": result.get("generator"),
         },
     )
-
-
-from app.release_studio.jobset import WORKFLOW_OUTPUT_IDS as _WORKFLOW_OUTPUT_IDS
 
 
 def run_kicad_workflow_job_v3(context: JobContext) -> JobResult:

--- a/backend/tests/test_release_studio_jobset.py
+++ b/backend/tests/test_release_studio_jobset.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 from app.release_studio.jobset import (
     HERMETIC_STEP_TYPES,
+    KICAD_10_0_4_JOB_TYPES,
+    KICAD_10_0_4_STEP_TYPE_STATUS,
+    StepTypeStatus,
     WORKFLOW_OUTPUT_IDS,
+    classify_step_type,
     classify_output_hermetic,
     load_jobset,
     step_closure_for_output,
@@ -37,17 +41,11 @@ class ReleaseStudioJobsetTests(unittest.TestCase):
             self.assertIn(output_id, output_ids)
             self.assertEqual(workflow_output_id(workflow_type), output_id)
 
-        project_service_source = (
-            REPO_ROOT / "backend" / "app" / "services" / "project_service.py"
-        ).read_text(encoding="utf-8")
-        self.assertIn(
-            "from app.release_studio.jobset import WORKFLOW_OUTPUT_IDS as _WORKFLOW_OUTPUT_IDS",
-            project_service_source,
-        )
-        self.assertNotIn(
-            '"design": "28dab1d3-7bf2-4d8a-9723-bcdd14e1d814"',
-            project_service_source,
-        )
+        from app.services import project_service
+
+        self.assertIs(project_service._WORKFLOW_OUTPUT_IDS, WORKFLOW_OUTPUT_IDS)
+        with self.assertRaises(TypeError):
+            WORKFLOW_OUTPUT_IDS["new-workflow"] = "must-not-mutate"  # type: ignore[index]
 
     def test_reference_outputs_are_hermetic_despite_unreferenced_special_execute(
         self,
@@ -60,7 +58,9 @@ class ReleaseStudioJobsetTests(unittest.TestCase):
         for output_id in WORKFLOW_OUTPUT_IDS.values():
             closure = classify_output_hermetic(model, output_id)
             self.assertTrue(closure.hermetic, output_id)
+            self.assertIs(closure.status, StepTypeStatus.HERMETIC)
             self.assertEqual(closure.non_hermetic_reasons, ())
+            self.assertEqual(closure.unsupported_reasons, ())
             closed_ids = {job.id for job in closure.jobs}
             self.assertTrue(closed_ids.isdisjoint(special_ids), output_id)
             self.assertEqual(
@@ -84,15 +84,9 @@ class ReleaseStudioJobsetTests(unittest.TestCase):
             ],
             "outputs": [
                 {
-                    "id": "nested-safe",
-                    "type": "folder",
-                    "only": ["safe-job"],
-                    "settings": {},
-                },
-                {
                     "id": "with-special",
                     "type": "folder",
-                    "only": ["nested-safe", "unsafe-job"],
+                    "only": ["safe-job", "unsafe-job"],
                     "settings": {},
                 },
             ],
@@ -103,12 +97,9 @@ class ReleaseStudioJobsetTests(unittest.TestCase):
             path.write_text(json.dumps(payload), encoding="utf-8")
             model = load_jobset(path)
 
-            nested = classify_output_hermetic(model, "nested-safe")
-            self.assertTrue(nested.hermetic)
-            self.assertEqual([job.id for job in nested.jobs], ["safe-job"])
-
             flagged = classify_output_hermetic(model, "with-special")
             self.assertFalse(flagged.hermetic)
+            self.assertIs(flagged.status, StepTypeStatus.NON_HERMETIC)
             self.assertEqual(
                 [job.id for job in flagged.jobs],
                 ["safe-job", "unsafe-job"],
@@ -117,25 +108,136 @@ class ReleaseStudioJobsetTests(unittest.TestCase):
             reason = flagged.non_hermetic_reasons[0]
             self.assertEqual(reason.step_id, "unsafe-job")
             self.assertEqual(reason.step_type, "special_execute")
-
-            # Recursive expansion must visit nested outputs before sibling jobs.
             self.assertEqual(
                 [job.id for job in step_closure_for_output(model, "with-special")],
                 ["safe-job", "unsafe-job"],
             )
 
-    def test_unknown_and_cyclic_closures_raise(self) -> None:
+    def test_missing_or_empty_only_selects_every_job(self) -> None:
         payload = {
-            "jobs": [{"id": "job-a", "type": "pcb_drc", "settings": {}}],
+            "jobs": [
+                {"id": "safe-job", "type": "pcb_export_stats", "settings": {}},
+                {
+                    "id": "unsafe-job",
+                    "type": "special_execute",
+                    "settings": {"command": "echo hi"},
+                },
+            ],
+            "outputs": [
+                {"id": "missing-only", "type": "folder", "settings": {}},
+                {"id": "empty-only", "type": "folder", "only": [], "settings": {}},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "default-selection.kicad_jobset"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            model = load_jobset(path)
+
+            for output_id in ("missing-only", "empty-only"):
+                self.assertEqual(
+                    [job.id for job in step_closure_for_output(model, output_id)],
+                    ["safe-job", "unsafe-job"],
+                )
+                closure = classify_output_hermetic(model, output_id)
+                self.assertFalse(closure.hermetic)
+                self.assertIs(closure.status, StepTypeStatus.NON_HERMETIC)
+                self.assertEqual(
+                    [(reason.step_id, reason.step_type)
+                     for reason in closure.non_hermetic_reasons],
+                    [("unsafe-job", "special_execute")],
+                )
+
+    def test_kicad_10_0_4_registry_classification_is_explicit(self) -> None:
+        expected_hermetic = {
+            "pcb_drc",
+            "pcb_export_3d",
+            "pcb_export_drill",
+            "pcb_export_dxf",
+            "pcb_export_gencad",
+            "pcb_export_gerbers",
+            "pcb_export_hpgl",
+            "pcb_export_ipc2581",
+            "pcb_export_ipcd356",
+            "pcb_export_odb",
+            "pcb_export_pdf",
+            "pcb_export_pos",
+            "pcb_export_ps",
+            "pcb_export_stats",
+            "pcb_export_svg",
+            "pcb_render",
+            "sch_erc",
+            "sch_export_bom",
+            "sch_export_netlist",
+            "sch_export_plot_dxf",
+            "sch_export_plot_hpgl",
+            "sch_export_plot_pdf",
+            "sch_export_plot_ps",
+            "sch_export_plot_svg",
+        }
+        self.assertEqual(HERMETIC_STEP_TYPES, frozenset(expected_hermetic))
+        self.assertEqual(
+            KICAD_10_0_4_JOB_TYPES,
+            expected_hermetic | {"special_copyfiles", "special_execute"},
+        )
+        self.assertEqual(
+            set(KICAD_10_0_4_STEP_TYPE_STATUS),
+            KICAD_10_0_4_JOB_TYPES,
+        )
+
+        for step_type in expected_hermetic:
+            classification = classify_step_type(step_type)
+            self.assertIs(classification.status, StepTypeStatus.HERMETIC)
+
+        for step_type in ("special_copyfiles", "special_execute"):
+            classification = classify_step_type(step_type)
+            self.assertIs(classification.status, StepTypeStatus.NON_HERMETIC)
+
+        unknown = classify_step_type("customer_plugin_job")
+        self.assertIs(unknown.status, StepTypeStatus.UNSUPPORTED)
+
+    def test_unknown_types_are_unsupported_not_non_hermetic(self) -> None:
+        payload = {
+            "jobs": [
+                {"id": "unknown-job", "type": "customer_plugin_job", "settings": {}},
+            ],
+            "outputs": [
+                {
+                    "id": "unknown-type-output",
+                    "type": "folder",
+                    "only": ["unknown-job"],
+                    "settings": {},
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "unknown-type.kicad_jobset"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            closure = classify_output_hermetic(
+                load_jobset(path), "unknown-type-output"
+            )
+
+        self.assertFalse(closure.hermetic)
+        self.assertIs(closure.status, StepTypeStatus.UNSUPPORTED)
+        self.assertEqual(closure.non_hermetic_reasons, ())
+        self.assertEqual(len(closure.unsupported_reasons), 1)
+        reason = closure.unsupported_reasons[0]
+        self.assertEqual(reason.step_id, "unknown-job")
+        self.assertEqual(reason.step_type, "customer_plugin_job")
+
+    def test_only_is_flat_jobs_take_precedence_and_unknown_ids_fail_closed(self) -> None:
+        payload = {
+            "jobs": [
+                {"id": "shared-id", "type": "pcb_export_svg", "settings": {}},
+            ],
             "outputs": [
                 {
                     "id": "out-a",
                     "type": "folder",
-                    "only": ["out-b"],
+                    "only": ["shared-id", "missing-id"],
                     "settings": {},
                 },
                 {
-                    "id": "out-b",
+                    "id": "shared-id",
                     "type": "folder",
                     "only": ["out-a"],
                     "settings": {},
@@ -143,11 +245,21 @@ class ReleaseStudioJobsetTests(unittest.TestCase):
             ],
         }
         with tempfile.TemporaryDirectory() as temporary:
-            path = Path(temporary) / "cycle.kicad_jobset"
+            path = Path(temporary) / "flat-only.kicad_jobset"
             path.write_text(json.dumps(payload), encoding="utf-8")
             model = load_jobset(path)
-            with self.assertRaisesRegex(ValueError, "cyclic"):
-                step_closure_for_output(model, "out-a")
+            self.assertEqual(
+                [job.id for job in step_closure_for_output(model, "out-a")],
+                ["shared-id"],
+            )
+            closure = classify_output_hermetic(model, "out-a")
+            self.assertIs(closure.status, StepTypeStatus.UNSUPPORTED)
+            self.assertEqual(closure.unresolved_references, ("missing-id",))
+            self.assertEqual(
+                closure.unsupported_reasons[0].reference,
+                "missing-id",
+            )
+
             with self.assertRaisesRegex(ValueError, "unknown jobset output"):
                 step_closure_for_output(model, "missing")
 

--- a/docs/release-studio/R1.md
+++ b/docs/release-studio/R1.md
@@ -1,14 +1,14 @@
-# Release Studio R1: jobset model and hermetic step closures
+# Release Studio R1/R1b: jobset model and hermetic step closures
 
 R1 introduces a typed `.kicad_jobset` model and evaluates hermeticity over the
-**recursively selected output closure**, not over jobs that merely exist in the
-file.
+jobs selected by a destination. R1b aligns that selection with KiCad 10.0.4:
+destinations contain a flat list of job ids, not references to other outputs.
 
 ## Owned surface
 
 | Path | Role |
 | --- | --- |
-| `backend/app/release_studio/jobset.py` | Parse jobset, `step_closure_for_output`, `HERMETIC_STEP_TYPES`, `classify_output_hermetic` |
+| `backend/app/release_studio/jobset.py` | Parse jobset, KiCad-compatible destination selection, typed step/status classification, `HERMETIC_STEP_TYPES`, `classify_output_hermetic` |
 | `backend/app/services/project_service.py` | Imports `WORKFLOW_OUTPUT_IDS` instead of duplicating the three UUIDs |
 | `backend/tests/test_release_studio_jobset.py` | Acceptance tests |
 | `docs/release-studio/R1.md` | This note |
@@ -26,21 +26,44 @@ file.
 
 ## Closures and hermeticity
 
-`step_closure_for_output(model, output_id)` walks each output's `only` list:
+`step_closure_for_output(model, output_id)` follows KiCad 10.0.4's
+`JOBSET::GetJobsForDestination` behavior:
 
-- a job id contributes that job once (first occurrence wins order);
-- an output id expands that nested output's closure;
-- unknown ids and cycles raise.
+- if `only` is missing or `[]`, every job is selected in jobset order;
+- otherwise, each flat job id selects that job in `only` order;
+- a job id wins if it happens to have the same text as an output id;
+- unknown ids are skipped for execution, just as KiCad skips them;
+- output-to-output recursion and cycle detection are deliberately not modeled.
 
-`HERMETIC_STEP_TYPES` is the set of KiCad step types that never run an arbitrary
-external process. `special_execute` is intentionally excluded. R1 classifies an
-output as hermetic iff every job in its closure has a hermetic step type.
-Full input-path hermeticity (host libraries, LFS, env) arrives in R2b.
+`classify_output_hermetic` records skipped ids as `unsupported`, so the
+execution-compatible skip cannot silently make a Prism release hermetic. A
+truly unknown job type is also `unsupported`; it is not reported as a
+non-hermetic process. The status API is:
+
+| Status | Meaning |
+| --- | --- |
+| `hermetic` | Registered process-free KiCad 10.0.4 type; R2b input checks still apply |
+| `non_hermetic` | `special_execute`, or `special_copyfiles` pending R2b path proof |
+| `unsupported` | Unknown job type or unresolved `only` id; release gates fail closed |
+
+`HERMETIC_STEP_TYPES` is an immutable `frozenset` of the 24 process-free
+types registered by KiCad 10.0.4 (including `pcb_export_stats`,
+`pcb_export_svg`, and `pcb_export_ipc2581`). The typed
+`KICAD_10_0_4_STEP_TYPE_STATUS` mapping additionally records the two special
+types. The registry was checked against the local KiCad tag
+`f7414d419cae5df2d00e7eaacb16fc0e803799bc` in `common/jobs/*.cpp`.
+
+R1b classifies an output as hermetic only when its selected jobs have no
+non-hermetic reasons and no unsupported reasons. The `status` field remains
+available to R11/R13 so `unsupported` is not conflated with a genuine
+non-hermetic finding. Full input-path hermeticity (host libraries, LFS, env)
+arrives in R2b.
 
 The reference jobset contains a `special_execute` iBoM job that is **not**
 referenced by any of the three workflow outputs, so those outputs remain
-hermetic. An output whose recursive `only` includes that step is flagged with a
-`NonHermeticReason`.
+hermetic. A destination with no `only` or `only: []` selects that job and is
+therefore non-hermetic, matching KiCad's execute-all default. A destination
+whose selected jobs include it is flagged with a `NonHermeticReason`.
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- match KiCad 10.0.4 empty/missing `only` and flat job selection semantics
- classify all 26 registered job types explicitly (24 process-free, 2 non-hermetic)
- fail closed for unknown types and unknown output references
- replace brittle source-text assertions and freeze the workflow output map

## Verification
- 18 focused job-set/service tests pass in the pinned backend image
- implementation registry checked against exact KiCad 10.0.4 source tag
- `git diff --check` passes