### PR TITLE
fix(release-studio): harden audit and approval migration contracts

### DIFF
--- a/backend/app/services/workspace_schema_migrations.py
+++ b/backend/app/services/workspace_schema_migrations.py
@@ -1012,6 +1012,53 @@ def _release_studio(conn: Any) -> None:
     )
 
 
+def _preflight_release_studio_audit_history(conn: Any) -> None:
+    """Reject M8 audit rows that M9 cannot validate without rewriting them.
+
+    Sequence and previous-hash values are part of the audit chain.  Rebuilding
+    either value during a schema migration would fabricate a different chain,
+    so M9 fails before changing any data when an existing stream violates the
+    shape of its new CHECK constraints.
+    """
+
+    row = conn.execute(
+        """
+        SELECT project_id,
+               config_key,
+               sequence,
+               CASE
+                   WHEN sequence IS NULL OR sequence <= 0
+                       THEN 'sequence_must_be_positive'
+                   WHEN sequence = 1 AND previous_hash IS NOT NULL
+                       THEN 'genesis_previous_hash_must_be_null'
+                   ELSE 'non_genesis_previous_hash_must_be_nonblank'
+               END AS violation
+        FROM ws_release_audit_events
+        WHERE sequence IS NULL
+           OR sequence <= 0
+           OR (sequence = 1 AND previous_hash IS NOT NULL)
+           OR (
+               sequence > 1
+               AND (previous_hash IS NULL OR btrim(previous_hash) = '')
+           )
+        ORDER BY project_id, config_key, sequence, id
+        LIMIT 1
+        """
+    ).fetchone()
+    if row is None:
+        return
+
+    raise RuntimeError(
+        "Migration 9 precondition failed: ws_release_audit_events contains "
+        "an invalid existing audit row "
+        f"(project_id={row['project_id']!r}, "
+        f"config_key={row['config_key']!r}, sequence={row['sequence']!r}, "
+        f"violation={row['violation']}). Migration 9 does not backfill audit "
+        "sequence or hash fields; repair or archive the M8 audit history with "
+        "an approved data-migration procedure before retrying."
+    )
+
+
 def _release_studio_hardening(conn: Any) -> None:
     """Harden the Release Studio schema introduced by Migration 8.
 
@@ -1019,6 +1066,11 @@ def _release_studio_hardening(conn: Any) -> None:
     repairs its already-applied data and constraints in place before later
     Release Studio writers depend on the stricter contracts.
     """
+
+    # Audit sequence and hash fields are chain material, not ordinary
+    # backfillable data.  Fail before any M9 repair or constraint validation so
+    # a bad M8 stream cannot be silently rewritten or partially migrated.
+    _preflight_release_studio_audit_history(conn)
 
     # Drop the Migration 8 outcome CHECK before rewriting legacy values; the
     # old vocabulary rejects the canonical replacements.
@@ -1407,6 +1459,64 @@ def _release_studio_hardening(conn: Any) -> None:
     )
 
 
