### PR TITLE
fix(release-studio): verify pinned resource digests

### DIFF
--- a/backend/app/release_studio/closure.py
+++ b/backend/app/release_studio/closure.py
@@ -28,6 +28,7 @@ from app.release_studio.canonical import sha256_canonical
 
 _LFS_POINTER_VERSION = "version https://git-lfs.github.com/spec/v1"
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_RESOURCE_DIGEST_RE = _SHA256_RE
 _VARIABLE_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _URI_RE = re.compile(
     r"\(\s*uri\s+(?:\"((?:\\.|[^\"\\])*)\"|([^\s()]+))",
@@ -692,22 +693,22 @@ def _coerce_toolchain_resources(
             raise ClosureError("toolchain resource names must be non-empty strings")
         if isinstance(value, PinnedToolchainResource):
             root = Path(value.root)
-            digest = value.digest
+            digest = _verify_resource_digest(name, root, value.digest)
             resource_name = value.name or name
         elif isinstance(value, Mapping):
             raw_root = value.get("root") or value.get("path")
-            digest = str(value.get("digest") or "")
+            supplied_digest = value.get("digest")
             if not raw_root:
                 raise ClosureError(f"toolchain resource {name!r} has no root")
+            if supplied_digest is None:
+                raise ClosureError(f"toolchain resource {name!r} has no pinned digest")
             root = Path(os.fspath(raw_root))
+            digest = _verify_resource_digest(name, root, supplied_digest)
             resource_name = name
         else:
             root = Path(os.fspath(value))
             resource_name = name
-            digest = _digest_path(root)
-        digest = str(digest).strip()
-        if not digest:
-            raise ClosureError(f"toolchain resource {name!r} has no pinned digest")
+            digest = resource_root_digest(root)
         specs[resource_name] = _ToolchainSpec(
             name=resource_name,
             root=root.resolve(strict=False),
@@ -717,7 +718,7 @@ def _coerce_toolchain_resources(
 
 
 def _digest_path(path: Path) -> str:
-    """Hash a local toolchain directory without embedding its host path."""
+    """Hash a resource tree without embedding its host path."""
 
     if not path.exists() or not path.is_dir():
         raise ClosureError(f"toolchain resource root is not a directory: {path}")
@@ -744,6 +745,30 @@ def _digest_path(path: Path) -> str:
             }
         )
     return _digest_json(entries)
+
+
+def resource_root_digest(path: str | Path) -> str:
+    """Return the canonical content/tree digest for a pinned resource root."""
+
+    return _digest_path(Path(path).resolve(strict=False))
+
+
+def _verify_resource_digest(name: str, root: Path, supplied: object) -> str:
+    digest = str(supplied).strip()
+    if not digest:
+        raise ClosureError(f"toolchain resource {name!r} has no pinned digest")
+    if not _RESOURCE_DIGEST_RE.fullmatch(digest):
+        raise ClosureError(
+            f"toolchain resource {name!r} digest must be canonical lowercase "
+            "64-hex SHA-256"
+        )
+    actual = resource_root_digest(root)
+    if digest != actual:
+        raise ClosureError(
+            f"toolchain resource {name!r} digest mismatch: supplied {digest}, "
+            f"resolved root has {actual}"
+        )
+    return digest
 
 
 def _resolve_project_paths(
@@ -988,4 +1013,5 @@ __all__ = [
     "build_input_closure",
     "materialize_input_closure",
     "materialize_project_input_closure",
+    "resource_root_digest",
 ]

--- a/backend/tests/test_release_studio_closure.py
+++ b/backend/tests/test_release_studio_closure.py
@@ -16,6 +16,7 @@ from app.release_studio.closure import (
     LfsMaterializationError,
     PinnedToolchainResource,
     materialize_input_closure,
+    resource_root_digest,
 )
 
 
@@ -272,7 +273,7 @@ class ReleaseStudioClosureTests(unittest.TestCase):
             '(options "") (descr "")))\n',
             encoding="utf-8",
         )
-        resource_digest = hashlib.sha256(b"pinned-resource").hexdigest()
+        resource_digest = resource_root_digest(toolchain)
         self.assertTrue(resource_digest)
         copied_toolchain = self.root / "pinned-kicad-copy/footprints"
         shutil.copytree(toolchain, copied_toolchain)
@@ -294,9 +295,10 @@ class ReleaseStudioClosureTests(unittest.TestCase):
             self.root / "pinned-closure-copy",
             relative_path="hardware/board",
             toolchain_resources={
-                "KICAD10_FOOTPRINT_DIR": PinnedToolchainResource(
-                    "KICAD10_FOOTPRINT_DIR", copied_toolchain, resource_digest
-                )
+                "KICAD10_FOOTPRINT_DIR": {
+                    "root": copied_toolchain,
+                    "digest": resource_digest,
+                }
             },
         )
         self.assertEqual(closure.input_closure_digest, copied_closure.input_closure_digest)
@@ -307,6 +309,23 @@ class ReleaseStudioClosureTests(unittest.TestCase):
             {reference.resolved_path for reference in closure.library_references},
         )
         self.assertEqual(closure.env_bindings[0].value, "toolchain:KICAD10_FOOTPRINT_DIR")
