### PR TITLE
[Feature] Add password auth path

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -27,11 +27,19 @@ from app.core.session import (
     set_oidc_transaction_cookie,
     set_session_cookie,
 )
-from app.services import rate_limit_service, session_store_service
+from app.services import (
+    password_credential_service,
+    rate_limit_service,
+    session_store_service,
+)
 from app.services.auth_service import (
+    PasswordAuthResult,
     ResolvedSessionUser,
     authenticate_oidc_auth_code,
+    authenticate_password,
     build_oidc_authorization_url,
+    oidc_enabled,
+    password_auth_enabled,
 )
 
 router = APIRouter()
@@ -49,6 +57,27 @@ class LoginStartResponse(BaseModel):
     authorization_url: str
 
 
+class PasswordLoginRequest(BaseModel):
+    """Request body for local email/password login."""
+    email: str = Field(min_length=1, max_length=320)
+    password: str = Field(min_length=1, max_length=1024)
+    remember_me: bool = False
+
+
+class PasswordLoginResponse(BaseModel):
+    """The signed-in user, plus a flag when they must set a new password first."""
+    email: str
+    name: str
+    picture: str = ""
+    role: Role
+    must_change_password: bool = False
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str = Field(min_length=1, max_length=1024)
+    new_password: str = Field(min_length=1, max_length=1024)
+
+
 class UserSession(BaseModel):
     """User session data returned after successful login."""
     email: str
@@ -61,7 +90,9 @@ class AuthConfig(BaseModel):
     """Authentication configuration exposed to frontend."""
     auth_enabled: bool
     dev_mode: bool
+    oidc_enabled: bool = False
     oidc_provider_name: str = ""
+    password_auth_enabled: bool = False
     workspace_name: str
 
 
@@ -85,6 +116,33 @@ def _build_user_session(user: ResolvedSessionUser | AuthenticatedUser) -> UserSe
 
 def _guest_user_session() -> UserSession:
     return _build_user_session(guest_user())
+
+
+def _issue_session(
+    user: ResolvedSessionUser,
+    http_request: Request,
+    response: Response,
+    *,
+    remember_me: bool = False,
+) -> None:
+    """Create the server session and set the cookie. Shared by every login method
+    so the session, its cookie, and its lifetime are minted identically."""
+    ttl_seconds = (
+        settings.SESSION_REMEMBER_ME_DAYS * 86400 if remember_me else None
+    )
+    session_id, _ = session_store_service.create_session(
+        email=user.email,
+        name=user.name,
+        picture=user.picture,
+        user_agent=http_request.headers.get("user-agent", ""),
+        client_ip=rate_limit_service.client_fingerprint(http_request),
+        ttl_seconds=ttl_seconds,
+    )
+    set_session_cookie(
+        response,
+        create_session_token(session_id, ttl_seconds=ttl_seconds),
+        max_age_seconds=ttl_seconds,
+    )
 
 
 def _login_redirect_uri(request: Request) -> str:
@@ -126,7 +184,9 @@ async def get_auth_config():
     return AuthConfig(
         auth_enabled=settings.AUTH_ENABLED,
         dev_mode=settings.DEV_MODE,
+        oidc_enabled=oidc_enabled(),
         oidc_provider_name=settings.OIDC_PROVIDER_NAME.strip() or "SSO",
+        password_auth_enabled=password_auth_enabled(),
         workspace_name=settings.WORKSPACE_NAME,
     )
 
@@ -193,17 +253,73 @@ async def login(request: LoginRequest, http_request: Request, response: Response
         code_verifier=transaction["code_verifier"],
     )
 
-    session_id, _ = session_store_service.create_session(
-        email=session_user.email,
-        name=session_user.name,
-        picture=session_user.picture,
-        user_agent=http_request.headers.get("user-agent", ""),
-        client_ip=rate_limit_service.client_fingerprint(http_request),
-    )
-    set_session_cookie(response, create_session_token(session_id))
+    _issue_session(session_user, http_request, response)
     rate_limit_service.clear(bucket)
 
     return _build_user_session(session_user)
+
+
+@router.post("/login/password", response_model=PasswordLoginResponse)
+async def login_with_password(
+    request: PasswordLoginRequest, http_request: Request, response: Response
+):
+    """Complete a local email/password login and issue a session.
+
+    Rate limited on the same bucket as OIDC. A failed attempt returns a generic
+    401 and does not clear the limiter, so repeated guessing is throttled.
+    """
+    if not settings.AUTH_ENABLED:
+        return PasswordLoginResponse(**_guest_user_session().model_dump())
+    if not password_auth_enabled():
+        raise HTTPException(status_code=400, detail="Password login is not enabled on this deployment")
+
+    bucket = _enforce_login_rate_limit(http_request, "password")
+
+    result: PasswordAuthResult = authenticate_password(request.email, request.password)
+
+    _issue_session(result.user, http_request, response, remember_me=request.remember_me)
+    rate_limit_service.clear(bucket)
+
+    return PasswordLoginResponse(
+        email=result.user.email,
+        name=result.user.name,
+        picture=result.user.picture,
+        role=result.user.role,
+        must_change_password=result.must_change_password,
+    )
+
+
+@router.post("/password/change")
+async def change_own_password(
+    request: ChangePasswordRequest,
+    http_request: Request,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Change the signed-in user's own local password.
+
+    The current password is re-verified even though the caller holds a valid
+    session, so a walk-up on an unlocked screen cannot silently reset it. Other
+    sessions are revoked, since the old password should no longer grant access.
+    """
+    if not password_auth_enabled():
+        raise HTTPException(status_code=400, detail="Password login is not enabled on this deployment")
+    if not password_credential_service.has_credential(user.email):
+        raise HTTPException(status_code=400, detail="This account does not use a local password")
+
+    if not password_credential_service.verify_password(user.email, request.current_password).ok:
+        raise HTTPException(status_code=403, detail="Current password is incorrect")
+
+    try:
+        password_credential_service.set_password(
+            user.email, request.new_password, updated_by=user.email
+        )
+    except password_credential_service.PasswordPolicyError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    session_store_service.revoke_sessions_for_email(
+        user.email, reason="password_changed", keep_session_id=user.session_id
+    )
+    return {"success": True}
 
 
 @router.get("/me", response_model=UserSession)

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -10,6 +10,7 @@ from app.core.security import AuthenticatedUser, require_admin
 from app.services import (
     access_service,
     git_access_service,
+    password_credential_service,
     project_import_service,
     session_store_service,
 )
@@ -40,10 +41,18 @@ class RoleAssignmentResponse(BaseModel):
     email: str
     role: Role
     source: str
+    has_password: bool = False
 
 
 class UpsertRoleRequest(BaseModel):
     role: str
+
+
+class SetPasswordRequest(BaseModel):
+    password: str
+    # When true (the default), the user must change this password on next login,
+    # so an admin's chosen value never becomes their lasting secret.
+    must_change: bool = True
 
 @router.get("/ssh-key", response_model=SSHKeyResponse)
 async def get_ssh_key():
@@ -225,7 +234,14 @@ async def forget_git_host_key(host: str):
 
 @router.get("/access/users", response_model=List[RoleAssignmentResponse])
 async def list_access_users():
-    return [RoleAssignmentResponse(**item) for item in access_service.list_role_assignments()]
+    credentialed = set(password_credential_service.list_credentialed_emails())
+    return [
+        RoleAssignmentResponse(
+            **item,
+            has_password=item["email"].strip().lower() in credentialed,
+        )
+        for item in access_service.list_role_assignments()
+    ]
 
 
 @router.put("/access/users/{email}", response_model=RoleAssignmentResponse)
@@ -261,3 +277,44 @@ async def delete_access_user(email: str, user: AuthenticatedUser = Depends(requi
     revoked = session_store_service.revoke_sessions_for_email(email, reason=f"access_revoked:{user.email}")
 
     return {"deleted": email.strip().lower(), "sessions_revoked": revoked}
+
+
+@router.put("/access/users/{email}/password")
+async def set_user_password(
+    email: str,
+    request: SetPasswordRequest,
+    user: AuthenticatedUser = Depends(require_admin),
+):
+    """Set or reset a user's local password (admin only).
+
+    Resetting revokes the user's existing sessions, since the old password no
+    longer grants access. must_change defaults true, so the admin's value is a
+    one-time credential the user replaces on next login.
+    """
+    try:
+        password_credential_service.set_password(
+            email,
+            request.password,
+            updated_by=user.email,
+            must_change=request.must_change,
+        )
+    except password_credential_service.PasswordPolicyError as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
+
+    revoked = session_store_service.revoke_sessions_for_email(
+        email, reason=f"password_reset:{user.email}"
+    )
+    return {
+        "email": email.strip().lower(),
+        "must_change": request.must_change,
+        "sessions_revoked": revoked,
+    }
+
+
+@router.delete("/access/users/{email}/password")
+async def remove_user_password(email: str, user: AuthenticatedUser = Depends(require_admin)):
+    """Remove a user's local password credential (e.g. they move to SSO-only)."""
+    removed = password_credential_service.delete_credential(email)
+    if not removed:
+        raise HTTPException(status_code=404, detail="No local password for this user")
+    return {"email": email.strip().lower(), "removed": True}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -143,6 +143,19 @@ class Settings(BaseSettings):
         description="Comma-separated list of admin user emails provisioned from env"
     )
 
+    # A one-time password seeded for the bootstrap admins on first startup, so a
+    # password-only deployment has a way to sign in and create real accounts. It
+    # is only ever applied when the admin has no credential yet, and always with
+    # must-change set, so the first sign-in forces a replacement.
+    BOOTSTRAP_ADMIN_PASSWORD: str = Field(
+        default="",
+        description=(
+            "One-time password seeded for BOOTSTRAP_ADMIN_USERS on first startup "
+            "when password auth is enabled. The admin must change it on first "
+            "sign-in. Leave empty once real accounts exist."
+        ),
+    )
+
     # Comma-separated list of email domains that receive implicit viewer access.
     DEFAULT_VIEWER_DOMAINS_STR: str = Field(
         default="",
@@ -735,6 +748,13 @@ class Settings(BaseSettings):
                 "host a user names -- including addresses inside this network that the "
                 "browser cannot reach but the server can. Set it to the Git hosts this "
                 "installation is meant to reach."
+            )
+
+        if self.BOOTSTRAP_ADMIN_PASSWORD.strip():
+            warnings.append(
+                "BOOTSTRAP_ADMIN_PASSWORD is set. It seeds a one-time admin password "
+                "for first login; clear it once the admin has signed in and set a real "
+                "password, so a bootstrap secret is not left in the environment."
             )
 
         return warnings

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -212,6 +212,30 @@ class Settings(BaseSettings):
         description="Sliding window for authentication attempt rate limiting."
     )
 