+def _release_studio_approval_hardening(conn: Any) -> None:
+    """Append Migration 10's explicit approval decision contract.
+
+    ``emergency_override`` was present in the shipped M9 vocabulary without a
+    documented contract.  Preserve it for compatibility, but only as an
+    exceptional, reasoned decision; later approval-gate code must not count it
+    as an ordinary required approval.
+    """
+
+    row = conn.execute(
+        """
+        SELECT id
+        FROM ws_release_approvals
+        WHERE decision = 'emergency_override'
+          AND NULLIF(btrim(self_approval_override_reason), '') IS NULL
+        ORDER BY id
+        LIMIT 1
+        """
+    ).fetchone()
+    if row is not None:
+        raise RuntimeError(
+            "Migration 10 precondition failed: ws_release_approvals row "
+            f"{row['id']!r} uses emergency_override without a nonblank "
+            "self_approval_override_reason. Add the approved override reason "
+            "or remediate that exceptional decision before retrying."
+        )
+
+    # M9 is already shipped, so replace its narrower CHECK rather than editing
+    # the historical migration.  No rows are rewritten by this migration.
+    conn.execute(
+        "ALTER TABLE ws_release_approvals "
+        "DROP CONSTRAINT IF EXISTS ck_ws_release_approvals_decision_vocabulary"
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_approvals
+            ADD CONSTRAINT ck_ws_release_approvals_decision_vocabulary
+            CHECK (decision IN (
+                'approved', 'rejected', 'changes_requested', 'emergency_override'
+            ))
+        """
+    )
+    conn.execute(
+        "ALTER TABLE ws_release_approvals "
+        "DROP CONSTRAINT IF EXISTS ck_ws_release_approvals_override_reason"
+    )
+    conn.execute(
+        """
+        ALTER TABLE ws_release_approvals
+            ADD CONSTRAINT ck_ws_release_approvals_override_reason
+            CHECK (
+                decision <> 'emergency_override'
+                OR NULLIF(btrim(self_approval_override_reason), '') IS NOT NULL
+            )
+        """
+    )
+
+
 MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (1, "v3_job_foundation", _v3_job_foundation),
     (2, "workspace_read_versions", _workspace_read_versions),
@@ -1417,6 +1527,7 @@ MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (7, "generated_thumbnail_default", _generated_thumbnail_default),
     (8, "release_studio", _release_studio),
     (9, "release_studio_hardening", _release_studio_hardening),
+    (10, "release_studio_approval_hardening", _release_studio_approval_hardening),
 )
 
 

--- a/backend/tests/test_release_studio_schema_migration.py
+++ b/backend/tests/test_release_studio_schema_migration.py
@@ -22,6 +22,7 @@ except ImportError:  # pragma: no cover - dependency guard for host-only checks
 from app.services.workspace_schema_migrations import (  # noqa: E402
     MIGRATIONS,
     _release_studio,
+    _release_studio_approval_hardening,
     _release_studio_hardening,
     apply_workspace_migrations,
 )
@@ -480,7 +481,7 @@ EXPECTED_FKS = {
     "TEST_POSTGRES_URL must not target PRISM_DATABASE_URL",
 )
 class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
-    """Run Migrations 8 and 9 against a disposable test schema."""
+    """Run Release Studio Migrations 8 through 10 against isolated PostgreSQL."""
 
     def setUp(self) -> None:
         assert psycopg is not None
@@ -775,6 +776,7 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             "ck_ws_release_findings_severity_vocabulary",
             "ck_ws_release_findings_status_vocabulary",
             "ck_ws_release_approvals_decision_vocabulary",
+            "ck_ws_release_approvals_override_reason",
             "ck_ws_release_policy_versions_publication_provenance",
             "ck_ws_release_records_signature_key_pair",
             "ck_ws_release_audit_events_sequence_positive",
@@ -789,6 +791,10 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
         ):
             self.assertIn(constraint, constraint_definitions)
         self.assertIn("sequence > 0", constraint_definitions["ck_ws_release_audit_events_sequence_positive"])
+        self.assertIn(
+            "rejected",
+            constraint_definitions["ck_ws_release_approvals_decision_vocabulary"],
+        )
         self.assertIn(
             "previous_hash",
             constraint_definitions["ck_ws_release_audit_events_genesis_previous_hash"],
@@ -1304,7 +1310,10 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             ),
         )
 
-        for index, decision in enumerate(("changes_requested", "emergency_override"), start=1):
+        for index, decision in enumerate(
+            ("approved", "rejected", "changes_requested"),
+            start=1,
+        ):
             self.conn.execute(
                 """
                 INSERT INTO ws_release_approvals(
@@ -1323,6 +1332,42 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
                     f"approval-digest-{index}-{uuid.uuid4().hex}",
                 ),
             )
