### PR TITLE
Skip Windows fsync on read-only job artifact handles

### DIFF
--- a/backend/app/services/job_artifact_service.py
+++ b/backend/app/services/job_artifact_service.py
@@ -102,7 +102,13 @@ class JobArtifactService:
             # Callers may have populated the staging file with copy helpers rather
             # than an explicitly fsynced writer. Durability must be established
             # before the file can become the authoritative content-addressed object.
-            os.fsync(handle.fileno())
+            #
+            # Windows rejects fsync on a read-only handle ([Errno 9] Bad file
+            # descriptor), the same platform gap _fsync_directory guards against.
+            # Artifacts are content-addressed and re-derivable, so skipping the
+            # flush there costs at most a rebuild after an unclean shutdown.
+            if os.name != "nt":
+                os.fsync(handle.fileno())
         sha = digest.hexdigest()
         destination = self.objects / sha[:2] / sha[2:4] / sha
         destination.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/tests/test_job_artifact_service.py
+++ b/backend/tests/test_job_artifact_service.py
@@ -41,6 +41,35 @@ class JobArtifactServiceTests(unittest.TestCase):
             )
             context.check_cancelled.assert_called_once()
 
+    def test_prepare_file_skips_handle_fsync_on_windows(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            staging = root / "staging" / "job" / "7"
+            staging.mkdir(parents=True)
+            source = staging / "result.json"
+            source.write_bytes(b'{"ready":true}')
+            context = SimpleNamespace(
+                staging_dir=staging,
+                check_cancelled=mock.Mock(),
+            )
+            service = JobArtifactService(root)
+
+            with (
+                mock.patch("app.services.job_artifact_service.os.name", "nt"),
+                mock.patch("app.services.job_artifact_service.os.fsync") as fsync,
+            ):
+                artifact = service.prepare_file(
+                    context,
+                    source,
+                    kind="test",
+                    artifact_key="key",
+                    media_type="application/json",
+                )
+
+            fsync.assert_not_called()
+            self.assertTrue(Path(artifact.object_path).is_file())
+            self.assertEqual(Path(artifact.object_path).read_bytes(), b'{"ready":true}')
+
     def test_failed_promotion_never_returns_an_authoritative_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

Skip `os.fsync` on the read-only staging handle in `JobArtifactService.prepare_file` when running on Windows. That call was raising `[Errno 9] Bad file descriptor` after a successful design comparison, so the job died at artifact publish with "Semantic comparison failed".

Matches the existing Windows guard on `_fsync_directory`. Artifacts are content-addressed and re-derivable.

Cherry-picked from #142 (@Keybored02).

## Test plan

- [x] Unit test: `prepare_file` still publishes the object when `os.name` is `nt`, and does not call `os.fsync`
- [ ] Quality gate on this PR
- [ ] On Windows, run a design comparison and confirm it publishes instead of failing at the artifact step