+    # Local username/password login, offered alongside or instead of OIDC. A
+    # deployment with AUTH_ENABLED=true must configure at least one method.
+    PASSWORD_AUTH_ENABLED: bool = Field(
+        default=False,
+        description="Enable local email/password login in addition to (or instead of) OIDC."
+    )
+
+    PASSWORD_MIN_LENGTH: int = Field(
+        default=12,
+        ge=8,
+        le=72,
+        description="Minimum length for a local password (bytes cap at 72, bcrypt's limit)."
+    )
+
+    # 'Remember me' session lifetime. A normal session lives SESSION_TTL_HOURS; a
+    # remembered one lives this long instead, for both the cookie and the stored
+    # session record so revocation still governs it.
+    SESSION_REMEMBER_ME_DAYS: int = Field(
+        default=30,
+        ge=1,
+        le=365,
+        description="Lifetime (days) of a 'remember me' session."
+    )
+
     # Comma-separated browser origins allowed to make credentialed API requests.
     CORS_ORIGINS_STR: str = Field(
         default="http://127.0.0.1:5173,http://localhost:5173,http://127.0.0.1:8080,http://localhost:8080",
@@ -600,6 +624,25 @@ class Settings(BaseSettings):
         return self.OIDC_SCOPES.strip() or "openid profile email"
 
     @property
+    def OIDC_FULLY_CONFIGURED(self) -> bool:
+        """All three OIDC values are present, so OIDC is a usable login method."""
+        return bool(
+            self.EFFECTIVE_OIDC_ISSUER_URL
+            and self.EFFECTIVE_OIDC_CLIENT_ID
+            and self.EFFECTIVE_OIDC_CLIENT_SECRET
+        )
+
+    @property
+    def OIDC_PARTIALLY_CONFIGURED(self) -> bool:
+        """Some but not all OIDC values are present: a misconfiguration to flag."""
+        present = [
+            bool(self.EFFECTIVE_OIDC_ISSUER_URL),
+            bool(self.EFFECTIVE_OIDC_CLIENT_ID),
+            bool(self.EFFECTIVE_OIDC_CLIENT_SECRET),
+        ]
+        return any(present) and not all(present)
+
+    @property
     def KICAD_PROJECTS_ROOT(self) -> str:
         return os.environ.get(
             "KICAD_PROJECTS_ROOT",
@@ -702,15 +745,30 @@ class Settings(BaseSettings):
             return self._open_auth_errors()
 
         errors: List[str] = []
-        if not self.EFFECTIVE_OIDC_ISSUER_URL:
-            errors.append("OIDC_ISSUER_URL is required when AUTH_ENABLED=true")
-        elif not self.EFFECTIVE_OIDC_ISSUER_URL.startswith("https://"):
+
+        # At least one login method must be usable. Password auth alone is
+        # enough, so OIDC is no longer unconditionally required.
+        if not self.OIDC_FULLY_CONFIGURED and not self.PASSWORD_AUTH_ENABLED:
+            errors.append(
+                "AUTH_ENABLED=true requires a login method: configure OIDC "
+                "(OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET) or set "
+                "PASSWORD_AUTH_ENABLED=true."
+            )
+
+        # A half-configured OIDC is a mistake even when password auth covers the
+        # deployment: the operator clearly intended OIDC, so name what is missing.
+        if self.OIDC_PARTIALLY_CONFIGURED:
+            if not self.EFFECTIVE_OIDC_ISSUER_URL:
+                errors.append("OIDC_ISSUER_URL is required to enable OIDC")
+            if not self.EFFECTIVE_OIDC_CLIENT_ID:
+                errors.append("OIDC_CLIENT_ID is required to enable OIDC")
+            if not self.EFFECTIVE_OIDC_CLIENT_SECRET:
+                errors.append("OIDC_CLIENT_SECRET is required to enable OIDC")
+
+        # Validate the OIDC details whenever any OIDC config is present.
+        if self.EFFECTIVE_OIDC_ISSUER_URL and not self.EFFECTIVE_OIDC_ISSUER_URL.startswith("https://"):
             errors.append("OIDC_ISSUER_URL must use https://")
-        if not self.EFFECTIVE_OIDC_CLIENT_ID:
-            errors.append("OIDC_CLIENT_ID is required when AUTH_ENABLED=true")
-        if not self.EFFECTIVE_OIDC_CLIENT_SECRET:
-            errors.append("OIDC_CLIENT_SECRET is required when AUTH_ENABLED=true")
-        if self.OIDC_TOKEN_AUTH_METHOD.strip().lower() not in {"client_secret_post", "client_secret_basic"}:
+        if self.OIDC_FULLY_CONFIGURED and self.OIDC_TOKEN_AUTH_METHOD.strip().lower() not in {"client_secret_post", "client_secret_basic"}:
             errors.append("OIDC_TOKEN_AUTH_METHOD must be client_secret_post or client_secret_basic")
 
         secret = self.SESSION_SECRET.strip()

--- a/backend/app/core/session.py
+++ b/backend/app/core/session.py
@@ -77,17 +77,19 @@ def _decode(token: str, *, purpose: str, version: str) -> dict[str, Any] | None:
     return data
 
 
-def create_session_token(session_id: str) -> str:
+def create_session_token(session_id: str, *, ttl_seconds: int | None = None) -> str:
     """Wrap an opaque session id in a signed, expiring envelope.
 
     Identity and revocation live in the session store; this token only proves the
     cookie was minted by this deployment and has not been tampered with.
+    ``ttl_seconds`` overrides the default lifetime for a 'remember me' session.
     """
     now = int(time.time())
+    lifetime = ttl_seconds if ttl_seconds else settings.SESSION_TTL_HOURS * 3600
     payload: SessionPayload = SessionPayload(
         sid=session_id,
         iat=now,
-        exp=now + (settings.SESSION_TTL_HOURS * 3600),
+        exp=now + lifetime,
     )
     return _encode(dict(payload), purpose="session", version="v2")
 
@@ -131,14 +133,14 @@ def decode_oidc_transaction_token(token: str) -> OidcTransaction | None:
         return None
 
 
-def set_session_cookie(response: Response, token: str) -> None:
+def set_session_cookie(response: Response, token: str, *, max_age_seconds: int | None = None) -> None:
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=token,
         httponly=True,
         secure=settings.SESSION_COOKIE_SECURE,
         samesite=SESSION_COOKIE_SAMESITE,
-        max_age=settings.SESSION_TTL_HOURS * 3600,
+        max_age=max_age_seconds if max_age_seconds else settings.SESSION_TTL_HOURS * 3600,
         path="/",
     )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from app.api.oauth import router as oauth_router
 from app.api.service_clients import router as service_clients_router
 from app.api.jobs import router as jobs_router
 from app.api.health import router as health_router
-from app.services import rate_limit_service, session_store_service
+from app.services import password_credential_service, rate_limit_service, session_store_service
 from app.services.comments_store_service import initialize_comments_store
 from app.services.component_catalog_service import catalog_service
 from app.services.postgres_database import database
@@ -171,6 +171,20 @@ async def lifespan(app: FastAPI):
         session_store_service.initialize_session_store()
         session_store_service.prune_expired_sessions()
         rate_limit_service.initialize_rate_limit_store()
+        # Seed a one-time password for bootstrap admins so a password-only
+        # deployment has a way to sign in and create real accounts. No-op unless
+        # BOOTSTRAP_ADMIN_PASSWORD is set and the admin has no credential yet.
+        try:
+            seeded = password_credential_service.seed_bootstrap_admins()
+            if seeded:
+                logger.warning(
+                    "Seeded a one-time bootstrap password for: %s. They must "
+                    "change it on first sign-in; clear BOOTSTRAP_ADMIN_PASSWORD "
+                    "afterwards.",
+                    ", ".join(seeded),
+                )
+        except Exception:
+            logger.exception("Failed to seed bootstrap admin password")
     try:
         yield
     finally:

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -18,7 +18,7 @@ from requests.auth import HTTPBasicAuth
 
 from app.core.config import settings
 from app.core.roles import Role, normalize_role
-from app.services import access_service
+from app.services import access_service, password_credential_service
 
 logger = logging.getLogger(__name__)
 
@@ -257,11 +257,9 @@ def _fetch_userinfo(access_token: str) -> dict[str, Any]:
         raise HTTPException(status_code=502, detail="Failed to fetch OIDC user profile") from exc
 
 
-def _validate_allowed_user(email: str) -> str:
-    normalized_email = email.strip().casefold()
-    if not normalized_email:
-        raise HTTPException(status_code=401, detail="OIDC profile did not include an email address")
-
+def _enforce_user_allowlist(normalized_email: str) -> None:
+    """Apply the ALLOWED_USERS / ALLOWED_DOMAINS gate. Shared by every login method
+    so OIDC and password grant access on identical terms."""
     allowed_users = {user.strip().casefold() for user in settings.ALLOWED_USERS if user.strip()}
     if allowed_users and normalized_email not in allowed_users:
         raise HTTPException(status_code=403, detail="Access denied. Your email is not in the allowed users list.")
@@ -272,6 +270,12 @@ def _validate_allowed_user(email: str) -> str:
         if domain not in allowed_domains:
             raise HTTPException(status_code=403, detail="Access denied. Your email domain is not allowed.")
 
+
+def _validate_allowed_user(email: str) -> str:
+    normalized_email = email.strip().casefold()
+    if not normalized_email:
+        raise HTTPException(status_code=401, detail="OIDC profile did not include an email address")
+    _enforce_user_allowlist(normalized_email)
     return normalized_email
 
 
@@ -285,6 +289,48 @@ def _resolve_session_user(profile: dict[str, Any]) -> ResolvedSessionUser:
     name = str(profile.get(settings.OIDC_NAME_CLAIM) or profile.get("name") or email.split("@")[0])
     picture = str(profile.get(settings.OIDC_PICTURE_CLAIM) or profile.get("picture") or "")
     return ResolvedSessionUser(email=email, name=name, picture=picture, role=role)
+
+
+@dataclass(frozen=True)
+class PasswordAuthResult:
+    user: ResolvedSessionUser
+    must_change_password: bool
+
+
+def password_auth_enabled() -> bool:
+    return bool(settings.PASSWORD_AUTH_ENABLED)
+
+
+def authenticate_password(email: str, password: str) -> PasswordAuthResult:
+    """Verify a local password and resolve the same session user OIDC would.
+
+    A wrong password and an unknown/credential-less email both raise the same
+    401 with the same generic message, and the credential store equalizes their
+    timing, so neither response reveals whether an address has an account. Only
+    after the password matches do the allowlist and role checks run, and those
+    403s are expected to be seen only by someone who already proved the password.
+    """
+    normalized_email = email.strip().casefold()
+    if not normalized_email or not password:
+        raise HTTPException(status_code=401, detail="Invalid email or password.")
+
+    verification = password_credential_service.verify_password(normalized_email, password)
+    if not verification.ok:
+        raise HTTPException(status_code=401, detail="Invalid email or password.")
+
+    _enforce_user_allowlist(normalized_email)
+    access_service.ensure_default_viewer_assignment(normalized_email)
+    role = access_service.resolve_user_role(normalized_email)
+    if not role:
+        raise HTTPException(status_code=403, detail="Access denied. No role assignment found for your account.")
+
+    user = ResolvedSessionUser(
+        email=normalized_email,
+        name=normalized_email.split("@")[0],
+        picture="",
+        role=role,
+    )
+    return PasswordAuthResult(user=user, must_change_password=verification.must_change)
 
 
 def authenticate_oidc_auth_code(

--- a/backend/app/services/password_credential_service.py
+++ b/backend/app/services/password_credential_service.py
@@ -1,0 +1,211 @@
+"""Local username/password credentials.
+
+Identity (does this person hold the password?) is stored here; authorization
+(what may they do?) stays in ``access_service`` keyed by the same email, exactly
+as it is for OIDC. So a password login and an OIDC login for the same address
+resolve to the same role and the same session machinery.
+
+Passwords are stored only as bcrypt hashes. Plaintext never touches the database
+or a log line, and verification is constant-time by construction.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+
+import bcrypt
+
+from app.core.config import settings
+from app.services.postgres_database import database
+
+
+_init_lock = threading.Lock()
+_initialized = False
+
+# bcrypt truncates silently at 72 bytes; refuse longer inputs rather than let two
+# distinct long passwords collide on their first 72 bytes.
+_MAX_PASSWORD_BYTES = 72
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def initialize_credential_store() -> None:
+    global _initialized
+    if _initialized:
+        return
+    with _init_lock:
+        if _initialized:
+            return
+        with database.connection() as connection:
+            connection.execute("CREATE SCHEMA IF NOT EXISTS workspace")
+            connection.execute("SET search_path TO workspace, public")
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_credentials (
+                    email TEXT PRIMARY KEY,
+                    password_hash TEXT NOT NULL,
+                    must_change_password BOOLEAN NOT NULL DEFAULT FALSE,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_by TEXT NOT NULL
+                )
+                """
+            )
+            connection.commit()
+        _initialized = True
+
+
+class PasswordPolicyError(ValueError):
+    """Raised when a proposed password does not meet the configured policy."""
+
+
+def validate_password_policy(password: str) -> None:
+    """Enforce the server-side minimums. Raises PasswordPolicyError on failure."""
+    if len(password.encode("utf-8")) > _MAX_PASSWORD_BYTES:
+        raise PasswordPolicyError(
+            f"Password must be at most {_MAX_PASSWORD_BYTES} bytes long."
+        )
+    minimum = int(settings.PASSWORD_MIN_LENGTH)
+    if len(password) < minimum:
+        raise PasswordPolicyError(
+            f"Password must be at least {minimum} characters long."
+        )
+
+
+def _hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("ascii")
+
+
+def set_password(
+    email: str,
+    password: str,
+    *,
+    updated_by: str,
+    must_change: bool = False,
+) -> None:
+    """Create or replace a user's password credential.
+
+    ``must_change`` forces a change on the user's next login, used when an admin
+    sets or resets a password so the admin's chosen value is never a lasting
+    secret.
+    """
+    normalized = _normalize_email(email)
+    if not normalized:
+        raise PasswordPolicyError("An email address is required.")
+    validate_password_policy(password)
+
+    initialize_credential_store()
+    password_hash = _hash_password(password)
+    with database.connection() as connection:
+        connection.execute("SET search_path TO workspace, public")
+        connection.execute(
+            """
+            INSERT INTO user_credentials (email, password_hash, must_change_password, updated_by)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (email) DO UPDATE
+                SET password_hash = EXCLUDED.password_hash,
+                    must_change_password = EXCLUDED.must_change_password,
+                    updated_at = NOW(),
+                    updated_by = EXCLUDED.updated_by
+            """,
+            (normalized, password_hash, must_change, updated_by),
+        )
+        connection.commit()
+
+
+def _load_credential(normalized_email: str) -> dict | None:
+    initialize_credential_store()
+    with database.connection() as connection:
+        connection.execute("SET search_path TO workspace, public")
+        row = connection.execute(
+            """
+            SELECT password_hash, must_change_password
+            FROM user_credentials
+            WHERE email = %s
+            """,
+            (normalized_email,),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def has_credential(email: str) -> bool:
+    return _load_credential(_normalize_email(email)) is not None
+
+
+class PasswordVerification:
+    """Result of verifying a password: whether it matched and whether a change is due."""
+
+    __slots__ = ("ok", "must_change")
+
+    def __init__(self, ok: bool, must_change: bool = False) -> None:
+        self.ok = ok
+        self.must_change = must_change
+
+
+# A fixed bcrypt hash of a random value, used to spend the same work verifying a
+# password for an email that has no credential as for one that does. Without it,
+# the absence of a row is observable through timing and leaks which emails exist.
+_DUMMY_HASH = bcrypt.hashpw(b"kicad-prism-timing-equalizer", bcrypt.gensalt())
+
+
+def verify_password(email: str, password: str) -> PasswordVerification:
+    """Check a password against the stored hash in constant time.
+
+    Returns ok=False for both an unknown email and a wrong password, and takes
+    the same time in both cases, so the response cannot be used to enumerate
+    which addresses have credentials.
+    """
+    credential = _load_credential(_normalize_email(email))
+    encoded = password.encode("utf-8")
+    if credential is None:
+        # Still spend the hashing cost so the timing matches a real check.
+        bcrypt.checkpw(encoded, _DUMMY_HASH)
+        return PasswordVerification(ok=False)
+    matched = bcrypt.checkpw(encoded, credential["password_hash"].encode("utf-8"))
+    return PasswordVerification(
+        ok=matched,
+        must_change=bool(matched and credential["must_change_password"]),
+    )
+
+
+def clear_must_change(email: str) -> None:
+    normalized = _normalize_email(email)
+    initialize_credential_store()
+    with database.connection() as connection:
+        connection.execute("SET search_path TO workspace, public")
+        connection.execute(
+            "UPDATE user_credentials SET must_change_password = FALSE, updated_at = NOW() WHERE email = %s",
+            (normalized,),
+        )
+        connection.commit()
+
+
+def delete_credential(email: str) -> bool:
+    normalized = _normalize_email(email)
+    initialize_credential_store()
+    with database.connection() as connection:
+        connection.execute("SET search_path TO workspace, public")
+        result = connection.execute(
+            "DELETE FROM user_credentials WHERE email = %s",
+            (normalized,),
+        )
+        connection.commit()
+        return bool(result.rowcount)
+
+
+def list_credentialed_emails() -> list[str]:
+    """Every email that has a local password, for the admin user list."""
+    initialize_credential_store()
+    with database.connection() as connection:
+        connection.execute("SET search_path TO workspace, public")
+        rows = connection.execute(
+            "SELECT email FROM user_credentials ORDER BY email"
+        ).fetchall()
+    return [str(row["email"]) for row in rows]

--- a/backend/app/services/password_credential_service.py
+++ b/backend/app/services/password_credential_service.py
@@ -209,3 +209,38 @@ def list_credentialed_emails() -> list[str]:
             "SELECT email FROM user_credentials ORDER BY email"
         ).fetchall()
     return [str(row["email"]) for row in rows]
+
+
+def seed_bootstrap_admins() -> list[str]:
+    """Seed a one-time password for bootstrap admins that have none yet.
+
+    This solves the first-login problem for a password-only deployment: without
+    it, a bootstrap admin holds the admin role but has no credential to sign in
+    with, and cannot reach the admin UI to create one.
+
+    It is deliberately conservative. It only runs when password auth is on and a
+    bootstrap password is set, only touches emails with no existing credential
+    (so a real password is never clobbered), and always seeds with must_change,
+    so the seeded value is a one-time key the admin replaces on first sign-in.
+    Returns the emails it seeded.
+    """
+    if not settings.PASSWORD_AUTH_ENABLED:
+        return []
+    seed_password = settings.BOOTSTRAP_ADMIN_PASSWORD.strip()
+    if not seed_password:
+        return []
+
+    admins = [email.strip().lower() for email in settings.BOOTSTRAP_ADMIN_USERS if email.strip()]
+    if not admins:
+        return []
+
+    # A weak seed defeats the purpose; enforce the same policy as any password.
+    validate_password_policy(seed_password)
+
+    seeded: list[str] = []
+    for email in admins:
+        if has_credential(email):
+            continue
+        set_password(email, seed_password, updated_by="bootstrap", must_change=True)
+        seeded.append(email)
+    return seeded

--- a/backend/app/services/session_store_service.py
+++ b/backend/app/services/session_store_service.py
@@ -103,11 +103,18 @@ def create_session(
     picture: str,
     user_agent: str = "",
     client_ip: str = "",
+    ttl_seconds: int | None = None,
 ) -> tuple[str, SessionRecord]:
-    """Mint a new session and return its secret id alongside the stored record."""
+    """Mint a new session and return its secret id alongside the stored record.
+
+    ``ttl_seconds`` overrides the default lifetime, used for a 'remember me'
+    login. The store's expires_at is the revocation authority, so it must carry
+    the same lifetime the cookie does.
+    """
     initialize_session_store()
     session_id = secrets.token_urlsafe(32)
-    expires_at = _now() + timedelta(hours=settings.SESSION_TTL_HOURS)
+    lifetime = timedelta(seconds=ttl_seconds) if ttl_seconds else timedelta(hours=settings.SESSION_TTL_HOURS)
+    expires_at = _now() + lifetime
 
     with database.connection() as connection:
         connection.execute("SET search_path TO workspace, public")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ pydantic-settings
 python-dotenv
 requests
 PyJWT[crypto]
+bcrypt>=4,<5
 kiutils
 python-multipart
 psycopg[binary]>=3.2,<4

--- a/backend/tests/test_auth_hardening.py
+++ b/backend/tests/test_auth_hardening.py
@@ -48,16 +48,46 @@ class AuthConfigurationFailClosedTests(unittest.TestCase):
         self.assertEqual(self._settings().auth_configuration_errors(), [])
 
     def test_missing_oidc_secret_blocks_startup_instead_of_disabling_auth(self) -> None:
+        # OIDC is partially configured (issuer + client id, no secret) and
+        # password auth is off, so this must fail closed rather than serve open.
         broken = self._settings(OIDC_CLIENT_SECRET="")
         # The old behaviour: AUTH_ENABLED silently became False and every caller
         # was served as an admin guest.
         self.assertTrue(broken.AUTH_ENABLED)
         self.assertIn(
-            "OIDC_CLIENT_SECRET is required when AUTH_ENABLED=true",
+            "OIDC_CLIENT_SECRET is required to enable OIDC",
             broken.auth_configuration_errors(),
         )
         with self.assertRaises(RuntimeError):
             broken.validate_auth_configuration()
+
+    def test_password_auth_alone_is_a_valid_method(self) -> None:
+        # No OIDC configured, password auth on: a complete, accepted deployment.
+        configured = self._settings(
+            OIDC_ISSUER_URL="",
+            OIDC_CLIENT_ID="",
+            OIDC_CLIENT_SECRET="",
+            PASSWORD_AUTH_ENABLED=True,
+        )
+        self.assertTrue(configured.AUTH_ENABLED)
+        self.assertEqual(configured.auth_configuration_errors(), [])
+
+    def test_no_method_at_all_blocks_startup(self) -> None:
+        # AUTH_ENABLED with neither OIDC nor password is the dangerous case.
+        broken = self._settings(
+            OIDC_ISSUER_URL="",
+            OIDC_CLIENT_ID="",
+            OIDC_CLIENT_SECRET="",
+            PASSWORD_AUTH_ENABLED=False,
+        )
+        errors = broken.auth_configuration_errors()
+        self.assertTrue(any("requires a login method" in error for error in errors))
+        with self.assertRaises(RuntimeError):
+            broken.validate_auth_configuration()
+
+    def test_password_and_oidc_can_coexist(self) -> None:
+        both = self._settings(PASSWORD_AUTH_ENABLED=True)
+        self.assertEqual(both.auth_configuration_errors(), [])
 
     def test_dev_mode_no_longer_disables_authentication(self) -> None:
         self.assertTrue(self._settings(DEV_MODE=True).AUTH_ENABLED)

--- a/backend/tests/test_password_authentication.py
+++ b/backend/tests/test_password_authentication.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services import auth_service  # noqa: E402
+from app.services.password_credential_service import PasswordVerification  # noqa: E402
+
+
+def _ok(must_change: bool = False) -> PasswordVerification:
+    return PasswordVerification(ok=True, must_change=must_change)
+
+
+def _bad() -> PasswordVerification:
+    return PasswordVerification(ok=False)
+
+
+class AuthenticatePasswordTests(unittest.TestCase):
+    """Authorization logic around password verification, with the store mocked."""
+
+    def _run(
+        self,
+        *,
+        verification: PasswordVerification,
+        role: str | None = "viewer",
+        allowed_users: tuple[str, ...] = (),
+        allowed_domains: tuple[str, ...] = (),
+        email: str = "user@example.com",
+        password: str = "a valid password",
+    ):
+        with patch.object(auth_service.password_credential_service, "verify_password", return_value=verification), \
+             patch.object(auth_service.access_service, "ensure_default_viewer_assignment"), \
+             patch.object(auth_service.access_service, "resolve_user_role", return_value=role), \
+             patch.object(auth_service.settings, "ALLOWED_USERS_STR", ",".join(allowed_users)), \
+             patch.object(auth_service.settings, "ALLOWED_DOMAINS_STR", ",".join(allowed_domains)):
+            return auth_service.authenticate_password(email, password)
+
+    def test_success_returns_resolved_user(self) -> None:
+        result = self._run(verification=_ok(), role="designer")
+        self.assertEqual(result.user.email, "user@example.com")
+        self.assertEqual(result.user.role, "designer")
+        self.assertEqual(result.user.name, "user")  # email local-part
+        self.assertFalse(result.must_change_password)
+
+    def test_must_change_flag_carries_through(self) -> None:
+        result = self._run(verification=_ok(must_change=True))
+        self.assertTrue(result.must_change_password)
+
+    def test_wrong_password_is_generic_401(self) -> None:
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(verification=_bad())
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(ctx.exception.detail, "Invalid email or password.")
+
+    def test_empty_credentials_are_generic_401(self) -> None:
+        for email, password in (("", "pw"), ("user@example.com", "")):
+            with self.assertRaises(HTTPException) as ctx:
+                self._run(verification=_ok(), email=email, password=password)
+            self.assertEqual(ctx.exception.status_code, 401)
+            self.assertEqual(ctx.exception.detail, "Invalid email or password.")
+
+    def test_unknown_email_and_wrong_password_are_indistinguishable(self) -> None:
+        # Both surface as the same 401 with the same message, so a caller cannot
+        # tell whether the account exists.
+        with self.assertRaises(HTTPException) as unknown:
+            self._run(verification=_bad(), email="nobody@example.com")
+        with self.assertRaises(HTTPException) as wrong:
+            self._run(verification=_bad(), email="user@example.com")
+        self.assertEqual(unknown.exception.detail, wrong.exception.detail)
+        self.assertEqual(unknown.exception.status_code, wrong.exception.status_code)
+
+    def test_allowlist_blocks_after_password_matches(self) -> None:
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(verification=_ok(), allowed_users=("someone-else@example.com",))
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_domain_allowlist_blocks_wrong_domain(self) -> None:
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(verification=_ok(), allowed_domains=("allowed.com",), email="user@notallowed.com")
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_domain_allowlist_permits_right_domain(self) -> None:
+        result = self._run(verification=_ok(), allowed_domains=("example.com",))
+        self.assertEqual(result.user.role, "viewer")
+
+    def test_no_role_assignment_is_403(self) -> None:
+        with self.assertRaises(HTTPException) as ctx:
+            self._run(verification=_ok(), role=None)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_email_is_normalized_before_verification(self) -> None:
+        captured: dict[str, str] = {}
+
+        def fake_verify(email: str, password: str) -> PasswordVerification:
+            captured["email"] = email
+            return _ok()
+
+        with patch.object(auth_service.password_credential_service, "verify_password", side_effect=fake_verify), \
+             patch.object(auth_service.access_service, "ensure_default_viewer_assignment"), \
+             patch.object(auth_service.access_service, "resolve_user_role", return_value="viewer"), \
+             patch.object(auth_service.settings, "ALLOWED_USERS_STR", ""), \
+             patch.object(auth_service.settings, "ALLOWED_DOMAINS_STR", ""):
+            auth_service.authenticate_password("  MixedCase@Example.COM ", "a valid password")
+        self.assertEqual(captured["email"], "mixedcase@example.com")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_password_authentication.py
+++ b/backend/tests/test_password_authentication.py
@@ -12,6 +12,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from app.services import auth_service  # noqa: E402
 from app.services.password_credential_service import PasswordVerification  # noqa: E402
 
+# A synthetic, non-secret placeholder used wherever a test needs "some password".
+VALID_PASSWORD = "x" * 12
+
 
 def _ok(must_change: bool = False) -> PasswordVerification:
     return PasswordVerification(ok=True, must_change=must_change)
@@ -32,7 +35,7 @@ class AuthenticatePasswordTests(unittest.TestCase):
         allowed_users: tuple[str, ...] = (),
         allowed_domains: tuple[str, ...] = (),
         email: str = "user@example.com",
-        password: str = "a valid password",
+        password: str = VALID_PASSWORD,
     ):
         with patch.object(auth_service.password_credential_service, "verify_password", return_value=verification), \
              patch.object(auth_service.access_service, "ensure_default_viewer_assignment"), \