+        self.conn.execute(
+            """
+            INSERT INTO ws_release_approvals(
+                id, project_id, config_key, candidate_id, build_id, role,
+                decision, approver, self_approval_override_reason,
+                policy_binding_digest
+            )
+            VALUES (%s, %s, 'default', %s, %s, 'engineering',
+                    'emergency_override', 'approver@example.test',
+                    'incident-2026-08-11: release owner unavailable', %s)
+            """,
+            (
+                f"approval-vocabulary-emergency-{uuid.uuid4().hex}",
+                ids["project"],
+                ids["candidate"],
+                ids["build"],
+                f"approval-emergency-digest-{uuid.uuid4().hex}",
+            ),
+        )
+        self._assert_rejected(
+            """
+            INSERT INTO ws_release_approvals(
+                id, project_id, config_key, candidate_id, build_id, role,
+                decision, approver, policy_binding_digest
+            )
+            VALUES (%s, %s, 'default', %s, %s, 'engineering',
+                    'emergency_override', 'approver@example.test', %s)
+            """,
+            (
+                f"approval-emergency-without-reason-{uuid.uuid4().hex}",
+                ids["project"],
+                ids["candidate"],
+                ids["build"],
+                f"approval-emergency-invalid-digest-{uuid.uuid4().hex}",
+            ),
+        )
         self._assert_rejected(
             """
             INSERT INTO ws_release_approvals(
@@ -1615,6 +1660,8 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
 
             _release_studio_hardening(self.conn)
             _release_studio_hardening(self.conn)
+            _release_studio_approval_hardening(self.conn)
+            _release_studio_approval_hardening(self.conn)
 
             evaluation = self.conn.execute(
                 "SELECT outcome FROM ws_release_evaluations WHERE id = %s",
@@ -1648,9 +1695,232 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             self.conn.execute(f'DROP SCHEMA IF EXISTS "{legacy_schema}" CASCADE')
             self.conn.commit()
 
+    def test_m9_preflights_invalid_m8_audit_rows_without_rewriting_chain_data(self) -> None:
+        legacy_schema = f"release_r3_invalid_audit_{uuid.uuid4().hex}"
+        self.conn.execute(f'CREATE SCHEMA "{legacy_schema}"')
+        try:
+            self.conn.execute(f'SET search_path TO "{legacy_schema}", public')
+            self._create_base_workspace_tables()
+            for version, _, migration in MIGRATIONS:
+                if version <= 8:
+                    migration(self.conn)
+
+            self.conn.execute("INSERT INTO ws_repositories(id) VALUES ('audit-repository')")
+            self.conn.execute(
+                "INSERT INTO ws_projects(id, repo_id) VALUES ('audit-project', 'audit-repository')"
+            )
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_audit_events(
+                    id, project_id, config_key, sequence, event_type, actor,
+                    subject_kind, subject_id, previous_hash, event_hash, created_at_iso
+                )
+                VALUES (
+                    'audit-invalid-sequence', 'audit-project', 'default', 0,
+                    'release.created', 'migration-test', 'release',
+                    'release-1', NULL, 'event-hash-0', '2026-01-01T00:00:00Z'
+                )
+                """
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"Migration 9 precondition failed: .*sequence=0.*sequence_must_be_positive",
+            ):
+                _release_studio_hardening(self.conn)
+
+            row = self.conn.execute(
+                """
+                SELECT sequence, previous_hash
+                FROM ws_release_audit_events
+                WHERE id = 'audit-invalid-sequence'
+                """
+            ).fetchone()
+            self.assertEqual(row["sequence"], 0)
+            self.assertIsNone(row["previous_hash"])
+            constraint = self.conn.execute(
+                """
+                SELECT 1
+                FROM pg_constraint AS constraint_row
+                JOIN pg_class AS table_row
+                  ON table_row.oid = constraint_row.conrelid
+                JOIN pg_namespace AS namespace_row
+                  ON namespace_row.oid = table_row.relnamespace
+                WHERE namespace_row.nspname = %s
+                  AND table_row.relname = 'ws_release_audit_events'
+                  AND constraint_row.conname = 'ck_ws_release_audit_events_sequence_positive'
+                """,
+                (legacy_schema,),
+            ).fetchone()
+            self.assertIsNone(constraint)
+        finally:
+            self.conn.rollback()
+            self.conn.execute(f'SET search_path TO "{self.schema}", public')
+            self.conn.execute(f'DROP SCHEMA IF EXISTS "{legacy_schema}" CASCADE')
+            self.conn.commit()
+
+    def test_v9_rows_upgrade_m10_adds_rejected_and_preserves_reasoned_override(self) -> None:
+        legacy_schema = f"release_r3_m10_{uuid.uuid4().hex}"
+        self.conn.execute(f'CREATE SCHEMA "{legacy_schema}"')
+        try:
+            self.conn.execute(f'SET search_path TO "{legacy_schema}", public')
+            self._create_base_workspace_tables()
+            for version, _, migration in MIGRATIONS:
+                if version <= 9:
+                    migration(self.conn)
+            ids = self._seed_release_graph()
+            emergency_id = f"approval-m10-emergency-{uuid.uuid4().hex}"
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_approvals(
+                    id, project_id, config_key, candidate_id, build_id, role,
+                    decision, approver, self_approval_override_reason,
+                    policy_binding_digest
+                )
+                VALUES (%s, %s, 'default', %s, %s, 'engineering',
+                        'emergency_override', 'approver@example.test',
+                        'incident-2026-08-11: emergency release authority', %s)
+                """,
+                (
+                    emergency_id,
+                    ids["project"],
+                    ids["candidate"],
+                    ids["build"],
+                    f"m10-emergency-digest-{uuid.uuid4().hex}",
+                ),
+            )
+
+            _release_studio_approval_hardening(self.conn)
+            _release_studio_approval_hardening(self.conn)
+            rejected_id = f"approval-m10-rejected-{uuid.uuid4().hex}"
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_approvals(
+                    id, project_id, config_key, candidate_id, build_id, role,
+                    decision, approver, policy_binding_digest
+                )
+                VALUES (%s, %s, 'default', %s, %s, 'engineering',
+                        'rejected', 'approver@example.test', %s)
+                """,
+                (
+                    rejected_id,
+                    ids["project"],
+                    ids["candidate"],
+                    ids["build"],
+                    f"m10-rejected-digest-{uuid.uuid4().hex}",
+                ),
+            )
+            self._assert_rejected(
+                """
+                INSERT INTO ws_release_approvals(
+                    id, project_id, config_key, candidate_id, build_id, role,
+                    decision, approver, policy_binding_digest
+                )
+                VALUES (%s, %s, 'default', %s, %s, 'engineering',
+                        'emergency_override', 'approver@example.test', %s)
+                """,
+                (
+                    f"approval-m10-blank-reason-{uuid.uuid4().hex}",
+                    ids["project"],
+                    ids["candidate"],
+                    ids["build"],
+                    f"m10-blank-reason-digest-{uuid.uuid4().hex}",
+                ),
+            )
+            stored = self.conn.execute(
+                """
+                SELECT decision, self_approval_override_reason
+                FROM ws_release_approvals
+                WHERE id IN (%s, %s)
+                ORDER BY id
+                """,
+                (emergency_id, rejected_id),
+            ).fetchall()
+            self.assertEqual(
+                {(row["decision"], row["self_approval_override_reason"]) for row in stored},
+                {
+                    (
+                        "emergency_override",
+                        "incident-2026-08-11: emergency release authority",
+                    ),
+                    ("rejected", None),
+                },
+            )
+        finally:
+            self.conn.rollback()
+            self.conn.execute(f'SET search_path TO "{self.schema}", public')
+            self.conn.execute(f'DROP SCHEMA IF EXISTS "{legacy_schema}" CASCADE')
+            self.conn.commit()
+
+    def test_m10_rejects_existing_blank_emergency_override_before_constraint_change(self) -> None:
+        legacy_schema = f"release_r3_m10_invalid_{uuid.uuid4().hex}"
+        self.conn.execute(f'CREATE SCHEMA "{legacy_schema}"')
+        try:
+            self.conn.execute(f'SET search_path TO "{legacy_schema}", public')
+            self._create_base_workspace_tables()
+            for version, _, migration in MIGRATIONS:
+                if version <= 9:
+                    migration(self.conn)
+            ids = self._seed_release_graph()
+            self.conn.execute(
+                """
+                INSERT INTO ws_release_approvals(
+                    id, project_id, config_key, candidate_id, build_id, role,
+                    decision, approver, policy_binding_digest
+                )
+                VALUES ('approval-m10-invalid', %s, 'default', %s, %s,
+                        'engineering', 'emergency_override',
+                        'approver@example.test', 'm10-invalid-digest')
+                """,
+                (ids["project"], ids["candidate"], ids["build"]),
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"Migration 10 precondition failed: .*approval-m10-invalid.*nonblank",
+            ):
+                _release_studio_approval_hardening(self.conn)
+
+            old_constraint = self.conn.execute(
+                """
+                SELECT 1
+                FROM pg_constraint AS constraint_row
+                JOIN pg_class AS table_row
+                  ON table_row.oid = constraint_row.conrelid
+                JOIN pg_namespace AS namespace_row
+                  ON namespace_row.oid = table_row.relnamespace
+                WHERE namespace_row.nspname = %s
+                  AND table_row.relname = 'ws_release_approvals'
+                  AND constraint_row.conname = 'ck_ws_release_approvals_decision_vocabulary'
+                """,
+                (legacy_schema,),
+            ).fetchone()
+            self.assertIsNotNone(old_constraint)
+            self.assertIsNone(
+                self.conn.execute(
+                    """
+                    SELECT 1
+                    FROM pg_constraint AS constraint_row
+                    JOIN pg_class AS table_row
+                      ON table_row.oid = constraint_row.conrelid
+                    JOIN pg_namespace AS namespace_row
+                      ON namespace_row.oid = table_row.relnamespace
+                    WHERE namespace_row.nspname = %s
+                      AND table_row.relname = 'ws_release_approvals'
+                      AND constraint_row.conname = 'ck_ws_release_approvals_override_reason'
+                    """,
+                    (legacy_schema,),
+                ).fetchone()
+            )
+        finally:
+            self.conn.rollback()
+            self.conn.execute(f'SET search_path TO "{self.schema}", public')
+            self.conn.execute(f'DROP SCHEMA IF EXISTS "{legacy_schema}" CASCADE')
+            self.conn.commit()
+
 
 class ReleaseStudioMigrationLadderTests(unittest.TestCase):
