### PR TITLE
Drop Library Manager header subtitles

### DIFF
--- a/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
+++ b/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
@@ -487,7 +487,7 @@ export function LibraryBulkEditWorkspace({ user }: { user: User | null }) {
     <input ref={csvInputRef} className="hidden" type="file" accept=".csv,text/csv" onChange={(event) => { const file = event.currentTarget.files?.[0]; event.currentTarget.value = ""; if (file) void uploadCsv(file); }} />
     <header className="shrink-0 border-b bg-card">
       <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-        <div><div className="flex items-center gap-2"><FilePenLine className="h-5 w-5 text-primary" /><h2 className="text-lg font-semibold">Bulk Edit Metadata</h2></div><p className="mt-1 text-xs text-muted-foreground">Stage engineering metadata changes without altering CAD assets.</p></div>
+        <div><div className="flex items-center gap-2"><FilePenLine className="h-5 w-5 text-primary" /><h2 className="text-lg font-semibold">Bulk Edit Metadata</h2></div></div>
         <div className="flex flex-wrap items-center gap-2">
           <Button size="sm" variant="outline" onClick={() => void exportCsv()}><Download className="h-3.5 w-3.5" /> Export CSV</Button>
           {canEdit ? <Button size="sm" variant="outline" onClick={() => csvInputRef.current?.click()}><Upload className="h-3.5 w-3.5" /> Import CSV</Button> : null}

--- a/frontend/src/components/workspace/library-catalog-workspace.tsx
+++ b/frontend/src/components/workspace/library-catalog-workspace.tsx
@@ -450,7 +450,6 @@ export function LibraryCatalogWorkspace({
         <div className="flex flex-wrap items-start justify-between gap-3 px-4 py-3">
           <div>
             <div className="flex items-center gap-2"><Database className="h-5 w-5 text-primary" /><h2 className="text-lg font-semibold">Component Catalog</h2></div>
-            <p className="mt-1 text-xs text-muted-foreground">Server-indexed component identity, lifecycle, CAD readiness, and revision evidence.</p>
           </div>
           <div className="flex items-center gap-2">
             <Button size="sm" variant="outline" aria-label="Refresh component catalog" disabled={loading} onClick={() => setRefreshKey((value) => value + 1)}><RefreshCw className={cn("h-3.5 w-3.5", loading && "animate-spin")} /> Refresh</Button>

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -434,7 +434,6 @@ function AssetsPanel({
       <div className="flex flex-wrap items-center justify-between gap-3 border bg-card p-3">
         <div>
           <p className="text-sm font-medium">Revision assets and evidence</p>
-          <p className="mt-1 text-xs text-muted-foreground">Asset attachments and detachments create immutable component revisions. Downloads remain available while browsing released history.</p>
         </div>
         {canMutate ? (
           <div className="flex flex-wrap gap-2">

--- a/frontend/src/components/workspace/library-import-center.tsx
+++ b/frontend/src/components/workspace/library-import-center.tsx
@@ -408,7 +408,6 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <h2 className="text-lg font-semibold">Import Center</h2>
-            <p className="mt-1 text-sm text-muted-foreground">Capture KiCad library folders or extract components from Prism projects. Every result remains staged for review.</p>
           </div>
           {/* One hint for the whole cluster: six identical tooltips on six
               adjacent buttons is noise, and the reason is the same for all. */}

--- a/frontend/src/components/workspace/library-release-queue.tsx
+++ b/frontend/src/components/workspace/library-release-queue.tsx
@@ -188,7 +188,6 @@ export function LibraryReleaseQueue({ onOpenComponent }: { onOpenComponent: (com
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <div className="flex items-center gap-2"><FileCheck2 className="h-5 w-5 text-primary" /><h2 className="text-lg font-semibold">Release Queue</h2></div>
-            <p className="mt-1 text-xs text-muted-foreground">Review immutable component revisions, resolve blockers, and release with auditable decisions.</p>
           </div>
           <Button size="sm" variant="outline" aria-label="Refresh release queue" disabled={loading} onClick={() => setRefreshKey((value) => value + 1)}>
             <RefreshCw className={cn("h-3.5 w-3.5", loading && "animate-spin")} /> Refresh


### PR DESCRIPTION
## Summary

Remove the grey brochure one-liners under Library Manager section titles (Catalog, Bulk Edit, Import Center, Release Queue) and under **Revision assets and evidence**. Headers are just the name.

Cherry-picked from #142 (@Keybored02).

## Test plan

- [ ] Open Catalog, Bulk Edit, Import Center, Release Queue: title only, no grey subtitle
- [ ] Open a component: **Revision assets and evidence** has no helper line
- [ ] Quality gate on this PR