@@ -106,7 +109,7 @@ class AuthenticatePasswordTests(unittest.TestCase):
              patch.object(auth_service.access_service, "resolve_user_role", return_value="viewer"), \
              patch.object(auth_service.settings, "ALLOWED_USERS_STR", ""), \
              patch.object(auth_service.settings, "ALLOWED_DOMAINS_STR", ""):
-            auth_service.authenticate_password("  MixedCase@Example.COM ", "a valid password")
+            auth_service.authenticate_password("  MixedCase@Example.COM ", VALID_PASSWORD)
         self.assertEqual(captured["email"], "mixedcase@example.com")
 
 

--- a/backend/tests/test_password_credential_service.py
+++ b/backend/tests/test_password_credential_service.py
@@ -109,5 +109,64 @@ class PasswordCredentialStoreTests(unittest.TestCase):
         self.assertFalse(pcs.has_credential(self.EMAIL))
 
 
+@unittest.skipUnless(
+    os.environ.get("PRISM_DATABASE_URL"),
+    "PRISM_DATABASE_URL not set; skipping database-backed credential tests",
+)
+class BootstrapSeedTests(unittest.TestCase):
+    EMAIL = "bootstrap-admin@example.com"
+    SEED = "a bootstrap password"
+
+    def setUp(self) -> None:
+        pcs.initialize_credential_store()
+        pcs.delete_credential(self.EMAIL)
+
+    def tearDown(self) -> None:
+        pcs.delete_credential(self.EMAIL)
+
+    def _seed(self, **overrides):
+        from unittest.mock import patch
+
+        base = {
+            "PASSWORD_AUTH_ENABLED": True,
+            "BOOTSTRAP_ADMIN_PASSWORD": self.SEED,
+            "BOOTSTRAP_ADMIN_USERS_STR": self.EMAIL,
+        }
+        base.update(overrides)
+        with patch.object(pcs.settings, "PASSWORD_AUTH_ENABLED", base["PASSWORD_AUTH_ENABLED"]), \
+             patch.object(pcs.settings, "BOOTSTRAP_ADMIN_PASSWORD", base["BOOTSTRAP_ADMIN_PASSWORD"]), \
+             patch.object(pcs.settings, "BOOTSTRAP_ADMIN_USERS_STR", base["BOOTSTRAP_ADMIN_USERS_STR"]):
+            return pcs.seed_bootstrap_admins()
+
+    def test_seeds_a_must_change_credential(self) -> None:
+        seeded = self._seed()
+        self.assertEqual(seeded, [self.EMAIL])
+        result = pcs.verify_password(self.EMAIL, self.SEED)
+        self.assertTrue(result.ok)
+        self.assertTrue(result.must_change)  # forced change on first login
+
+    def test_is_idempotent_and_never_clobbers(self) -> None:
+        # The user changed their password after the first seed...
+        self._seed()
+        pcs.set_password(self.EMAIL, "user chosen password", updated_by=self.EMAIL, must_change=False)
+        # ...a restart must not reset it back to the seed.
+        seeded_again = self._seed()
+        self.assertEqual(seeded_again, [])
+        self.assertTrue(pcs.verify_password(self.EMAIL, "user chosen password").ok)
+        self.assertFalse(pcs.verify_password(self.EMAIL, self.SEED).ok)
+
+    def test_no_op_when_password_auth_disabled(self) -> None:
+        self.assertEqual(self._seed(PASSWORD_AUTH_ENABLED=False), [])
+        self.assertFalse(pcs.has_credential(self.EMAIL))
+
+    def test_no_op_when_no_seed_password(self) -> None:
+        self.assertEqual(self._seed(BOOTSTRAP_ADMIN_PASSWORD=""), [])
+        self.assertFalse(pcs.has_credential(self.EMAIL))
+
+    def test_weak_seed_is_rejected(self) -> None:
+        with self.assertRaises(pcs.PasswordPolicyError):
+            self._seed(BOOTSTRAP_ADMIN_PASSWORD="short")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_password_credential_service.py
+++ b/backend/tests/test_password_credential_service.py
@@ -10,6 +10,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.services import password_credential_service as pcs  # noqa: E402
 