-    def test_migration_9_is_named_and_follows_migrations_1_to_8(self) -> None:
+    def test_migration_10_is_named_and_follows_migrations_1_to_9(self) -> None:
         self.assertEqual(
             [(version, name) for version, name, _ in MIGRATIONS],
             [
@@ -1663,6 +1933,7 @@ class ReleaseStudioMigrationLadderTests(unittest.TestCase):
                 (7, "generated_thumbnail_default"),
                 (8, "release_studio"),
                 (9, "release_studio_hardening"),
+                (10, "release_studio_approval_hardening"),
             ],
         )
 

--- a/backend/tests/test_release_studio_schema_migration.py
+++ b/backend/tests/test_release_studio_schema_migration.py
@@ -1696,68 +1696,82 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
             self.conn.commit()
 
     def test_m9_preflights_invalid_m8_audit_rows_without_rewriting_chain_data(self) -> None:
-        legacy_schema = f"release_r3_invalid_audit_{uuid.uuid4().hex}"
-        self.conn.execute(f'CREATE SCHEMA "{legacy_schema}"')
-        try:
-            self.conn.execute(f'SET search_path TO "{legacy_schema}", public')
-            self._create_base_workspace_tables()
-            for version, _, migration in MIGRATIONS:
-                if version <= 8:
-                    migration(self.conn)
+        cases = (
+            ("nonpositive_sequence", 0, None, "sequence_must_be_positive"),
+            ("non_null_genesis", 1, "not-genesis", "genesis_previous_hash_must_be_null"),
+            ("null_non_genesis", 2, None, "non_genesis_previous_hash_must_be_nonblank"),
+            ("blank_non_genesis", 2, "   ", "non_genesis_previous_hash_must_be_nonblank"),
+        )
+        for label, sequence, previous_hash, expected_violation in cases:
+            with self.subTest(violation=label):
+                legacy_schema = f"release_r3_invalid_audit_{label}_{uuid.uuid4().hex}"
+                self.conn.execute(f'CREATE SCHEMA "{legacy_schema}"')
+                try:
+                    self.conn.execute(f'SET search_path TO "{legacy_schema}", public')
+                    self._create_base_workspace_tables()
+                    for version, _, migration in MIGRATIONS:
+                        if version <= 8:
+                            migration(self.conn)
 