+
+        (toolchain / "Common.pretty/common.kicad_mod").write_text(
+            "(footprint mutated)", encoding="utf-8"
+        )
+        with self.assertRaisesRegex(ClosureError, "digest mismatch"):
+            materialize_input_closure(
+                self.repo,
+                pinned_commit,
+                self.root / "pinned-closure-mutated",
+                relative_path="hardware/board",
+                toolchain_resources={
+                    "KICAD10_FOOTPRINT_DIR": {
+                        "root": toolchain,
+                        "digest": resource_digest,
+                    }
+                },
+            )
 
         with self.assertRaisesRegex(ClosureError, "no pinned digest"):
             materialize_input_closure(

--- a/docs/release-studio/R2b.md
+++ b/docs/release-studio/R2b.md
@@ -36,7 +36,7 @@ turn the materialization into a subpath snapshot, so a table such as
 repository_inputs[]  { path, git_object_id, mode, type, materialized_digest }
 submodule_inputs[]   { path, gitlink_sha, resolved_tree_digest, recursive }
 lfs_inputs[]         { path, pointer_blob_sha, lfs_oid, materialized_digest }
-toolchain_resources  { name, digest }
+toolchain_resources  { name, digest }  # verified resource-root digest
 env_bindings[]       { name, value }
 library_references[] { source_path, reference, resolved_path, location }
 ```
@@ -48,10 +48,18 @@ excluded.  Records are sorted before hashing, and
 `app.release_studio.canonical.sha256_canonical` boundary.  Consequently two
 independent materializations of the same commit and pinned resources have the
 same digest, while a regular file and a symlink differ through their mode/type
-record even when they point at equivalent content.  A pinned toolchain digest
-is an opaque, caller-supplied nonblank identity (for example an OCI digest or
-resource-bundle digest); R2b intentionally does not require a particular digest
-format, and records only that stable value, not the host resource path.
+record even when they point at equivalent content.  `digest` for a supplied
+`PinnedToolchainResource` or `{root, digest}` mapping must be a canonical
+lowercase 64-hex SHA-256.  R2b recomputes that digest from the resolved
+resource-root tree (relative paths, modes/types, and file or symlink content)
+and fails closed on a mismatch.  A bare resource path derives the same digest
+automatically.  Only the stable digest enters the record, never the host path,
+so identical trees at different mount points remain path-independent.
+
+This verified resource-bundle digest is separate from the later
+`toolchain_digest` identity: R00/R00a bind the executor to the pinned OCI image
+digest, while R2b verifies the mounted project/toolchain resource root.  R2b
+does not redesign the executor/toolchain identity composition.
 
 The dynamic tests in `backend/tests/test_release_studio_closure.py` build small
 local repositories with nested submodules and LFS pointer blobs.  They do not


### PR DESCRIPTION
## Summary
- verify every explicit pinned toolchain resource digest against the resolved resource tree
- fail closed for blank, malformed, or mismatched digests while retaining host-path independence
- add a mutation regression and correct the earlier fake-digest acceptance fixture
- distinguish the verified resource-bundle digest from the separately pinned OCI executor identity

## Validation
- focused Luna suite: 15 passed
- parent final-image closure/jobset/live fixture suite: 20 passed
- compile and diff checks passed