+# Synthetic, non-secret placeholders used wherever a test needs "some password".
+VALID_PASSWORD = "x" * 12
+OTHER_PASSWORD = "y" * 12
+
 
 class PasswordPolicyTests(unittest.TestCase):
     """Policy and hashing checks that need no database."""
@@ -27,8 +31,8 @@ class PasswordPolicyTests(unittest.TestCase):
             pcs.validate_password_policy("a" * 73)
 
     def test_hash_round_trip(self) -> None:
-        digest = pcs._hash_password("correct horse battery staple")
-        self.assertNotIn("correct horse", digest)  # never store plaintext
+        digest = pcs._hash_password(VALID_PASSWORD)
+        self.assertNotIn(VALID_PASSWORD, digest)  # never store plaintext
         self.assertTrue(digest.startswith("$2"))  # a bcrypt hash
 
     def test_dummy_hash_verification_is_constant_time_shaped(self) -> None:
@@ -67,9 +71,9 @@ class PasswordCredentialStoreTests(unittest.TestCase):
         pcs.delete_credential(self.EMAIL)
 
     def test_set_and_verify(self) -> None:
-        pcs.set_password(self.EMAIL, "a valid password", updated_by="admin@x")
+        pcs.set_password(self.EMAIL, VALID_PASSWORD, updated_by="admin@x")
         self.assertTrue(pcs.has_credential(self.EMAIL))
-        self.assertTrue(pcs.verify_password(self.EMAIL, "a valid password").ok)
+        self.assertTrue(pcs.verify_password(self.EMAIL, VALID_PASSWORD).ok)
         self.assertFalse(pcs.verify_password(self.EMAIL, "wrong password").ok)
 
     def test_unknown_email_verifies_false_without_error(self) -> None:
@@ -78,27 +82,27 @@ class PasswordCredentialStoreTests(unittest.TestCase):
         self.assertFalse(result.must_change)
 
     def test_email_is_normalized(self) -> None:
-        pcs.set_password("  MixedCase@Example.COM  ", "a valid password", updated_by="admin@x")
-        self.assertTrue(pcs.verify_password("mixedcase@example.com", "a valid password").ok)
+        pcs.set_password("  MixedCase@Example.COM  ", VALID_PASSWORD, updated_by="admin@x")
+        self.assertTrue(pcs.verify_password("mixedcase@example.com", VALID_PASSWORD).ok)
         pcs.delete_credential("mixedcase@example.com")
 
     def test_must_change_flag_flows_through_and_clears(self) -> None:
-        pcs.set_password(self.EMAIL, "a valid password", updated_by="admin@x", must_change=True)
-        result = pcs.verify_password(self.EMAIL, "a valid password")
+        pcs.set_password(self.EMAIL, VALID_PASSWORD, updated_by="admin@x", must_change=True)
+        result = pcs.verify_password(self.EMAIL, VALID_PASSWORD)
         self.assertTrue(result.ok)
         self.assertTrue(result.must_change)
 
         pcs.clear_must_change(self.EMAIL)
-        self.assertFalse(pcs.verify_password(self.EMAIL, "a valid password").must_change)
+        self.assertFalse(pcs.verify_password(self.EMAIL, VALID_PASSWORD).must_change)
 
     def test_set_password_replaces_existing(self) -> None:
-        pcs.set_password(self.EMAIL, "first password value", updated_by="admin@x")
-        pcs.set_password(self.EMAIL, "second password value", updated_by="admin@x")
-        self.assertFalse(pcs.verify_password(self.EMAIL, "first password value").ok)
-        self.assertTrue(pcs.verify_password(self.EMAIL, "second password value").ok)
+        pcs.set_password(self.EMAIL, VALID_PASSWORD, updated_by="admin@x")
+        pcs.set_password(self.EMAIL, OTHER_PASSWORD, updated_by="admin@x")
+        self.assertFalse(pcs.verify_password(self.EMAIL, VALID_PASSWORD).ok)
+        self.assertTrue(pcs.verify_password(self.EMAIL, OTHER_PASSWORD).ok)
 
     def test_delete_removes_credential(self) -> None:
-        pcs.set_password(self.EMAIL, "a valid password", updated_by="admin@x")
+        pcs.set_password(self.EMAIL, VALID_PASSWORD, updated_by="admin@x")
         self.assertTrue(pcs.delete_credential(self.EMAIL))
         self.assertFalse(pcs.has_credential(self.EMAIL))
         self.assertFalse(pcs.delete_credential(self.EMAIL))  # already gone
@@ -115,7 +119,7 @@ class PasswordCredentialStoreTests(unittest.TestCase):
 )
 class BootstrapSeedTests(unittest.TestCase):
     EMAIL = "bootstrap-admin@example.com"
-    SEED = "a bootstrap password"
+    SEED = VALID_PASSWORD
 
     def setUp(self) -> None:
         pcs.initialize_credential_store()
@@ -148,11 +152,11 @@ class BootstrapSeedTests(unittest.TestCase):
     def test_is_idempotent_and_never_clobbers(self) -> None:
         # The user changed their password after the first seed...
         self._seed()
-        pcs.set_password(self.EMAIL, "user chosen password", updated_by=self.EMAIL, must_change=False)
+        pcs.set_password(self.EMAIL, OTHER_PASSWORD, updated_by=self.EMAIL, must_change=False)
         # ...a restart must not reset it back to the seed.
         seeded_again = self._seed()
         self.assertEqual(seeded_again, [])
-        self.assertTrue(pcs.verify_password(self.EMAIL, "user chosen password").ok)
+        self.assertTrue(pcs.verify_password(self.EMAIL, OTHER_PASSWORD).ok)
         self.assertFalse(pcs.verify_password(self.EMAIL, self.SEED).ok)
 
     def test_no_op_when_password_auth_disabled(self) -> None:

--- a/backend/tests/test_password_credential_service.py
+++ b/backend/tests/test_password_credential_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services import password_credential_service as pcs  # noqa: E402
+
+
+class PasswordPolicyTests(unittest.TestCase):
+    """Policy and hashing checks that need no database."""
+
+    def test_rejects_short_password(self) -> None:
+        with self.assertRaises(pcs.PasswordPolicyError):
+            pcs.validate_password_policy("short")
+
+    def test_accepts_password_at_minimum_length(self) -> None:
+        # Exactly the default minimum (12) must pass.
+        pcs.validate_password_policy("a" * 12)
+
+    def test_rejects_over_bcrypt_byte_limit(self) -> None:
+        with self.assertRaises(pcs.PasswordPolicyError):
+            pcs.validate_password_policy("a" * 73)
+
+    def test_hash_round_trip(self) -> None:
+        digest = pcs._hash_password("correct horse battery staple")
+        self.assertNotIn("correct horse", digest)  # never store plaintext
+        self.assertTrue(digest.startswith("$2"))  # a bcrypt hash
+
+    def test_dummy_hash_verification_is_constant_time_shaped(self) -> None:
+        # An unknown email still spends bcrypt work, so its verify latency is on
+        # the same order as a real check. This is a coarse guard against a
+        # zero-cost early return, not a precise timing assertion.
+        import bcrypt
+
+        real = bcrypt.hashpw(b"a-real-password", bcrypt.gensalt())
+
+        start = time.perf_counter()
+        bcrypt.checkpw(b"guess", real)
+        real_ms = time.perf_counter() - start
+
+        start = time.perf_counter()
+        bcrypt.checkpw(b"guess", pcs._DUMMY_HASH)
+        dummy_ms = time.perf_counter() - start
+
+        # Both must actually run the KDF (non-trivial time), and be comparable.
+        self.assertGreater(real_ms, 0.0005)
+        self.assertGreater(dummy_ms, 0.0005)
+
+
+@unittest.skipUnless(
+    os.environ.get("PRISM_DATABASE_URL"),
+    "PRISM_DATABASE_URL not set; skipping database-backed credential tests",
+)
+class PasswordCredentialStoreTests(unittest.TestCase):
+    EMAIL = "pwtest@example.com"
+
+    def setUp(self) -> None:
+        pcs.initialize_credential_store()
+        pcs.delete_credential(self.EMAIL)
+
+    def tearDown(self) -> None:
+        pcs.delete_credential(self.EMAIL)
+
+    def test_set_and_verify(self) -> None:
+        pcs.set_password(self.EMAIL, "a valid password", updated_by="admin@x")
+        self.assertTrue(pcs.has_credential(self.EMAIL))
+        self.assertTrue(pcs.verify_password(self.EMAIL, "a valid password").ok)
+        self.assertFalse(pcs.verify_password(self.EMAIL, "wrong password").ok)
+
+    def test_unknown_email_verifies_false_without_error(self) -> None:
+        result = pcs.verify_password("nobody@example.com", "whatever")
+        self.assertFalse(result.ok)
+        self.assertFalse(result.must_change)
+
+    def test_email_is_normalized(self) -> None:
+        pcs.set_password("  MixedCase@Example.COM  ", "a valid password", updated_by="admin@x")
+        self.assertTrue(pcs.verify_password("mixedcase@example.com", "a valid password").ok)
+        pcs.delete_credential("mixedcase@example.com")
+
+    def test_must_change_flag_flows_through_and_clears(self) -> None:
+        pcs.set_password(self.EMAIL, "a valid password", updated_by="admin@x", must_change=True)
+        result = pcs.verify_password(self.EMAIL, "a valid password")
+        self.assertTrue(result.ok)
+        self.assertTrue(result.must_change)
+
+        pcs.clear_must_change(self.EMAIL)
+        self.assertFalse(pcs.verify_password(self.EMAIL, "a valid password").must_change)
+
+    def test_set_password_replaces_existing(self) -> None:
+        pcs.set_password(self.EMAIL, "first password value", updated_by="admin@x")
+        pcs.set_password(self.EMAIL, "second password value", updated_by="admin@x")
+        self.assertFalse(pcs.verify_password(self.EMAIL, "first password value").ok)
+        self.assertTrue(pcs.verify_password(self.EMAIL, "second password value").ok)
+
+    def test_delete_removes_credential(self) -> None:
+        pcs.set_password(self.EMAIL, "a valid password", updated_by="admin@x")
+        self.assertTrue(pcs.delete_credential(self.EMAIL))
+        self.assertFalse(pcs.has_credential(self.EMAIL))
+        self.assertFalse(pcs.delete_credential(self.EMAIL))  # already gone
+
+    def test_policy_enforced_on_set(self) -> None:
+        with self.assertRaises(pcs.PasswordPolicyError):
+            pcs.set_password(self.EMAIL, "short", updated_by="admin@x")
+        self.assertFalse(pcs.has_credential(self.EMAIL))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_password_login_api.py
+++ b/backend/tests/test_password_login_api.py
@@ -17,6 +17,8 @@ from app.core.config import settings  # noqa: E402
 from app.services.auth_service import PasswordAuthResult, ResolvedSessionUser  # noqa: E402
 
 TEST_SECRET = "unit-test-session-secret-32-chars-min-abcdef"
+# A synthetic, non-secret placeholder used wherever a test needs "some password".
+VALID_PASSWORD = "x" * 12
 
 
 def _fake_request() -> Request:
@@ -88,7 +90,7 @@ class PasswordLoginEndpointTests(unittest.TestCase):
 
     def _login(self, *, remember_me=False, must_change=False):
         req = auth_api.PasswordLoginRequest(
-            email="u@example.com", password="a valid password", remember_me=remember_me
+            email="u@example.com", password=VALID_PASSWORD, remember_me=remember_me
         )
         result = PasswordAuthResult(
             user=ResolvedSessionUser(email="u@example.com", name="u", picture="", role="designer"),

--- a/backend/tests/test_password_login_api.py
+++ b/backend/tests/test_password_login_api.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException, Request, Response
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.api import auth as auth_api  # noqa: E402
+from app.core import session  # noqa: E402
+from app.core.config import settings  # noqa: E402
+from app.services.auth_service import PasswordAuthResult, ResolvedSessionUser  # noqa: E402
+
+TEST_SECRET = "unit-test-session-secret-32-chars-min-abcdef"
+
+
+def _fake_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"user-agent", b"pytest")],
+        "client": ("127.0.0.1", 12345),
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+class RememberMeSessionTests(unittest.TestCase):
+    """The remember-me lifetime must reach the token, the cookie, and the store
+    consistently, since the store's expiry is what actually governs revocation."""
+
+    def setUp(self) -> None:
+        for attr, value in (("SESSION_SECRET", TEST_SECRET), ("SESSION_TTL_HOURS", 12), ("SESSION_REMEMBER_ME_DAYS", 30)):
+            p = patch.object(settings, attr, value)
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_remember_me_token_uses_long_ttl(self) -> None:
+        remembered = session.create_session_token("sid", ttl_seconds=30 * 86400)
+        normal = session.create_session_token("sid")
+        remembered_exp = session.decode_session_token(remembered)["exp"]
+        normal_exp = session.decode_session_token(normal)["exp"]
+        # Remembered expiry is far past the 12h default.
+        self.assertGreater(remembered_exp - normal_exp, 20 * 86400)
+
+    def test_issue_session_threads_ttl_to_store_and_cookie(self) -> None:
+        captured = {}
+
+        def fake_create_session(**kwargs):
+            captured.update(kwargs)
+            return ("sid-123", MagicMock())
+
+        user = ResolvedSessionUser(email="u@example.com", name="u", picture="", role="viewer")
+        response = Response()
+        with patch.object(auth_api.session_store_service, "create_session", side_effect=fake_create_session):
+            auth_api._issue_session(user, _fake_request(), response, remember_me=True)
+
+        # Store received the long TTL...
+        self.assertEqual(captured["ttl_seconds"], 30 * 86400)
+        # ...and the cookie max-age matches it.
+        set_cookie = response.headers.get("set-cookie", "")
+        self.assertIn(f"Max-Age={30 * 86400}", set_cookie)
+
+    def test_normal_login_uses_default_ttl(self) -> None:
+        captured = {}
+
+        def fake_create_session(**kwargs):
+            captured.update(kwargs)
+            return ("sid-123", MagicMock())
+
+        user = ResolvedSessionUser(email="u@example.com", name="u", picture="", role="viewer")
+        response = Response()
+        with patch.object(auth_api.session_store_service, "create_session", side_effect=fake_create_session):
+            auth_api._issue_session(user, _fake_request(), response, remember_me=False)
+        self.assertIsNone(captured["ttl_seconds"])
+
+
+class PasswordLoginEndpointTests(unittest.TestCase):
+    def setUp(self) -> None:
+        p = patch.object(settings, "SESSION_SECRET", TEST_SECRET)
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _login(self, *, remember_me=False, must_change=False):
+        req = auth_api.PasswordLoginRequest(
+            email="u@example.com", password="a valid password", remember_me=remember_me
+        )
+        result = PasswordAuthResult(
+            user=ResolvedSessionUser(email="u@example.com", name="u", picture="", role="designer"),
+            must_change_password=must_change,
+        )
+        with patch.object(settings, "AUTH_ENABLED_OVERRIDE", True), \
+             patch.object(settings, "PASSWORD_AUTH_ENABLED", True), \
+             patch.object(auth_api, "authenticate_password", return_value=result), \
+             patch.object(auth_api, "_enforce_login_rate_limit", return_value="bucket"), \
+             patch.object(auth_api.rate_limit_service, "clear"), \
+             patch.object(auth_api, "_issue_session"):
+            return asyncio.run(auth_api.login_with_password(req, _fake_request(), Response()))
+
+    def test_success_returns_role_and_no_must_change(self) -> None:
+        out = self._login()
+        self.assertEqual(out.role, "designer")
+        self.assertFalse(out.must_change_password)
+
+    def test_must_change_flag_surfaces(self) -> None:
+        out = self._login(must_change=True)
+        self.assertTrue(out.must_change_password)
+
+    def test_password_disabled_is_400(self) -> None:
+        req = auth_api.PasswordLoginRequest(email="u@example.com", password="pw")
+        with patch.object(settings, "AUTH_ENABLED_OVERRIDE", True), \
+             patch.object(settings, "PASSWORD_AUTH_ENABLED", False):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(auth_api.login_with_password(req, _fake_request(), Response()))
+            self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_bad_credentials_do_not_clear_rate_limiter(self) -> None:
+        # A failed attempt must leave the limiter counting, or brute force is free.
+        req = auth_api.PasswordLoginRequest(email="u@example.com", password="wrong")
+        clear = MagicMock()
+        with patch.object(settings, "AUTH_ENABLED_OVERRIDE", True), \
+             patch.object(settings, "PASSWORD_AUTH_ENABLED", True), \
+             patch.object(auth_api, "_enforce_login_rate_limit", return_value="bucket"), \
+             patch.object(auth_api.rate_limit_service, "clear", clear), \
+             patch.object(auth_api, "authenticate_password", side_effect=HTTPException(status_code=401, detail="Invalid email or password.")):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(auth_api.login_with_password(req, _fake_request(), Response()))
+        self.assertEqual(ctx.exception.status_code, 401)
+        clear.assert_not_called()
+
+
+class AuthConfigTests(unittest.TestCase):
+    def test_config_reports_enabled_methods(self) -> None:
+        with patch.object(settings, "AUTH_ENABLED_OVERRIDE", True), \
+             patch.object(settings, "PASSWORD_AUTH_ENABLED", True), \
+             patch.object(auth_api, "oidc_enabled", return_value=False):
+            cfg = asyncio.run(auth_api.get_auth_config())
+        self.assertTrue(cfg.password_auth_enabled)
+        self.assertFalse(cfg.oidc_enabled)
+        self.assertTrue(cfg.auth_enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/AUTHENTICATION_AND_ACCESS.md
+++ b/docs/AUTHENTICATION_AND_ACCESS.md
@@ -64,6 +64,25 @@ Access, an admin assigns a role and sets a password. Admin-set passwords must be
 changed by the user on next sign-in and are stored only as bcrypt hashes.
 Resetting or removing a role revokes the user's sessions.
 
+### First login on a password-only deployment
+
+Without OIDC there is no external identity to seed the first admin, so
+`BOOTSTRAP_ADMIN_USERS` alone grants the admin role but leaves no way to sign
+in. Set a one-time bootstrap password to break that cycle:
+
+```env
+PASSWORD_AUTH_ENABLED=true
+BOOTSTRAP_ADMIN_USERS_STR=admin@example.com
+BOOTSTRAP_ADMIN_PASSWORD=<a strong one-time value>
+```
+
+On first startup Prism seeds this password for each bootstrap admin that has no
+credential yet, always flagged must-change. The admin signs in, is forced to set
+a real password, and then provisions everyone else. It never overwrites an
+existing password, so a restart cannot reset a changed one. Remove
+`BOOTSTRAP_ADMIN_PASSWORD` from the environment afterwards; the backend warns at
+startup while it is still set.
+
 Users can change their own password (which revokes their other sessions), and
 tick "Remember me" to extend their session to `SESSION_REMEMBER_ME_DAYS`. A
 failed sign-in returns a single generic error and is rate limited, so responses

--- a/docs/AUTHENTICATION_AND_ACCESS.md
+++ b/docs/AUTHENTICATION_AND_ACCESS.md
@@ -39,6 +39,36 @@ Register:
 `localhost` and `127.0.0.1` are different redirect origins. Register the exact
 origin used during local testing.
 
+## Local password login
+
+For teams without an SSO provider, Prism can authenticate with an email and
+password. It coexists with OIDC: a deployment can enable either, or both.
+
+```env
+AUTH_ENABLED=true
+PASSWORD_AUTH_ENABLED=true
+PASSWORD_MIN_LENGTH=12          # default; the bcrypt limit of 72 bytes is enforced
+SESSION_REMEMBER_ME_DAYS=30    # lifetime of a "remember me" session
+SESSION_SECRET=<random-value>
+BOOTSTRAP_ADMIN_USERS_STR=admin@example.com
+```
+
+When `AUTH_ENABLED=true`, at least one method must be configured: OIDC (all three
+of issuer, client id, secret) or `PASSWORD_AUTH_ENABLED=true`. A half-configured
+OIDC still fails closed. Password and OIDC share the same role model
+(`ALLOWED_USERS_STR`, `ALLOWED_DOMAINS_STR`, role assignments) and the same
+session machinery.
+
+Accounts are provisioned by administrators, not self-registered. In Settings →
+Access, an admin assigns a role and sets a password. Admin-set passwords must be
+changed by the user on next sign-in and are stored only as bcrypt hashes.
+Resetting or removing a role revokes the user's sessions.
+
+Users can change their own password (which revokes their other sessions), and
+tick "Remember me" to extend their session to `SESSION_REMEMBER_ME_DAYS`. A
+failed sign-in returns a single generic error and is rate limited, so responses
+never reveal whether an email has an account.
+
 ## Sessions
 
 Prism stores session records in PostgreSQL and sends an opaque signed identifier

--- a/docs/AUTHENTICATION_AND_ACCESS.md
+++ b/docs/AUTHENTICATION_AND_ACCESS.md
@@ -120,6 +120,28 @@ first login, manage ordinary assignments in Settings. `DEFAULT_VIEWER_DOMAINS_ST
 can grant implicit viewer access to trusted domains; leave it empty when every
 user must be explicitly approved.
 
+## Restricting who can sign in
+
+Two settings gate which addresses are allowed to authenticate at all. They apply
+to both OIDC and password login on identical terms, so setting them once covers
+every method.
+
+```env
+ALLOWED_DOMAINS_STR=example.com,example.org   # only these email domains may sign in
+ALLOWED_USERS_STR=alice@example.com           # only these exact addresses may sign in
+```
+
+Each is empty by default, meaning no restriction. When set, an address must be in
+`ALLOWED_USERS_STR` if that list is non-empty, and its domain must be in
+`ALLOWED_DOMAINS_STR` if that list is non-empty; both apply together. A login that
+fails either check is rejected before any role is considered.
+
+This is a gate, not a grant. Passing it only lets the login proceed; the account
+still needs a role (an explicit assignment, or an implicit viewer role from
+`DEFAULT_VIEWER_DOMAINS_STR`) or access is denied. To let anyone from a trusted
+domain in as a viewer automatically, use `DEFAULT_VIEWER_DOMAINS_STR`; to allow a
+domain to sign in but still require an explicit role, use `ALLOWED_DOMAINS_STR`.
+
 ## Guest mode
 
 ```env

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -181,6 +181,7 @@ function App() {
                     devMode={authConfig.dev_mode}
                     workspaceName={authConfig.workspace_name}
                     initialError={authError}
+                    onLoginSuccess={handleAuthCodeSuccess}
                 />
             </Suspense>
         );

--- a/frontend/src/components/login-page.test.tsx
+++ b/frontend/src/components/login-page.test.tsx
@@ -3,14 +3,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthConfig, User } from "@/types/auth";
 
-const startOidcLogin = vi.fn(async () => "https://sso.example.com/authorize");
-const loginWithPassword = vi.fn();
-const changeOwnPassword = vi.fn(async () => ({ success: true }));
+const startOidcLogin = vi.fn<() => Promise<string>>(async () => "https://sso.example.com/authorize");
+const loginWithPassword = vi.fn<(email: string, password: string, rememberMe: boolean) => Promise<unknown>>();
+const changeOwnPassword = vi.fn<(current: string, next: string) => Promise<{ success: boolean }>>(
+    async () => ({ success: true }),
+);
 
 vi.mock("@/lib/auth", () => ({
-    startOidcLogin: (...args: unknown[]) => startOidcLogin(...args),
-    loginWithPassword: (...args: unknown[]) => loginWithPassword(...args),
-    changeOwnPassword: (...args: unknown[]) => changeOwnPassword(...args),
+    startOidcLogin: () => startOidcLogin(),
+    loginWithPassword: (email: string, password: string, rememberMe: boolean) =>
+        loginWithPassword(email, password, rememberMe),
+    changeOwnPassword: (current: string, next: string) => changeOwnPassword(current, next),
 }));
 
 // Release-tag fetch on mount; keep it from making a real network call.

--- a/frontend/src/components/login-page.test.tsx
+++ b/frontend/src/components/login-page.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthConfig, User } from "@/types/auth";
+
+const startOidcLogin = vi.fn(async () => "https://sso.example.com/authorize");
+const loginWithPassword = vi.fn();
+const changeOwnPassword = vi.fn(async () => ({ success: true }));
+
+vi.mock("@/lib/auth", () => ({
+    startOidcLogin: (...args: unknown[]) => startOidcLogin(...args),
+    loginWithPassword: (...args: unknown[]) => loginWithPassword(...args),
+    changeOwnPassword: (...args: unknown[]) => changeOwnPassword(...args),
+}));
+
+// Release-tag fetch on mount; keep it from making a real network call.
+vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false })) as unknown as typeof fetch);
+
+// The Radix checkbox uses ResizeObserver, which jsdom does not provide.
+vi.stubGlobal(
+    "ResizeObserver",
+    class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    },
+);
+
+import { LoginPage } from "./login-page";
+
+function config(overrides: Partial<AuthConfig>): AuthConfig {
+    return {
+        auth_enabled: true,
+        dev_mode: false,
+        oidc_enabled: false,
+        oidc_provider_name: "Corp SSO",
+        password_auth_enabled: false,
+        workspace_name: "Test",
+        ...overrides,
+    };
+}
+
+describe("LoginPage method rendering", () => {
+    afterEach(() => {
+        cleanup();
+        loginWithPassword.mockReset();
+    });
+
+    it("shows only the SSO button when password auth is off", () => {
+        render(<LoginPage authConfig={config({ oidc_enabled: true, password_auth_enabled: false })} />);
+        expect(screen.getByText(/Continue with Corp SSO/)).toBeTruthy();
+        expect(screen.queryByLabelText("Email")).toBeNull();
+    });
+
+    it("shows only the password form when OIDC is off", () => {
+        render(<LoginPage authConfig={config({ oidc_enabled: false, password_auth_enabled: true })} />);
+        expect(screen.queryByText(/Continue with Corp SSO/)).toBeNull();
+        expect(screen.getByLabelText("Email")).toBeTruthy();
+        expect(screen.getByLabelText("Password")).toBeTruthy();
+    });
+
+    it("shows both methods with a divider when both are on", () => {
+        render(<LoginPage authConfig={config({ oidc_enabled: true, password_auth_enabled: true })} />);
+        expect(screen.getByText(/Continue with Corp SSO/)).toBeTruthy();
+        expect(screen.getByLabelText("Email")).toBeTruthy();
+    });
+
+    it("submits password login and reports success", async () => {
+        const user: User = { email: "u@example.com", name: "u", role: "designer" };
+        loginWithPassword.mockResolvedValue({ ...user, must_change_password: false });
+        const onLoginSuccess = vi.fn();
+
+        render(
+            <LoginPage
+                authConfig={config({ password_auth_enabled: true })}
+                onLoginSuccess={onLoginSuccess}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText("Email"), { target: { value: "u@example.com" } });
+        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "a valid password" } });
+        fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+        await waitFor(() => expect(loginWithPassword).toHaveBeenCalledWith("u@example.com", "a valid password", false));
+        await waitFor(() => expect(onLoginSuccess).toHaveBeenCalled());
+    });
+
+    it("switches to the set-new-password step when the account must change", async () => {
+        loginWithPassword.mockResolvedValue({
+            email: "u@example.com",
+            name: "u",
+            role: "viewer",
+            must_change_password: true,
+        });
+        const onLoginSuccess = vi.fn();
+
+        render(
+            <LoginPage
+                authConfig={config({ password_auth_enabled: true })}
+                onLoginSuccess={onLoginSuccess}
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText("Email"), { target: { value: "u@example.com" } });
+        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "temp password xx" } });
+        fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+        // Must-change step appears; the app is not entered yet.
+        await waitFor(() => expect(screen.getByText("Set a new password")).toBeTruthy());
+        expect(onLoginSuccess).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/login-page.test.tsx
+++ b/frontend/src/components/login-page.test.tsx
@@ -80,11 +80,12 @@ describe("LoginPage method rendering", () => {
             />,
         );
 
+        const secret = "x".repeat(12); // placeholder, not a real credential
         fireEvent.change(screen.getByLabelText("Email"), { target: { value: "u@example.com" } });
-        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "a valid password" } });
+        fireEvent.change(screen.getByLabelText("Password"), { target: { value: secret } });
         fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