-            self.conn.execute("INSERT INTO ws_repositories(id) VALUES ('audit-repository')")
-            self.conn.execute(
-                "INSERT INTO ws_projects(id, repo_id) VALUES ('audit-project', 'audit-repository')"
-            )
-            self.conn.execute(
-                """
-                INSERT INTO ws_release_audit_events(
-                    id, project_id, config_key, sequence, event_type, actor,
-                    subject_kind, subject_id, previous_hash, event_hash, created_at_iso
-                )
-                VALUES (
-                    'audit-invalid-sequence', 'audit-project', 'default', 0,
-                    'release.created', 'migration-test', 'release',
-                    'release-1', NULL, 'event-hash-0', '2026-01-01T00:00:00Z'
-                )
-                """
-            )
+                    self.conn.execute("INSERT INTO ws_repositories(id) VALUES ('audit-repository')")
+                    self.conn.execute(
+                        "INSERT INTO ws_projects(id, repo_id) VALUES ('audit-project', 'audit-repository')"
+                    )
+                    self.conn.execute(
+                        """
+                        INSERT INTO ws_release_audit_events(
+                            id, project_id, config_key, sequence, event_type, actor,
+                            subject_kind, subject_id, previous_hash, event_hash, created_at_iso
+                        )
+                        VALUES (
+                            'audit-invalid', 'audit-project', 'default', %s,
+                            'release.created', 'migration-test', 'release',
+                            'release-1', %s, 'event-hash-original',
+                            '2026-01-01T00:00:00Z'
+                        )
+                        """,
+                        (sequence, previous_hash),
+                    )
 
