### PR TITLE
[codex] add Release Studio R5 board fact projections

### DIFF
--- a/backend/app/release_studio/projections.py
+++ b/backend/app/release_studio/projections.py
@@ -1,0 +1,820 @@
+"""Read-only, deterministic projections of KiCad board facts.
+
+R5 deliberately keeps this module at the data boundary.  KiCad owns the board
+statistics schema, while the existing Prism S-expression scanner is used for
+the board stackup and variant declarations.  No function in this module starts
+KiCad, opens a source file for writing, or updates a fixture/check-out.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from app.release_studio.canonical import canonicalize_board_stats_json
+from app.release_studio.canonical.json import canonical_json_bytes
+from app.services import semantic_index_service
+
+
+PathLike = str | Path
+JsonValue = Any
+
+PROJECTION_SCHEMA = "prism.release_studio.board_projections.a0"
+BOARD_STATS_SOURCE = "kicad-cli pcb export stats --format json"
+_SOURCE_NAMES = ("board", "project", "schematic")
+_VIA_TYPES = ("through", "blind", "buried", "micro")
+
+
+def _read_text(path: PathLike) -> str:
+    """Read one source file without exposing a write-capable file handle."""
+
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+def _read_json_source(source: Any) -> Mapping[str, Any]:
+    if isinstance(source, Mapping):
+        return source
+    if isinstance(source, bytes):
+        payload = json.loads(source.decode("utf-8"))
+    elif isinstance(source, Path):
+        payload = json.loads(_read_text(source))
+    elif isinstance(source, str):
+        # JSON text is common at this boundary.  Parse an object-shaped string
+        # before treating it as a possible path so long input cannot leak the
+        # platform's filename-too-long OSError from Path.is_file().
+        if source.lstrip().startswith("{"):
+            payload = json.loads(source)
+        else:
+            try:
+                candidate = Path(source)
+                source_is_file = candidate.is_file()
+            except (OSError, ValueError):
+                source_is_file = False
+            if source_is_file:
+                payload = json.loads(_read_text(candidate))
+            else:
+                payload = json.loads(source)
+    else:
+        raise TypeError("JSON source must be a mapping, path, text, or bytes")
+    if not isinstance(payload, Mapping):
+        raise ValueError("JSON projection source must be an object")
+    return payload
+
+
+def _canonicalize_board_stats_object(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Reuse R4's one-object board-stats canonicalization boundary."""
+
+    canonical = canonicalize_board_stats_json(canonical_json_bytes(value))
+    normalized = json.loads(canonical.decode("utf-8"))
+    if not isinstance(normalized, dict):
+        raise AssertionError("canonical board stats object was not a mapping")
+    return normalized
+
+
+def project_board_stats(source: Mapping[str, Any] | PathLike | bytes) -> dict[str, Any]:
+    """Return a timestamp-free copy of KiCad's board statistics JSON.
+
+    The projection does not derive or rename board facts.  It preserves the
+    KiCad 10.0.4 payload as emitted by ``pcb export stats --format json`` and
+    removes the volatile root ``metadata.date`` field.  When a caller supplies
+    the known R4-style wrapper, its nested ``stats`` object is canonicalized as
+    the raw KiCad payload too; unrelated nested objects are left untouched.
+    """
+
+    payload = _read_json_source(source)
+    projected = _canonicalize_board_stats_object(payload)
+    nested_stats = projected.get("stats")
+    if isinstance(nested_stats, Mapping):
+        projected["stats"] = _canonicalize_board_stats_object(nested_stats)
+    return projected
+
+
+def project_board_stats_file(path: PathLike) -> dict[str, Any]:
+    """Read and project a KiCad board-statistics JSON file."""
+
+    return project_board_stats(Path(path))
+
+
+def _iter_named_blocks(text: str, name: str):
+    """Yield balanced named S-expressions using the shared Prism scanner."""
+
+    pattern = re.compile(rf"\({re.escape(name)}(?=\s|\))")
+    for match in pattern.finditer(text):
+        end = semantic_index_service._balanced_s_expression_end(text, match.start())
+        if end is not None:
+            yield text[match.start() : end]
+
+
+def _unescape_quoted(value: str) -> str:
+    return value.replace("\\\"", '"').replace("\\\\", "\\")
+
+
+def _field_atom(block: str, field: str) -> str | None:
+    match = re.search(
+        rf'\({re.escape(field)}\s+(?:"((?:[^"\\]|\\.)*)"|([^\s()]+))\)',
+        block,
+    )
+    if match is None:
+        return None
+    quoted, atom = match.groups()
+    return _unescape_quoted(quoted) if quoted is not None else atom
+
+
+def _field_atoms(block: str, field: str) -> list[str]:
+    match = re.search(rf"\({re.escape(field)}\s+([^)]*)\)", block)
+    if match is None:
+        return []
+    return [
+        _unescape_quoted(quoted) if quoted is not None else atom
+        for quoted, atom in re.findall(
+            r'"((?:[^"\\]|\\.)*)"|([^\s()]+)', match.group(1)
+        )
+        if quoted or atom
+    ]
+
+
+def _property_value(block: str, name: str) -> str | None:
+    match = re.search(
+        rf'\(property\s+"{re.escape(name)}"\s+"((?:[^"\\]|\\.)*)"',
+        block,
+    )
+    return _unescape_quoted(match.group(1)) if match else None
+
+
+def _field_number(block: str, field: str) -> float | None:
+    atom = _field_atom(block, field)
+    if atom is None:
+        return None
+    try:
+        return float(Decimal(atom))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _field_decimal(block: str, field: str) -> Decimal | None:
+    atom = _field_atom(block, field)
+    if atom is None:
+        return None
+    try:
+        return Decimal(atom)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _boolean_atom(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    if value.lower() in {"yes", "true"}:
+        return True
+    if value.lower() in {"no", "false"}:
+        return False
+    return None
+
+
+def _layer_kind(name: str, layer_type: str | None) -> str:
+    type_text = (layer_type or "").casefold().replace("_", " ")
+    name_text = name.casefold()
+    if "copper" in type_text or name_text.endswith(".cu"):
+        return "copper"
+    if type_text in {"prepreg", "core"} or "dielectric" in type_text:
+        return "dielectric"
+    if "mask" in type_text or "mask" in name_text:
+        return "mask"
+    if "paste" in type_text or "paste" in name_text:
+        return "paste"
+    if "silk" in type_text or "silk" in name_text:
+        return "silkscreen"
+    return "other"
+
+
+def _board_layer_table(text: str) -> list[dict[str, Any]]:
+    layers_block = next(iter(_iter_named_blocks(text, "layers")), None)
+    if layers_block is None:
+        return []
+
+    layers: list[dict[str, Any]] = []
+    # Board layer-table entries are ``(numeric_id "name" type ["user name"])``.
+    entry_pattern = re.compile(
+        r'\(\s*(\d+)\s+"((?:[^"\\]|\\.)*)"\s+([^\s()]+)'
+        r'(?:\s+"((?:[^"\\]|\\.)*)")?\s*\)'
+    )
+    for match in entry_pattern.finditer(layers_block):
+        ordinal, name, layer_type, user_name = match.groups()
+        layers.append(
+            {
+                "order": len(layers),
+                "layer_id": int(ordinal),
+                "name": _unescape_quoted(name),
+                "type": layer_type,
+                "material": None,
+                "thickness": None,
+                "epsilon_r": None,
+                "loss_tangent": None,
+                "color": None,
+                "user_name": _unescape_quoted(user_name) if user_name else None,
+                "kind": _layer_kind(_unescape_quoted(name), layer_type),
+            }
+        )
+    return layers
+
+
+def _stackup_layers(text: str) -> tuple[list[dict[str, Any]], str]:
+    stackup_block = next(iter(_iter_named_blocks(text, "stackup")), None)
+    if stackup_block is None:
+        return _board_layer_table(text), "board.layers"
+
+    layers: list[dict[str, Any]] = []
+    for layer_block in _iter_named_blocks(stackup_block, "layer"):
+        # The first argument of a stackup layer is its quoted name, not a
+        # ``(layer ...)`` field.  The regex below mirrors KiCad's writer while
+        # retaining escaped names.
+        name_match = re.match(r'\(layer\s+"((?:[^"\\]|\\.)*)"', layer_block)
+        if name_match is None:
+            continue
+        layer_name = _unescape_quoted(name_match.group(1))
+        layer_type = _field_atom(layer_block, "type")
+        layers.append(
+            {
+                "order": len(layers),
+                "layer_id": None,
+                "name": layer_name,
+                "type": layer_type,
+                "material": _field_atom(layer_block, "material"),
+                "thickness": _field_number(layer_block, "thickness"),
+                "epsilon_r": _field_number(layer_block, "epsilon_r"),
+                "loss_tangent": _field_number(layer_block, "loss_tangent"),
+                "color": _field_atom(layer_block, "color"),
+                "user_name": None,
+                "kind": _layer_kind(layer_name, layer_type),
+            }
+        )
+    return layers, "board.setup.stackup"
+
+
+def _general_thickness(text: str) -> float | None:
+    general = next(iter(_iter_named_blocks(text, "general")), None)
+    return _field_number(general, "thickness") if general else None
+
+
+def _via_type(block: str) -> str:
+    match = re.match(r"\(via(?:\s+(blind|buried|micro))?(?=\s|\))", block)
+    return match.group(1) if match and match.group(1) else "through"
+
+
+def _drill_span(block: str, field: str) -> dict[str, Any] | None:
+    drill_block = next(iter(_iter_named_blocks(block, field)), None)
+    if drill_block is None:
+        return None
+    layers = _field_atoms(drill_block, "layers")
+    return {
+        "size": _field_number(drill_block, "size"),
+        "start_layer": layers[0] if len(layers) >= 1 else None,
+        "stop_layer": layers[1] if len(layers) >= 2 else None,
+    }
+
+
+def _via_span_record(
+    block: str,
+    copper_layers: list[str],
+) -> dict[str, Any]:
+    via_type = _via_type(block)
+    layers = _field_atoms(block, "layers")
+    start_layer = layers[0] if len(layers) >= 1 else None
+    stop_layer = layers[1] if len(layers) >= 2 else None
+    if start_layer in copper_layers and stop_layer in copper_layers:
+        start_index = copper_layers.index(start_layer)
+        stop_index = copper_layers.index(stop_layer)
+        lo, hi = sorted((start_index, stop_index))
+        span_layers: list[str] | None = copper_layers[lo : hi + 1]
+    else:
+        span_layers = None
+    return {
+        "via_type": via_type,
+        "start_layer": start_layer,
+        "stop_layer": stop_layer,
+        "span_layers": span_layers,
+        "span_layer_count": len(span_layers) if span_layers is not None else None,
+        "backdrill": _drill_span(block, "backdrill"),
+        "tertiary_drill": _drill_span(block, "tertiary_drill"),
+    }
+
+
+def _via_sort_key(record: dict[str, Any], copper_layers: list[str]) -> tuple[Any, ...]:
+    def layer_index(name: Any) -> int:
+        return copper_layers.index(name) if name in copper_layers else len(copper_layers)
+
+    def drill_sort_key(drill: Any) -> tuple[Any, ...]:
+        if not isinstance(drill, Mapping):
+            return (False, None, "", "")
+        return (
+            True,
+            drill.get("size"),
+            drill.get("start_layer") or "",
+            drill.get("stop_layer") or "",
+        )
+
+    return (
+        layer_index(record["start_layer"]),
+        layer_index(record["stop_layer"]),
+        record["via_type"],
+        record["start_layer"] or "",
+        record["stop_layer"] or "",
+        drill_sort_key(record["backdrill"]),
+        drill_sort_key(record["tertiary_drill"]),
+    )
+
+
+def _group_via_spans(
+    text: str,
+    copper_layers: list[str],
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    grouped: dict[tuple[Any, ...], dict[str, Any]] = {}
+    counts = {via_type: 0 for via_type in _VIA_TYPES}
+    for via_block in _iter_named_blocks(text, "via"):
+        record = _via_span_record(via_block, copper_layers)
+        via_type = record["via_type"]
+        if via_type in counts:
+            counts[via_type] += 1
+        key = (
+            record["via_type"],
+            record["start_layer"],
+            record["stop_layer"],
+            tuple(record["span_layers"] or ()),
+            tuple(
+                (record["backdrill"] or {}).get(field)
+                for field in ("size", "start_layer", "stop_layer")
+            ),
+            tuple(
+                (record["tertiary_drill"] or {}).get(field)
+                for field in ("size", "start_layer", "stop_layer")
+            ),
+        )
+        if key not in grouped:
+            grouped[key] = {**record, "count": 0}
+        grouped[key]["count"] += 1
+    records = list(grouped.values())
+    records.sort(key=lambda record: _via_sort_key(record, copper_layers))
+    return records, counts
+
+
+def _empty_stackup() -> dict[str, Any]:
+    return {
+        "schema": "prism.release_studio.stackup.a0",
+        "present": False,
+        "source": "none",
+        "units": "mm",
+        "layers": [],
+        "copper_layers": [],
+        "dielectric_layers": [],
+        "copper_layer_count": 0,
+        "dielectric_layer_count": 0,
+        "board_thickness": None,
+        "total_thickness": None,
+        "total_thickness_status": "unsupported",
+        "total_thickness_source": None,
+        "settings": {
+            "copper_finish": None,
+            "dielectric_constraints": None,
+        },
+        "via_count": 0,
+        "via_type_counts": {via_type: 0 for via_type in _VIA_TYPES},
+        "via_spans": [],
+    }
+
+
+def project_stackup(board_path: PathLike) -> dict[str, Any]:
+    """Project stackup ordering, materials, thickness, and via spans.
+
+    KiCad stores physical layer facts in ``setup.stackup`` and the complete
+    enabled-layer table in ``layers``.  A board without a stackup still gets a
+    useful layer-table projection, but all unavailable stackup fields remain
+    ``None`` rather than being inferred from a generic board thickness.
+    """
+
+    text = _read_text(board_path)
+    layers, source = _stackup_layers(text)
+    if not layers:
+        return _empty_stackup()
+
+    copper_layers = [layer["name"] for layer in layers if layer["kind"] == "copper"]
+    dielectric_layers = [
+        layer["name"] for layer in layers if layer["kind"] == "dielectric"
+    ]
+    thickness_values = [
+        Decimal(str(layer["thickness"]))
+        for layer in layers
+        if layer["kind"] in {"copper", "dielectric", "mask"}
+        and layer["thickness"] is not None
+    ]
+    physical_layers = [
+        layer
+        for layer in layers
+        if layer["kind"] in {"copper", "dielectric", "mask"}
+    ]
+    thickness_complete = bool(physical_layers) and all(
+        layer["thickness"] is not None for layer in physical_layers
+    )
+    total_thickness = (
+        float(sum(thickness_values, Decimal("0"))) if thickness_complete else None
+    )
+
+    stackup_block = next(iter(_iter_named_blocks(text, "stackup")), None)
+    copper_finish = _field_atom(stackup_block, "copper_finish") if stackup_block else None
+    dielectric_constraints = (
+        _boolean_atom(_field_atom(stackup_block, "dielectric_constraints"))
+        if stackup_block
+        else None
+    )
+    via_spans, via_type_counts = _group_via_spans(text, copper_layers)
+    return {
+        "schema": "prism.release_studio.stackup.a0",
+        "present": source == "board.setup.stackup",
+        "source": source,
+        "units": "mm",
+        "layers": layers,
+        "copper_layers": copper_layers,
+        "dielectric_layers": dielectric_layers,
+        "copper_layer_count": len(copper_layers),
+        "dielectric_layer_count": len(dielectric_layers),
+        "board_thickness": _general_thickness(text),
+        "total_thickness": total_thickness,
+        "total_thickness_status": (
+            "available" if thickness_complete else "partial" if thickness_values else "unsupported"
+        ),
+        "total_thickness_source": (
+            "board.setup.stackup.layer.thickness" if thickness_complete else None
+        ),
+        "settings": {
+            "copper_finish": copper_finish,
+            "dielectric_constraints": dielectric_constraints,
+        },
+        "via_count": sum(via_type_counts.values()),
+        "via_type_counts": via_type_counts,
+        "via_spans": via_spans,
+    }
+
+
+def _variant_declaration(
+    name: str,
+    description: str | None,
+    is_default: bool | None,
+    assignments: Mapping[str, bool] | None = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": description,
+        "is_default": name == "default" if is_default is None else is_default,
+        "assignments": {
+            reference: bool(value)
+            for reference, value in sorted((assignments or {}).items())
+        },
+    }
+
+
+def _merge_declaration_names(
+    declarations: list[dict[str, Any]],
+    names: Mapping[str, Mapping[str, bool]],
+) -> list[dict[str, Any]]:
+    by_name = {declaration["name"]: declaration for declaration in declarations}
+    for name, assignments in names.items():
+        if name not in by_name:
+            by_name[name] = _variant_declaration(name, None, None, assignments)
+        elif assignments:
+            merged = dict(by_name[name]["assignments"])
+            merged.update(assignments)
+            by_name[name]["assignments"] = {
+                reference: merged[reference] for reference in sorted(merged)
+            }
+    return [by_name[name] for name in by_name]
+
+
+def _board_variant_declarations(text: str) -> list[dict[str, Any]]:
+    declarations: list[dict[str, Any]] = []
+    catalog = next(iter(_iter_named_blocks(text, "variants")), None)
+    if catalog is not None:
+        for variant_block in _iter_named_blocks(catalog, "variant"):
+            name = _field_atom(variant_block, "name")
+            if not name:
+                continue
+            declarations.append(
+                _variant_declaration(
+                    name,
+                    _field_atom(variant_block, "description"),
+                    _boolean_atom(
+                        _field_atom(variant_block, "is_default")
+                        or _field_atom(variant_block, "default")
+                    ),
+                )
+            )
+
+    assignments: dict[str, dict[str, bool]] = {}
+    for footprint_block in _iter_named_blocks(text, "footprint"):
+        reference = _property_value(footprint_block, "Reference")
+        if reference is None:
+            reference_match = re.search(
+                r'\(fp_text\s+reference\s+"((?:[^"\\]|\\.)*)"', footprint_block
+            )
+            reference = (
+                _unescape_quoted(reference_match.group(1))
+                if reference_match
+                else None
+            )
+        if not reference:
+            continue
+        for variant_block in _iter_named_blocks(footprint_block, "variant"):
+            name = _field_atom(variant_block, "name")
+            dnp = _boolean_atom(_field_atom(variant_block, "dnp"))
+            if name and dnp is not None:
+                assignments.setdefault(name, {})[reference] = dnp
+    return _merge_declaration_names(declarations, assignments)
+
+
+def _project_variant_declarations(project_path: PathLike | None) -> list[dict[str, Any]]:
+    if project_path is None:
+        return []
+    payload = _read_json_source(Path(project_path))
+    schematic = payload.get("schematic")
+    if not isinstance(schematic, Mapping):
+        return []
+    raw_variants = schematic.get("variants")
+    if raw_variants is None:
+        return []
+    if not isinstance(raw_variants, list):
+        raise ValueError("project schematic.variants must be a list")
+
+    declarations: list[dict[str, Any]] = []
+    for index, raw_variant in enumerate(raw_variants):
+        if not isinstance(raw_variant, Mapping):
+            raise ValueError(f"project schematic.variants[{index}] must be an object")
+        name = raw_variant.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"project schematic.variants[{index}].name must be non-empty")
+        description = raw_variant.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValueError(
+                f"project schematic.variants[{index}].description must be a string"
+            )
+        explicit_default = raw_variant.get("is_default", raw_variant.get("default"))
+        if explicit_default is not None and not isinstance(explicit_default, bool):
+            raise ValueError(
+                f"project schematic.variants[{index}].default must be boolean"
+            )
+        declarations.append(
+            _variant_declaration(name, description, explicit_default)
+        )
+    return _dedupe_declarations(declarations)
+
+
+def _schematic_variant_declarations(schematic_path: PathLike | None) -> list[dict[str, Any]]:
+    if schematic_path is None:
+        return []
+    text = _read_text(schematic_path)
+    assignments: dict[str, dict[str, bool]] = {}
+    names: list[str] = []
+    for path_block in _iter_named_blocks(text, "path"):
+        reference = _field_atom(path_block, "reference")
+        for variant_block in _iter_named_blocks(path_block, "variant"):
+            name = _field_atom(variant_block, "name")
+            if not name:
+                continue
+            if name not in names:
+                names.append(name)
+            dnp = _boolean_atom(_field_atom(variant_block, "dnp"))
+            if reference and dnp is not None:
+                assignments.setdefault(name, {})[reference] = dnp
+    return [
+        _variant_declaration(name, None, None, assignments.get(name)) for name in names
+    ]
+
+
+def _dedupe_declarations(declarations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_name: dict[str, dict[str, Any]] = {}
+    for declaration in declarations:
+        name = declaration["name"]
+        if name not in by_name:
+            by_name[name] = declaration
+            continue
+        current = by_name[name]
+        if current["description"] is None:
+            current["description"] = declaration["description"]
+        current["assignments"].update(declaration["assignments"])
+        current["assignments"] = {
+            reference: current["assignments"][reference]
+            for reference in sorted(current["assignments"])
+        }
+    return list(by_name.values())
+
+
+def _declaration_map(declarations: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {
+        declaration["name"]: {
+            "description": declaration["description"],
+            "is_default": declaration["is_default"],
+            "assignments": declaration["assignments"],
+        }
+        for declaration in declarations
+    }
+
+
+def _compare_variant_sources(
+    left_name: str,
+    left: list[dict[str, Any]],
+    right_name: str,
+    right: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    left_map = _declaration_map(left)
+    right_map = _declaration_map(right)
+    left_names = set(left_map)
+    right_names = set(right_map)
+    changed = sorted(
+        name
+        for name in left_names & right_names
+        if (
+            (
+                left_map[name]["description"] is not None
+                and right_map[name]["description"] is not None
+                and left_map[name]["description"] != right_map[name]["description"]
+            )
+            or left_map[name]["is_default"] != right_map[name]["is_default"]
+            or (
+                left_map[name]["assignments"]
+                and right_map[name]["assignments"]
+                and left_map[name]["assignments"] != right_map[name]["assignments"]
+            )
+        )
+    )
+    missing_left = sorted(right_names - left_names)
+    missing_right = sorted(left_names - right_names)
+    if not changed and not missing_left and not missing_right:
+        return None
+    return {
+        "left": left_name,
+        "right": right_name,
+        "missing_in_left": missing_left,
+        "missing_in_right": missing_right,
+        "changed": changed,
+    }
+
+
+def project_variants(
+    board_path: PathLike,
+    project_path: PathLike | None = None,
+    schematic_path: PathLike | None = None,
+) -> dict[str, Any]:
+    """Union board, project, and schematic variant declarations.
+
+    Declaration order is retained within each source; the deterministic union
+    uses board order first, then project-only names, then schematic-only names.
+    Source comparison ignores ordering but includes names, descriptions,
+    default markers, and shared board/schematic DNP assignments.
+    """
+
+    board_declarations = _board_variant_declarations(_read_text(board_path))
+    project_declarations = _project_variant_declarations(project_path)
+    schematic_declarations = _schematic_variant_declarations(schematic_path)
+    declarations_by_source = {
+        "board": board_declarations,
+        "project": project_declarations,
+        "schematic": schematic_declarations,
+    }
+
+    ordered_names: list[str] = []
+    for source_name in _SOURCE_NAMES:
+        for declaration in declarations_by_source[source_name]:
+            name = declaration["name"]
+            if name not in ordered_names:
+                ordered_names.append(name)
+
+    divergence_reasons: list[dict[str, Any]] = []
+    present_sources = [
+        source_name
+        for source_name in _SOURCE_NAMES
+        if declarations_by_source[source_name]
+    ]
+    for index, left_name in enumerate(present_sources):
+        for right_name in present_sources[index + 1 :]:
+            difference = _compare_variant_sources(
+                left_name,
+                declarations_by_source[left_name],
+                right_name,
+                declarations_by_source[right_name],
+            )
+            if difference is not None:
+                divergence_reasons.append(difference)
+
+    declarations_by_name = {
+        source_name: _declaration_map(declarations_by_source[source_name])
+        for source_name in _SOURCE_NAMES
+    }
+    variants: list[dict[str, Any]] = []
+    for name in ordered_names:
+        source_membership = {
+            source_name: name in declarations_by_name[source_name]
+            for source_name in _SOURCE_NAMES
+        }
+        sources = [
+            source_name for source_name in _SOURCE_NAMES if source_membership[source_name]
+        ]
+        variants.append(
+            {
+                "name": name,
+                "is_default": name == "default"
+                or any(
+                    declarations_by_name[source_name].get(name, {}).get("is_default")
+                    is True
+                    for source_name in sources
+                ),
+                "sources": sources,
+                "source_membership": source_membership,
+                "declarations": {
+                    source_name: declarations_by_name[source_name][name]
+                    for source_name in sources
+                },
+            }
+        )
+
+    default_names = [variant["name"] for variant in variants if variant["is_default"]]
+    default_name = default_names[0] if default_names else None
+    default_sources = [
+        source_name
+        for source_name in _SOURCE_NAMES
+        if default_name is not None and default_name in declarations_by_name[source_name]
+    ]
+    return {
+        "schema": "prism.release_studio.variants.a0",
+        "diverged": bool(divergence_reasons),
+        "sources": present_sources,
+        "source_membership": {
+            source_name: bool(declarations_by_source[source_name])
+            for source_name in _SOURCE_NAMES
+        },
+        "ordering": ordered_names,
+        "default": {
+            "name": default_name,
+            "sources": default_sources,
+        },
+        "declarations": {
+            source_name: declarations_by_source[source_name]
+            for source_name in _SOURCE_NAMES
+        },
+        "variants": variants,
+        "divergence_reasons": divergence_reasons,
+    }
+
+
+def build_board_projections(
+    board_path: PathLike,
+    project_path: PathLike | None = None,
+    schematic_path: PathLike | None = None,
+    *,
+    board_stats: Mapping[str, Any] | PathLike | bytes | None = None,
+) -> dict[str, Any]:
+    """Build the three R5 projections from read-only source inputs.
+
+    ``board_stats`` is intentionally supplied separately because the R2
+    executor or a pinned KiCad live step owns creation of the CLI JSON.  If it
+    is absent, the result says ``unsupported`` instead of inventing counts.
+    """
+
+    stats_projection: dict[str, Any]
+    if board_stats is None:
+        stats_projection = {
+            "status": "unsupported",
+            "source": BOARD_STATS_SOURCE,
+            "reason": "KiCad board statistics JSON was not supplied",
+        }
+    else:
+        stats_projection = project_board_stats(board_stats)
+    return {
+        "schema": PROJECTION_SCHEMA,
+        "board_stats": stats_projection,
+        "stackup": project_stackup(board_path),
+        "variants": project_variants(board_path, project_path, schematic_path),
+    }
+
+
+# Descriptive aliases make the three projection boundaries discoverable to
+# callers that use noun-first names while keeping one implementation.
+board_stats_projection = project_board_stats
+stackup_projection = project_stackup
+variants_projection = project_variants
+build_projections = build_board_projections
+
+
+__all__ = [
+    "BOARD_STATS_SOURCE",
+    "PROJECTION_SCHEMA",
+    "board_stats_projection",
+    "build_board_projections",
+    "build_projections",
+    "project_board_stats",
+    "project_board_stats_file",
+    "project_stackup",
+    "project_variants",
+    "stackup_projection",
+    "variants_projection",
+]

--- a/backend/tests/release_studio_live_runner.py
+++ b/backend/tests/release_studio_live_runner.py
@@ -15,6 +15,7 @@ LIVE_MODULES: tuple[str, ...] = (
     "tests.test_release_studio_live_ci",
     "tests.test_release_studio_fixtures",
     "tests.test_release_studio_canonicalization",
+    "tests.test_release_studio_projections",
 )
 
 

--- a/backend/tests/test_release_studio_projections.py
+++ b/backend/tests/test_release_studio_projections.py
@@ -1,0 +1,342 @@
+"""R5 board fact projections and their read-only/live boundaries."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.release_studio.projections import (
+    build_board_projections,
+    project_board_stats,
+    project_stackup,
+    project_variants,
+)
+from tests.release_studio_support import (
+    fixture_entrypoint,
+    fixture_root,
+    requires_kicad_cli,
+    run_kicad_cli,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_owned_stats_dates_absent(
+    test_case: unittest.TestCase,
+    value: object,
+    *,
+    wrapper: bool = False,
+) -> None:
+    test_case.assertIsInstance(value, dict)
+    metadata = value.get("metadata")
+    if isinstance(metadata, dict):
+        test_case.assertNotIn("date", metadata)
+    if wrapper:
+        stats = value.get("stats")
+        test_case.assertIsInstance(stats, dict)
+        stats_metadata = stats.get("metadata")
+        if isinstance(stats_metadata, dict):
+            test_case.assertNotIn("date", stats_metadata)
+
+
+class ReleaseStudioProjectionTests(unittest.TestCase):
+    def test_board_stats_reuses_r4_boundary_without_mutating_input(self) -> None:
+        raw = {
+            "metadata": {
+                "date": "2026-08-11T00:00:00Z",
+                "generator": "KiCad 10.0.4",
+            },
+            "board": {
+                "has_outline": True,
+                "width": "30 mm",
+                "height": "15 mm",
+                "board_thickness": "1.6 mm",
+            },
+            "nested": {"metadata": {"date": "nested volatile value", "keep": True}},
+        }
+        original = copy.deepcopy(raw)
+
+        projected = project_board_stats(raw)
+
+        self.assertEqual(raw, original)
+        self.assertEqual(projected["metadata"], {"generator": "KiCad 10.0.4"})
+        self.assertEqual(
+            projected["nested"],
+            {"metadata": {"date": "nested volatile value", "keep": True}},
+        )
+        self.assertEqual(projected["board"]["board_thickness"], "1.6 mm")
+        _assert_owned_stats_dates_absent(self, projected)
+
+    def test_known_r4_wrapper_canonicalizes_only_owned_stats_paths(self) -> None:
+        wrapper = {
+            "metadata": {"date": "wrapper date", "owner": "R4"},
+            "stats": {
+                "metadata": {"date": "raw stats date", "generator": "KiCad 10.0.4"},
+                "board": {"board_thickness": "1.6 mm"},
+            },
+            "nested": {"metadata": {"date": "unrelated date", "keep": True}},
+        }
+        original = copy.deepcopy(wrapper)
+
+        projected = project_board_stats(wrapper)
+
+        self.assertEqual(wrapper, original)
+        _assert_owned_stats_dates_absent(self, projected, wrapper=True)
+        self.assertEqual(projected["stats"]["metadata"]["generator"], "KiCad 10.0.4")
+        self.assertEqual(
+            projected["nested"]["metadata"],
+            {"date": "unrelated date", "keep": True},
+        )
+
+    def test_object_json_text_does_not_probe_path_for_filename_length(self) -> None:
+        raw_text = json.dumps(
+            {
+                "metadata": {"date": "volatile", "generator": "KiCad 10.0.4"},
+                "board": {"board_thickness": "1.6 mm"},
+            }
+        )
+
+        with patch("pathlib.Path.is_file", side_effect=OSError("filename too long")):
+            projected = project_board_stats(raw_text)
+
+        _assert_owned_stats_dates_absent(self, projected)
+
+    def test_stackup_uses_authoritative_cynthion_layer_order_and_thickness(self) -> None:
+        board = fixture_entrypoint("cynthion", "board")
+
+        projection = project_stackup(board)
+
+        self.assertTrue(projection["present"])
+        self.assertEqual(
+            projection["copper_layers"],
+            ["F.Cu", "In1.Cu", "In2.Cu", "In3.Cu", "In4.Cu", "B.Cu"],
+        )
+        self.assertEqual(
+            projection["dielectric_layers"],
+            ["dielectric 1", "dielectric 2", "dielectric 3", "dielectric 4", "dielectric 5"],
+        )
+        self.assertEqual(projection["layers"][1]["type"], "Top Solder Paste")
+        dielectric_1 = next(
+            layer for layer in projection["layers"] if layer["name"] == "dielectric 1"
+        )
+        self.assertEqual(dielectric_1["material"], "3313")
+        self.assertEqual(dielectric_1["thickness"], 0.0994)
+        self.assertEqual(dielectric_1["epsilon_r"], 4.05)
+        self.assertEqual(projection["board_thickness"], 1.5584)
+        self.assertEqual(projection["total_thickness"], 1.5584)
+        self.assertEqual(projection["total_thickness_status"], "available")
+        self.assertEqual(projection["settings"]["copper_finish"], "None")
+        self.assertEqual(projection["settings"]["dielectric_constraints"], False)
+        self.assertGreater(projection["via_count"], 0)
+        self.assertEqual(projection["via_type_counts"]["blind"], 0)
+
+    def test_derived_stackup_preserves_explicit_via_span_and_missing_values(self) -> None:
+        source_board = fixture_entrypoint("cynthion", "board")
+        original_digest = _sha256(source_board)
+        via = """
+  (via blind
+    (at 10 10)
+    (size 0.45)
+    (drill 0.2)
+    (layers "F.Cu" "In2.Cu")
+  )
+"""
+        with tempfile.TemporaryDirectory() as temporary:
+            derived_board = Path(temporary) / source_board.name
+            source_text = source_board.read_text(encoding="utf-8")
+            closing = source_text.rfind(")")
+            derived_board.write_text(
+                source_text[:closing] + via + source_text[closing:],
+                encoding="utf-8",
+            )
+
+            projection = project_stackup(derived_board)
+
+        self.assertEqual(_sha256(source_board), original_digest)
+        self.assertEqual(projection["via_type_counts"]["blind"], 1)
+        self.assertEqual(
+            next(
+                span
+                for span in projection["via_spans"]
+                if span["via_type"] == "blind"
+            ),
+            {
+                "via_type": "blind",
+                "start_layer": "F.Cu",
+                "stop_layer": "In2.Cu",
+                "span_layers": ["F.Cu", "In1.Cu", "In2.Cu"],
+                "span_layer_count": 3,
+                "backdrill": None,
+                "tertiary_drill": None,
+                "count": 1,
+            },
+        )
+
+    def test_missing_stackup_is_explicit_and_not_derived_from_board_thickness(self) -> None:
+        projection = project_stackup(fixture_entrypoint("synthetic", "board"))
+
+        self.assertFalse(projection["present"])
+        self.assertEqual(projection["source"], "board.layers")
+        self.assertIsNone(projection["total_thickness"])
+        self.assertEqual(projection["total_thickness_status"], "unsupported")
+        f_cu = next(layer for layer in projection["layers"] if layer["name"] == "F.Cu")
+        self.assertEqual(f_cu["kind"], "copper")
+        self.assertIsNone(f_cu["thickness"])
+
+    def test_synchronized_variants_union_sources_with_stable_default(self) -> None:
+        board = fixture_entrypoint("synthetic", "board")
+        project = fixture_entrypoint("synthetic", "project")
+        schematic = fixture_entrypoint("synthetic", "schematic")
+
+        projection = project_variants(board, project, schematic)
+
+        self.assertFalse(projection["diverged"])
+        self.assertEqual(
+            projection["ordering"], ["default", "dnp-led", "assembly-reduced"]
+        )
+        self.assertEqual(
+            projection["default"],
+            {"name": "default", "sources": ["board", "project", "schematic"]},
+        )
+        self.assertEqual(
+            projection["source_membership"],
+            {"board": True, "project": True, "schematic": True},
+        )
+        dnp_led = next(
+            variant for variant in projection["variants"] if variant["name"] == "dnp-led"
+        )
+        self.assertEqual(dnp_led["sources"], ["board", "project", "schematic"])
+        self.assertEqual(dnp_led["declarations"]["board"]["assignments"]["D1"], True)
+        self.assertEqual(dnp_led["declarations"]["schematic"]["assignments"]["D1"], True)
+
+    def test_desynchronized_project_declaration_is_union_and_divergence(self) -> None:
+        board = fixture_entrypoint("synthetic", "board")
+        schematic = fixture_entrypoint("synthetic", "schematic")
+        project_source = fixture_entrypoint("synthetic", "project")
+        original_digests = {
+            path: _sha256(path) for path in (board, schematic, project_source)
+        }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary) / project_source.name
+            payload = json.loads(project_source.read_text(encoding="utf-8"))
+            payload["schematic"]["variants"].append(
+                {"name": "project-only", "description": "Declared only in the project"}
+            )
+            project.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+            projection = project_variants(board, project, schematic)
+
+        self.assertTrue(projection["diverged"])
+        self.assertIn("project-only", projection["ordering"])
+        project_only = next(
+            variant for variant in projection["variants"] if variant["name"] == "project-only"
+        )
+        self.assertEqual(project_only["sources"], ["project"])
+        self.assertEqual(
+            project_only["source_membership"],
+            {"board": False, "project": True, "schematic": False},
+        )
+        self.assertTrue(
+            any(
+                difference["left"] == "board" and difference["right"] == "project"
+                and "project-only" in difference["missing_in_left"]
+                for difference in projection["divergence_reasons"]
+            )
+        )
+        self.assertEqual(
+            {path: _sha256(path) for path in (board, schematic, project_source)},
+            original_digests,
+        )
+
+    def test_projections_are_deterministic_and_do_not_open_sources_for_writing(self) -> None:
+        board = fixture_entrypoint("synthetic", "board")
+        project = fixture_entrypoint("synthetic", "project")
+        schematic = fixture_entrypoint("synthetic", "schematic")
+        raw_stats = {
+            "metadata": {"date": "volatile", "generator": "KiCad 10.0.4"},
+            "board": {"board_thickness": "1.6 mm", "has_outline": True},
+        }
+
+        with patch("pathlib.Path.open", autospec=True, side_effect=Path.open) as open_mock:
+            first = build_board_projections(
+                board,
+                project,
+                schematic,
+                board_stats=raw_stats,
+            )
+            second = build_board_projections(
+                board,
+                project,
+                schematic,
+                board_stats=raw_stats,
+            )
+
+        self.assertEqual(
+            json.dumps(first, sort_keys=True, separators=(",", ":")),
+            json.dumps(second, sort_keys=True, separators=(",", ":")),
+        )
+        _assert_owned_stats_dates_absent(self, first["board_stats"])
+        for call in open_mock.call_args_list:
+            mode = call.kwargs.get("mode", "r")
+            self.assertNotIn("w", mode)
+            self.assertNotIn("a", mode)
+            self.assertNotIn("+", mode)
+
+    def test_missing_board_stats_is_explicitly_unsupported(self) -> None:
+        projection = build_board_projections(fixture_entrypoint("synthetic", "board"))
+
+        self.assertEqual(projection["board_stats"]["status"], "unsupported")
+        self.assertEqual(
+            projection["board_stats"]["source"],
+            "kicad-cli pcb export stats --format json",
+        )
+
+
+class ReleaseStudioProjectionLiveTests(unittest.TestCase):
+    @requires_kicad_cli()
+    def test_kicad_10_0_4_board_stats_feed_projection_without_date(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            live_root = Path(temporary) / "cynthion"
+            shutil.copytree(fixture_root("cynthion"), live_root)
+            board = live_root / fixture_entrypoint("cynthion", "board").relative_to(
+                fixture_root("cynthion")
+            )
+            stats_path = Path(temporary) / "board-stats.json"
+            result = run_kicad_cli(
+                "pcb",
+                "export",
+                "stats",
+                "--format",
+                "json",
+                "--output",
+                str(stats_path),
+                str(board),
+                cwd=live_root,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"board stats export failed:\n{result.stdout}\n{result.stderr}",
+            )
+            raw = json.loads(stats_path.read_text(encoding="utf-8"))
+            projected = project_board_stats(stats_path)
+
+        self.assertIn("metadata", raw)
+        self.assertIn("date", raw["metadata"])
+        self.assertEqual(projected["metadata"]["generator"], raw["metadata"]["generator"])
+        self.assertEqual(projected["board"], raw["board"])
+        self.assertNotIn("date", projected["metadata"])
+        _assert_owned_stats_dates_absent(self, projected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/release-studio/R5.md
+++ b/docs/release-studio/R5.md
@@ -1,0 +1,44 @@
+# Release Studio R5: board fact projections
+
+R5 adds read-only projections for the board facts that later technical
+fingerprinting and policy rules may consume:
+
+- `board_stats` preserves KiCad 10.0.4 `pcb export stats --format json` data and
+  reuses R4's canonical board-stats boundary, so `metadata.date` is absent
+  before a projection can be hashed. No board counts or measurements are
+  re-derived from guessed fields.
+- `stackup` reads the board's `setup.stackup` and complete layer table. It keeps
+  physical ordering, copper/dielectric classification, names, raw types,
+  material, thickness, dielectric constants, finish settings, total thickness,
+  and grouped via start/stop spans. Missing values remain `null`; a board with
+  only a layer table is reported as `board.layers`, not as a fabricated
+  stackup.
+- `variants` unions board catalog entries, `.kicad_pro` schematic variant
+  entries, and schematic per-instance declarations. Each variant records source
+  membership, stable source-priority ordering, default information, and DNP
+  assignments where KiCad stores them. Name/description/default and shared
+  board/schematic assignment drift sets `diverged`.
+
+The projection module only reads files. Board statistics JSON is supplied by
+the R2 executor or the pinned KiCad live step; the projection layer does not
+run KiCad and never opens a source for writing. Tests derive a desynchronized
+project copy and a via-bearing stackup copy under temporary directories, so the
+R0 fixture-root contract and committed fixture bytes remain unchanged.
+
+R5 does not implement R17 domain fingerprints or D3 artwork acquisition. The
+`50.000 mm` scale oracle is intentionally owned by D3, where artwork placement
+and rendering are introduced.
+
+## Validation
+
+```sh
+cd backend
+python -m unittest tests.test_release_studio_projections -v
+python -m unittest tests.test_release_studio_fixtures tests.test_release_studio_jobset -v
+python -m compileall -q app/release_studio/projections.py tests/test_release_studio_projections.py
+```
+
+The strict pinned executor runner includes `tests.test_release_studio_projections`.
+Its live test exports real KiCad 10.0.4 board statistics from a temporary
+Cynthion copy and fails closed rather than skipping when the pinned executor
+cannot provide KiCad.


### PR DESCRIPTION
## Summary

R5 adds deterministic, read-only board fact projections for Release Studio: KiCad board statistics, physical stackup/layer data with via spans, and the union of board/project/schematic variant declarations.

## Why

Later Release Studio fingerprint and policy work needs stable board facts grounded in KiCad 10.0.4 output. These projections preserve unsupported values explicitly, avoid guessing from incomplete files, and keep volatile statistics timestamps outside the canonical JSON boundary.

## Implementation

- Reuses R4's shared canonical JSON encoder and board-stats canonicalizer. Raw stats and the known R4 `stats` wrapper are canonicalized only at their owned paths; unrelated nested `metadata.date` values are preserved.
- Reads `setup.stackup` and the board layer table for ordered copper/dielectric layers, material/thickness fields, total thickness status, finish settings, and grouped via/span information.
- Unions board, `.kicad_pro`, and schematic variant declarations with stable ordering, source membership, defaults, assignments, and divergence reasons.
- Keeps all source reads read-only. Desync and via-span tests use temporary derived copies, preserving committed fixture bytes and the R0 fixture-root contract.
- Leaves R17 fingerprinting and D3 artwork/scale-oracle work out of scope; the `50.000 mm` oracle remains owned by D3.

## Validation

- `tests.test_release_studio_projections.ReleaseStudioProjectionTests`: 10 passed.
- R5/R0/R1/R2/R4 focused backend set: 42 passed, 11 expected host skips because the host has no KiCad CLI.
- `compileall` passed.
- `git diff --check` passed.
- The R5 live test is registered in the strict pinned executor runner for CI; local Docker live execution was not run because the available legacy backend image lacks the R00 baked-identity contract.