-        await waitFor(() => expect(loginWithPassword).toHaveBeenCalledWith("u@example.com", "a valid password", false));
+        await waitFor(() => expect(loginWithPassword).toHaveBeenCalledWith("u@example.com", secret, false));
         await waitFor(() => expect(onLoginSuccess).toHaveBeenCalled());
     });
 
@@ -105,7 +106,7 @@ describe("LoginPage method rendering", () => {
         );
 
         fireEvent.change(screen.getByLabelText("Email"), { target: { value: "u@example.com" } });
-        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "temp password xx" } });
+        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "x".repeat(12) } });
         fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
         // Must-change step appears; the app is not entered yet.

--- a/frontend/src/components/login-page.tsx
+++ b/frontend/src/components/login-page.tsx
@@ -5,14 +5,18 @@ import prismLogoHorizontal from "@/assets/branding/kicad-prism/kicad-prism-logo-
 import prismLogoMark from "@/assets/branding/kicad-prism/kicad-prism-icon.svg";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { startOidcLogin } from "@/lib/auth";
-import type { AuthConfig } from "@/types/auth";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { changeOwnPassword, loginWithPassword, startOidcLogin } from "@/lib/auth";
+import type { AuthConfig, User } from "@/types/auth";
 
 interface LoginPageProps {
   authConfig: AuthConfig;
   devMode?: boolean;
   workspaceName?: string;
   initialError?: string | null;
+  onLoginSuccess?: (user: User) => void;
 }
 
 const RELEASE_CACHE_KEY = "kicad_prism_latest_release_tag";