-            with self.assertRaisesRegex(
-                RuntimeError,
-                r"Migration 9 precondition failed: .*sequence=0.*sequence_must_be_positive",
-            ):
-                _release_studio_hardening(self.conn)
+                    with self.assertRaisesRegex(
+                        RuntimeError,
+                        rf"Migration 9 precondition failed: .*sequence={sequence}.*{expected_violation}",
+                    ):
+                        _release_studio_hardening(self.conn)
 
-            row = self.conn.execute(
-                """
-                SELECT sequence, previous_hash
-                FROM ws_release_audit_events
-                WHERE id = 'audit-invalid-sequence'
-                """
-            ).fetchone()
-            self.assertEqual(row["sequence"], 0)
-            self.assertIsNone(row["previous_hash"])
-            constraint = self.conn.execute(
-                """
-                SELECT 1
-                FROM pg_constraint AS constraint_row
-                JOIN pg_class AS table_row
-                  ON table_row.oid = constraint_row.conrelid
-                JOIN pg_namespace AS namespace_row
-                  ON namespace_row.oid = table_row.relnamespace
-                WHERE namespace_row.nspname = %s
-                  AND table_row.relname = 'ws_release_audit_events'
-                  AND constraint_row.conname = 'ck_ws_release_audit_events_sequence_positive'
-                """,
-                (legacy_schema,),
-            ).fetchone()
-            self.assertIsNone(constraint)
-        finally:
-            self.conn.rollback()
-            self.conn.execute(f'SET search_path TO "{self.schema}", public')
-            self.conn.execute(f'DROP SCHEMA IF EXISTS "{legacy_schema}" CASCADE')
-            self.conn.commit()
+                    row = self.conn.execute(
+                        """
+                        SELECT sequence, previous_hash, event_hash
+                        FROM ws_release_audit_events
+                        WHERE id = 'audit-invalid'
+                        """
+                    ).fetchone()
+                    self.assertEqual(row["sequence"], sequence)
+                    self.assertEqual(row["previous_hash"], previous_hash)
+                    self.assertEqual(row["event_hash"], "event-hash-original")
+                    constraints = self.conn.execute(
+                        """
+                        SELECT constraint_row.conname
+                        FROM pg_constraint AS constraint_row
+                        JOIN pg_class AS table_row
+                          ON table_row.oid = constraint_row.conrelid
+                        JOIN pg_namespace AS namespace_row
+                          ON namespace_row.oid = table_row.relnamespace
+                        WHERE namespace_row.nspname = %s
+                          AND table_row.relname = 'ws_release_audit_events'
+                          AND constraint_row.conname IN (
+                              'ck_ws_release_audit_events_sequence_positive',
+                              'ck_ws_release_audit_events_genesis_previous_hash'
+                          )
+                        """,
+                        (legacy_schema,),
+                    ).fetchall()
+                    self.assertEqual(constraints, [])
+                finally:
+                    self.conn.rollback()
+                    self.conn.execute(f'SET search_path TO "{self.schema}", public')
+                    self.conn.execute(f'DROP SCHEMA IF EXISTS "{legacy_schema}" CASCADE')
+                    self.conn.commit()
 
     def test_v9_rows_upgrade_m10_adds_rejected_and_preserves_reasoned_override(self) -> None:
         legacy_schema = f"release_r3_m10_{uuid.uuid4().hex}"

--- a/docs/release-studio/R3.md
+++ b/docs/release-studio/R3.md
@@ -131,3 +131,5 @@ python -m compileall -q \
 Migration 9 hardening for already-upgraded R3 databases is documented in
 [`R3a.md`](R3a.md). It tightens the historical M8 contracts before production
 writers land; the M8 definitions above remain unchanged as historical state.
+The follow-on approval vocabulary and audit-precondition decisions are
+documented in [`R3b.md`](R3b.md).

--- a/docs/release-studio/R3a.md
+++ b/docs/release-studio/R3a.md
@@ -4,10 +4,13 @@ R3a appends Migration 9, `release_studio_hardening`, to repair databases that
 already applied Migration 8. Migration 8 remains historical state; fresh
 databases still run M8 and then M9. The migration is safe to replay directly.
 
-## Stage 1 vocabulary
+Migration 10 is the follow-on correction for the approval decision vocabulary;
+its compatibility and upgrade rules are documented in [`R3b.md`](R3b.md).
 
-The database now deliberately accepts only these evaluator and approval
-values:
+## Stage 1 vocabulary in Migration 9
+
+Migration 9 deliberately accepts only these evaluator and approval values in
+the schema it installs:
 
 | Column | Vocabulary |
 | --- | --- |
@@ -19,6 +22,11 @@ values:
 Migration 9 converts the old development-only evaluation values
 `warn` → `warning`, `block` → `blocker`, and `error` → `failure` before adding
 the canonical CHECK. The old aggregate vocabulary is not retained.
+
+Migration 9's approval CHECK is historical and accepts
+`approved|changes_requested|emergency_override`. Migration 10 adds the
+plan-specified `rejected` value and gives the pre-existing
+`emergency_override` value an explicit, reasoned exceptional meaning.
 
 ## Data-shape and provenance contracts
 
@@ -48,7 +56,12 @@ history. Release supersession uses a composite foreign key over
 Audit sequence numbers are positive and scoped by `(project_id, config_key)`.
 Sequence 1 is the genesis event and requires `previous_hash IS NULL`; later
 events require a nonblank previous hash. Canonical hashing represents that
-genesis value as JSON `null`, never as an empty string.
+genesis value as JSON `null`, never as an empty string. Before adding these
+CHECKs, M9 deterministically preflights the existing M8 audit table. An
+invalid row stops the migration with a named precondition error; M9 does not
+rewrite sequence or hash fields because doing so would fabricate a different
+audit chain. M9 is expected before R11 writers and requires a valid or empty
+audit history.
 
 The redundant leading-key indexes on closure inputs, members, scope
 fingerprints, and audit events are removed. The member-domain build index is
@@ -62,7 +75,7 @@ remain lifecycle-updateable; and release records may update only
 ## Validation
 
 `backend/tests/test_release_studio_schema_migration.py` applies a disposable
-PostgreSQL schema through M9, replays M9 directly, inspects
+PostgreSQL schema through M10, replays M9/M10 directly, inspects
 `information_schema`/`pg_catalog`, checks v8-shaped upgrade data, and probes
 the FK, CHECK, provenance, supersession, signature, audit, and trigger
 boundaries. It uses `TEST_POSTGRES_URL` only and skips when that isolated URL
@@ -75,6 +88,8 @@ Migration ordering that the upgrade path depends on:
 2. Disable `trg_ws_release_policy_versions_guard` while normalizing `rules` and
    backfilling `published_at`/`published_by` on published/retired rows, then
    re-enable it before installing the replacement guard function.
+3. Preflight existing audit rows before adding the sequence/genesis CHECKs;
+   there is no hash-destroying backfill path.
 
 Isolated acceptance run:
 

--- a/docs/release-studio/R3b.md
+++ b/docs/release-studio/R3b.md
@@ -1,9 +1,12 @@
 # Release Studio R3b: Migration 10 and pre-release hardening
 
-R3b preserves the merged M8/M9 history and appends Migration 10,
-`release_studio_approval_hardening`. M9 remains the historical schema
-hardening migration; it is not silently rewritten. Fresh databases run M8,
-M9, and M10 in order, while an already-upgraded M9 database only needs M10.
+R3b preserves the already-merged M8/M9 migration numbers and ordering, and
+appends Migration 10, `release_studio_approval_hardening`. As a pre-release
+correction, the implementation of M9 is amended to preflight existing audit
+rows before its new CHECKs; this does not change the migration ledger. A
+database that has already recorded M9 does not rerun it and already satisfies
+those constraints. Fresh databases run M8, amended M9, and M10 in order,
+while an already-upgraded M9 database only needs M10.
 
 ## Approval decision contract
 