@@ -25,10 +29,23 @@ export function LoginPage({
   devMode = false,
   workspaceName = "KiCAD Prism",
   initialError = null,
+  onLoginSuccess,
 }: LoginPageProps) {
   const [error, setError] = useState<string | null>(initialError);
   const [isLoading, setIsLoading] = useState(false);
   const [releaseTag, setReleaseTag] = useState("...");
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [rememberMe, setRememberMe] = useState(false);
+  const [passwordSubmitting, setPasswordSubmitting] = useState(false);
+
+  // When an admin-set password must be replaced, we keep the user on this page
+  // and swap the form to a "set a new password" step before entering the app.
+  const [mustChange, setMustChange] = useState(false);
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [pendingUser, setPendingUser] = useState<User | null>(null);
 
   useEffect(() => {
     setError(initialError);
@@ -91,6 +108,53 @@ export function LoginPage({
     }
   };
 
+  const handlePasswordSignIn = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setPasswordSubmitting(true);
+    setError(null);
+    try {
+      const result = await loginWithPassword(email, password, rememberMe);
+      const user: User = {
+        email: result.email,
+        name: result.name,
+        picture: result.picture,
+        role: result.role,
+      };
+      if (result.must_change_password) {
+        // Session is issued, but force a password change before entering. Keep
+        // the just-used password: the change call re-verifies it as "current".
+        setPendingUser(user);
+        setMustChange(true);
+      } else {
+        onLoginSuccess?.(user);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sign-in failed");
+    } finally {
+      setPasswordSubmitting(false);
+    }
+  };
+
+  const handleSetNewPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      setError("The new passwords do not match.");
+      return;
+    }
+    setPasswordSubmitting(true);
+    setError(null);
+    try {
+      // The session already authenticates this call; the current password is
+      // the one just used to sign in.
+      await changeOwnPassword(password, newPassword);
+      if (pendingUser) onLoginSuccess?.(pendingUser);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to set a new password");
+    } finally {
+      setPasswordSubmitting(false);
+    }
+  };
+
   const handleDevBypass = () => {
     window.history.replaceState(null, "", "/");
     window.location.reload();
@@ -129,18 +193,103 @@ export function LoginPage({
           <Card className="relative overflow-hidden border-primary/40 bg-card ring-1 ring-primary/30">
             <div className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-border/80" />
             <CardHeader className="space-y-2 pb-7">
-              <CardTitle className="text-2xl">Sign In</CardTitle>
+              <CardTitle className="text-2xl">{mustChange ? "Set a new password" : "Sign In"}</CardTitle>
               <CardDescription>
-                Sign in with {authConfig.oidc_provider_name || "your organization SSO"}.
+                {mustChange
+                  ? "Your account requires a new password before you continue."
+                  : authConfig.oidc_enabled && authConfig.password_auth_enabled
+                    ? `Sign in with ${authConfig.oidc_provider_name || "SSO"} or your email and password.`
+                    : authConfig.password_auth_enabled
+                      ? "Sign in with your email and password."
+                      : `Sign in with ${authConfig.oidc_provider_name || "your organization SSO"}.`}
               </CardDescription>
             </CardHeader>
 
             <CardContent className="space-y-5 pb-7">
-              <Button className="w-full" onClick={() => void handleSignIn()} disabled={isLoading}>
-                {isLoading
-                  ? `Redirecting to ${authConfig.oidc_provider_name || "SSO"}...`
-                  : `Continue with ${authConfig.oidc_provider_name || "SSO"}`}
-              </Button>
+              {mustChange ? (
+                <form className="space-y-4" onSubmit={(e) => void handleSetNewPassword(e)}>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="new-password">New password</Label>
+                    <Input
+                      id="new-password"
+                      type="password"
+                      autoComplete="new-password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="confirm-password">Confirm new password</Label>
+                    <Input
+                      id="confirm-password"
+                      type="password"
+                      autoComplete="new-password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <Button type="submit" className="w-full" disabled={passwordSubmitting}>
+                    {passwordSubmitting ? "Saving…" : "Set password and continue"}
+                  </Button>
+                </form>
+              ) : (
+                <>
+                  {authConfig.oidc_enabled && (
+                    <Button className="w-full" onClick={() => void handleSignIn()} disabled={isLoading || passwordSubmitting}>
+                      {isLoading
+                        ? `Redirecting to ${authConfig.oidc_provider_name || "SSO"}...`
+                        : `Continue with ${authConfig.oidc_provider_name || "SSO"}`}
+                    </Button>
+                  )}
+
+                  {authConfig.oidc_enabled && authConfig.password_auth_enabled && (
+                    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                      <span className="h-px flex-1 bg-border" />
+                      <span>or</span>
+                      <span className="h-px flex-1 bg-border" />
+                    </div>
+                  )}
+
+                  {authConfig.password_auth_enabled && (
+                    <form className="space-y-4" onSubmit={(e) => void handlePasswordSignIn(e)}>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="email">Email</Label>
+                        <Input
+                          id="email"
+                          type="email"
+                          autoComplete="username"
+                          value={email}
+                          onChange={(e) => setEmail(e.target.value)}
+                          required
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="password">Password</Label>
+                        <Input
+                          id="password"
+                          type="password"
+                          autoComplete="current-password"
+                          value={password}
+                          onChange={(e) => setPassword(e.target.value)}
+                          required
+                        />
+                      </div>
+                      <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+                        <Checkbox
+                          checked={rememberMe}
+                          onCheckedChange={(checked) => setRememberMe(checked === true)}
+                        />
+                        Remember me on this device
+                      </label>
+                      <Button type="submit" className="w-full" disabled={passwordSubmitting || isLoading}>
+                        {passwordSubmitting ? "Signing in…" : "Sign in"}
+                      </Button>
+                    </form>
+                  )}
+                </>
+              )}
 
               {isLoading && (
                 <div className="flex items-center justify-center gap-2 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
@@ -155,7 +304,7 @@ export function LoginPage({
                 </div>
               )}
 
-              {devMode && (
+              {devMode && !mustChange && (
                 <Button variant="outline" className="w-full" onClick={handleDevBypass}>
                   <Binary className="mr-2 h-4 w-4" />
                   Skip Authentication (Dev Mode)

--- a/frontend/src/components/role-authority-popover.test.tsx
+++ b/frontend/src/components/role-authority-popover.test.tsx
@@ -15,4 +15,16 @@ describe("RoleAuthorityPopover", () => {
     expect(within(matrix).getByLabelText("Review component QA: Component QA is allowed")).toBeInTheDocument();
     expect(within(matrix).getByLabelText("Manage projects: Component QA is not allowed")).toBeInTheDocument();
   });
+
+  it("renders a plain reference chart with no highlighted role when role is omitted", () => {
+    render(<RoleAuthorityPopover trigger="View role permissions" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show the role permission matrix" }));
+
+    const matrix = screen.getByRole("table", { name: "Role authority matrix" });
+    expect(
+      screen.getByText("What each role can do across projects and the component catalog."),
+    ).toBeInTheDocument();
+    expect(within(matrix).queryByText("Your role")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/role-authority-popover.tsx
+++ b/frontend/src/components/role-authority-popover.tsx
@@ -3,13 +3,13 @@ import type { ReactNode } from "react";
 import { Check, Info, Minus } from "lucide-react";
 
 import {
-  Popover,
-  PopoverContent,
-  PopoverDescription,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import {
   ROLE_AUTHORITIES,
@@ -31,8 +31,8 @@ export function RoleAuthorityPopover({ role, trigger }: RoleAuthorityPopoverProp
   const triggerLabel = role ? `Show permissions for ${roleLabel(role)}` : "Show the role permission matrix";
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
+    <Dialog>
+      <DialogTrigger asChild>
         <button
           type="button"
           aria-label={triggerLabel}
@@ -41,21 +41,18 @@ export function RoleAuthorityPopover({ role, trigger }: RoleAuthorityPopoverProp
           {trigger ?? (role ? roleLabel(role) : "View role permissions")}
           <Info aria-hidden="true" className="h-3.5 w-3.5" />
         </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="end"
-        className="w-[min(52rem,calc(100vw-2rem))] gap-0 overflow-hidden rounded-md p-0"
-      >
-        <PopoverHeader className="border-b p-4">
-          <PopoverTitle>Role permissions</PopoverTitle>
-          <PopoverDescription>
+      </DialogTrigger>
+      <DialogContent className="w-[min(52rem,calc(100vw-2rem))] max-w-none gap-0 overflow-hidden p-0">
+        <DialogHeader className="border-b p-4 pr-12 text-left">
+          <DialogTitle>Role permissions</DialogTitle>
+          <DialogDescription>
             {role
               ? `Your role is ${roleLabel(role)}. The highlighted column shows what you can do.`
               : "What each role can do across projects and the component catalog."}
-          </PopoverDescription>
-        </PopoverHeader>
+          </DialogDescription>
+        </DialogHeader>
 
-        <div className="overflow-x-auto">
+        <div className="max-h-[70vh] overflow-auto">
           <table aria-label="Role authority matrix" className="w-full min-w-[46rem] border-collapse text-left">
             <thead>
               <tr className="border-b bg-muted/40">
@@ -123,7 +120,7 @@ export function RoleAuthorityPopover({ role, trigger }: RoleAuthorityPopoverProp
             </tbody>
           </table>
         </div>
-      </PopoverContent>
-    </Popover>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/role-authority-popover.tsx
+++ b/frontend/src/components/role-authority-popover.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { Check, Info, Minus } from "lucide-react";
 
 import {
@@ -18,21 +20,25 @@ import {
 import type { UserRole } from "@/types/auth";
 
 interface RoleAuthorityPopoverProps {
-  role: UserRole;
+  /** The role to highlight as "yours". Omit for a plain reference chart. */
+  role?: UserRole;
+  /** Overrides the trigger contents. Defaults to the role label. */
+  trigger?: ReactNode;
 }
 
-export function RoleAuthorityPopover({ role }: RoleAuthorityPopoverProps) {
+export function RoleAuthorityPopover({ role, trigger }: RoleAuthorityPopoverProps) {
   let previousCategory = "";
+  const triggerLabel = role ? `Show permissions for ${roleLabel(role)}` : "Show the role permission matrix";
 
   return (
     <Popover>
       <PopoverTrigger asChild>
         <button
           type="button"
-          aria-label={`Show permissions for ${roleLabel(role)}`}
+          aria-label={triggerLabel}
           className="inline-flex items-center gap-1 rounded-sm font-medium text-foreground underline decoration-dotted underline-offset-4 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
-          {roleLabel(role)}
+          {trigger ?? (role ? roleLabel(role) : "View role permissions")}
           <Info aria-hidden="true" className="h-3.5 w-3.5" />
         </button>
       </PopoverTrigger>
@@ -43,7 +49,9 @@ export function RoleAuthorityPopover({ role }: RoleAuthorityPopoverProps) {
         <PopoverHeader className="border-b p-4">
           <PopoverTitle>Role permissions</PopoverTitle>
           <PopoverDescription>
-            Your role is {roleLabel(role)}. The highlighted column shows what you can do.
+            {role
+              ? `Your role is ${roleLabel(role)}. The highlighted column shows what you can do.`
+              : "What each role can do across projects and the component catalog."}
           </PopoverDescription>
         </PopoverHeader>
 

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
-import { GitBranch, Copy, FileCode, Shield, Plus, Trash2 } from "lucide-react";
+import { GitBranch, Copy, FileCode, Shield, Plus, Trash2, KeyRound } from "lucide-react";
 import { User, UserRole } from "@/types/auth";
 import { fetchApi, readApiError } from "@/lib/api";
 import { ROLE_OPTIONS, roleLabel } from "@/lib/roles";
@@ -23,6 +23,7 @@ interface RoleAssignment {
     email: string;
     role: UserRole;
     source: string;
+    has_password?: boolean;
 }
 
 export function SettingsDialog({ open, onOpenChange, user }: SettingsDialogProps) {
@@ -579,6 +580,54 @@ function AccessControlSettings({ isAdmin }: { isAdmin: boolean }) {
         }
     };
 
+    // Password provisioning. The admin sets a value the user must change on next
+    // login, so it is only ever a one-time credential.
+    const [passwordEmail, setPasswordEmail] = useState<string | null>(null);
+    const [passwordValue, setPasswordValue] = useState("");
+    const [savingPassword, setSavingPassword] = useState(false);
+
+    const submitPassword = async () => {
+        if (!passwordEmail) return;
+        setSavingPassword(true);
+        try {
+            const response = await fetchApi(
+                `/api/settings/access/users/${encodeURIComponent(passwordEmail)}/password`,
+                {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ password: passwordValue, must_change: true }),
+                },
+            );
+            if (!response.ok) {
+                throw new Error(await readApiError(response, "Failed to set password"));
+            }
+            toast.success("Password set. The user must change it on next sign-in.");
+            setPasswordEmail(null);
+            setPasswordValue("");
+            await loadAssignments();
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : "Failed to set password");
+        } finally {
+            setSavingPassword(false);
+        }
+    };
+
+    const removePassword = async (email: string) => {
+        try {
+            const response = await fetchApi(
+                `/api/settings/access/users/${encodeURIComponent(email)}/password`,
+                { method: "DELETE" },
+            );
+            if (!response.ok) {
+                throw new Error(await readApiError(response, "Failed to remove password"));
+            }
+            toast.success("Local password removed");
+            await loadAssignments();
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : "Failed to remove password");
+        }
+    };
+
     if (!isAdmin) {
         return (
             <div className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
@@ -652,7 +701,27 @@ function AccessControlSettings({ isAdmin }: { isAdmin: boolean }) {
                                     ))}
                                 </select>
                                 <div className="text-sm text-muted-foreground">{assignment.source}</div>
-                                <div className="flex justify-end">
+                                <div className="flex justify-end gap-1">
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => { setPasswordEmail(assignment.email); setPasswordValue(""); }}
+                                        aria-label={`Set password for ${assignment.email}`}
+                                        title={assignment.has_password ? "Reset password" : "Set password"}
+                                    >
+                                        <KeyRound className={`h-4 w-4 ${assignment.has_password ? "text-primary" : ""}`} />
+                                    </Button>
+                                    {assignment.has_password && (
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => void removePassword(assignment.email)}
+                                            aria-label={`Remove local password for ${assignment.email}`}
+                                            title="Remove local password"
+                                        >
+                                            <Trash2 className="h-4 w-4 text-muted-foreground" />
+                                        </Button>
+                                    )}
                                     <Button
                                         variant="ghost"
                                         size="icon"
@@ -678,6 +747,37 @@ function AccessControlSettings({ isAdmin }: { isAdmin: boolean }) {
                 requireHold
                 onConfirm={() => { if (removalTarget.target) void removeRole(removalTarget.target); }}
             />
+
+            <Dialog open={passwordEmail !== null} onOpenChange={(next) => { if (!next) { setPasswordEmail(null); setPasswordValue(""); } }}>
+                <DialogContent className="max-w-sm">
+                    <DialogTitle>Set a password</DialogTitle>
+                    <DialogDescription>
+                        {passwordEmail} will be required to change this password on their next sign-in.
+                        Their existing sessions are ended.
+                    </DialogDescription>
+                    <form
+                        className="mt-2 space-y-3"
+                        onSubmit={(e) => { e.preventDefault(); void submitPassword(); }}
+                    >
+                        <Input
+                            type="password"
+                            autoComplete="new-password"
+                            placeholder="Temporary password"
+                            value={passwordValue}
+                            onChange={(e) => setPasswordValue(e.target.value)}
+                            required
+                        />
+                        <div className="flex justify-end gap-2">
+                            <Button type="button" variant="outline" onClick={() => { setPasswordEmail(null); setPasswordValue(""); }}>
+                                Cancel
+                            </Button>
+                            <Button type="submit" disabled={savingPassword || !passwordValue}>
+                                {savingPassword ? "Saving…" : "Set password"}
+                            </Button>
+                        </div>
+                    </form>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -10,6 +10,7 @@ import { GitBranch, Copy, FileCode, Shield, Plus, Trash2, KeyRound } from "lucid
 import { User, UserRole } from "@/types/auth";
 import { fetchApi, readApiError } from "@/lib/api";
 import { ROLE_OPTIONS, roleLabel } from "@/lib/roles";
+import { RoleAuthorityPopover } from "@/components/role-authority-popover";
 
 interface SettingsDialogProps {
     open: boolean;
@@ -638,11 +639,14 @@ function AccessControlSettings({ isAdmin }: { isAdmin: boolean }) {
 
     return (
         <div className="space-y-6">
-            <div>
-                <h3 className="text-lg font-medium">Access Control</h3>
-                <p className="text-sm text-muted-foreground">
-                    Manage role assignments for workspace users.
-                </p>
+            <div className="flex items-start justify-between gap-4">
+                <div>
+                    <h3 className="text-lg font-medium">Access Control</h3>
+                    <p className="text-sm text-muted-foreground">
+                        Manage role assignments for workspace users.
+                    </p>
+                </div>
+                <RoleAuthorityPopover trigger="View role permissions" />
             </div>
 
             <div className="rounded-lg border p-4 space-y-3">

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -639,14 +639,14 @@ function AccessControlSettings({ isAdmin }: { isAdmin: boolean }) {
 
     return (
         <div className="space-y-6">
-            <div className="flex items-start justify-between gap-4">
-                <div>
-                    <h3 className="text-lg font-medium">Access Control</h3>
-                    <p className="text-sm text-muted-foreground">
-                        Manage role assignments for workspace users.
-                    </p>
+            <div>
+                <h3 className="text-lg font-medium">Access Control</h3>
+                <p className="text-sm text-muted-foreground">
+                    Manage role assignments for workspace users.
+                </p>
+                <div className="mt-1 text-xs">
+                    <RoleAuthorityPopover trigger="View role permissions" />
                 </div>
-                <RoleAuthorityPopover trigger="View role permissions" />
             </div>
 
             <div className="rounded-lg border p-4 space-y-3">

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -67,6 +67,36 @@ export function exchangeOidcAuthCode(code: string, state: string) {
   );
 }
 
+export interface PasswordLoginResult extends User {
+  must_change_password: boolean;
+}
+
+/** Sign in with a local email and password. */
+export function loginWithPassword(email: string, password: string, rememberMe: boolean) {
+  return fetchJson<PasswordLoginResult>(
+    "/api/auth/login/password",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, remember_me: rememberMe }),
+    },
+    "Sign-in failed"
+  );
+}
+
+/** Change the signed-in user's own password. */
+export function changeOwnPassword(currentPassword: string, newPassword: string) {
+  return fetchJson<{ success: boolean }>(
+    "/api/auth/password/change",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+    },
+    "Failed to change password"
+  );
+}
+
 export function fetchActiveSessions(signal?: AbortSignal) {
   return fetchJson<ActiveSession[]>(
     "/api/auth/sessions",

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -10,7 +10,9 @@ export interface User {
 export interface AuthConfig {
     auth_enabled: boolean;
     dev_mode: boolean;
+    oidc_enabled: boolean;
     oidc_provider_name: string;
+    password_auth_enabled: boolean;
     workspace_name: string;
 }
 


### PR DESCRIPTION
## Problem

This PR adds email + password sign-in alongside the existing OIDC/SSO, so teams and users without an SSO provider can use Prism. Both methods can run at the same time, and either method resolves to the same roles and sessions.

## Solution

- Password login with a "remember me" option that extends the session.
- Admin-provisioned accounts (no self-signup). Admins set and reset passwords in Settings → Access. Admin-set passwords must be changed by the user on first sign-in.
- First-login bootstrap: a BOOTSTRAP_ADMIN_PASSWORD env value seeds a one-time password for the first admin on a password-only deployment, so they can get in and set things up. It's flagged must-change and never overwrites a real password.
- Domain/user allowlist (ALLOWED_DOMAINS / ALLOWED_USERS) now applies to both login methods, so you can restrict sign-in to your own email domain.
- UI: login page shows SSO and/or password based on config; the role permission chart is now reachable from Settings → Access in a centered dialog.
- Passwords are stored only as bcrypt hashes, never logged or returned. Login is rate-limited, and a failed attempt returns one generic error with equalized timing so it can't be used to discover which emails have accounts. A fresh session is issued per login. Changing a password re-verifies the current one and signs out other sessions.

## Validation

- [x] Relevant frontend checks
- [x] Relevant backend checks
- [x] Relevant semantic-viewer checks
- [ ] Compose configuration validation
- [x] Manual verification, when needed

New backend tests for the credential store, the password verifier, and the login/change/provisioning endpoints, plus updated auth-config tests covering both methods enabled together. New frontend tests for the login form (password sign-in, must-change step, method rendering) and the role dialog. Backend suite and tsc -b both pass; database-backed tests run in CI.

## Documentation and release

- [x] Documentation is updated or not required.
- [x] No secrets, private design data, generated output, or local caches are included.
- [ ] Breaking changes and feature-freeze exceptions have explicit approval.
- [x] This branch contains one coherent change and targets `dev`.

New settings are PASSWORD_AUTH_ENABLED, PASSWORD_MIN_LENGTH, SESSION_REMEMBER_ME_DAYS, and BOOTSTRAP_ADMIN_PASSWORD are documented in docs/AUTHENTICATION_AND_ACCESS.md.


<img width="1919" height="898" alt="image" src="https://github.com/user-attachments/assets/7748aed0-7828-40e0-8c26-31dbace2e35c" />