--- a/docs/release-studio/R3b.md
+++ b/docs/release-studio/R3b.md
@@ -1,0 +1,90 @@
+# Release Studio R3b: Migration 10 and pre-release hardening
+
+R3b preserves the merged M8/M9 history and appends Migration 10,
+`release_studio_approval_hardening`. M9 remains the historical schema
+hardening migration; it is not silently rewritten. Fresh databases run M8,
+M9, and M10 in order, while an already-upgraded M9 database only needs M10.
+
+## Approval decision contract
+
+The canonical approval decisions are:
+
+| Decision | Meaning | Counts as an ordinary required approval? |
+| --- | --- | --- |
+| `approved` | The approver accepts the bound technical scope under the bound policy. | Yes |
+| `rejected` | The approver rejects the candidate/release. | No |
+| `changes_requested` | The approver requires changes before approval. | No |
+| `emergency_override` | An exceptional, audited break-glass decision used when the normal two-person path is unavailable. | **No** |
+
+`emergency_override` existed in the merged M9 CHECK without a written
+contract. R3b retains it for compatibility, but Migration 10 requires
+`self_approval_override_reason` to be nonblank whenever that decision is used.
+The database CHECK provides the structural requirement; the future R16 gate
+must treat the row as exceptional evidence and must not let it satisfy an
+ordinary `required_approvals` entry. The reason is retained with the immutable
+approval row. No existing approval row is rewritten.
+
+Migration 10 first preflights existing `emergency_override` rows in a stable
+`id` order. If one lacks a reason, it stops with a deterministic error and
+leaves the M9 decision constraint unchanged. An operator must remediate the
+exception under the approved governance process before retrying. This is the
+intentional compatibility risk: legacy emergency rows created without a reason
+will block startup until they are reviewed, while ordinary `approved`,
+`rejected`, and `changes_requested` rows upgrade without data changes.
+
+## Audit-stream precondition
+
+M9 adds the positive-sequence and genesis/non-genesis `previous_hash` CHECKs.
+Because those fields are hashed chain material, M9 does not invent a backfill
+for an invalid M8 row. The precondition runs at the beginning of M9, before
+M9's repair statements and before PostgreSQL validates either new CHECK. It
+reports the first invalid `(project_id, config_key, sequence)` in deterministic
+order and identifies the violated shape. The migration therefore fails with a
+useful remediation error instead of an opaque `ALTER TABLE` failure.
+
+M9 is expected before R11 audit writers and requires a valid or empty audit
+history. A valid stream means positive sequence values, a NULL previous hash
+for sequence 1, and a nonblank previous hash for later events. Repairing a
+historical stream is a separate, explicitly approved data-migration exercise;
+rewriting its sequence or hashes inside M9 would destroy its provenance.
+
+## PostgreSQL immutability boundary
+
+The approval, invalidation, and audit triggers protect application-level writes
+and make accidental history mutation fail closed. They do not claim that a
+PostgreSQL owner or migration role is unable to mutate rows: the migration role
+can disable a trigger when a controlled schema/data repair requires it. That is
+an inherent database privilege boundary, not a defect in the trigger design.
+
+Tamper evidence at rest comes from the later audit-chain verification and the
+signed attestation/offline verifier. A privileged database mutation can still
+be made, but it cannot be honestly represented by the archived chain head or
+the organization signature without detection. Application immutability and
+cryptographic/offline integrity are separate guarantees.
+
+## R13 rule-outcome decision
+
+`ws_release_findings` remains a problem table. Its allowed severities are
+`warning|failure|blocker`, and its statuses are `open|waived`; `unsupported`
+and `info` are intentionally not added as finding values. A finding must
+describe an actual problem that can be waived or resolved, not an evaluation
+state.
+
+R13 must persist one outcome per evaluated rule, including `unsupported` and
+`info`, in a dedicated `ws_release_rule_outcomes` table or an equivalent
+separate structure. That table should carry the evaluation/rule identity and
+the per-rule outcome independently of problem findings. R3b records this
+design decision but does not implement the R13 evaluator or add a premature
+table with no writers.
+
+## Validation and compatibility
+
+The isolated PostgreSQL tests use `TEST_POSTGRES_URL` and cover:
+
+- the full M8→M9→M10 ladder and replay idempotency;
+- the M8 invalid-audit precondition before M9 CHECK validation;
+- M9→M10 upgrade with a reasoned emergency decision;
+- safe refusal of a legacy emergency decision with no reason; and
+- real PostgreSQL CHECK, FK, trigger, and canonical vocabulary boundaries.
+
+Static acceptance also includes Python compilation and `git diff --check`.


### PR DESCRIPTION
## Summary
- preflight invalid M8 audit-chain rows before Migration 9 adds constraints, without rewriting hashed history
- append Migration 10 to add `rejected` and require a nonblank reason for exceptional `emergency_override`
- document application immutability versus privileged-database mutation and reserve per-rule outcomes for R13

## Verification
- 15 PostgreSQL migration tests pass against the isolated PostgreSQL 17 database
- all audit preflight violation classes are covered
- Python compile and `git diff --check` pass