### PR TITLE
Give compare sheet selector and New toggle a primary outline

### DIFF
--- a/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
+++ b/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
@@ -1249,14 +1249,14 @@ export function ComparisonPresentationShell({
                     // the switcher's "Old / New" otherwise collide on a bare
                     // /Old/ accessible-name query.
                     <div
-                        className="inline-flex shrink-0 items-center gap-0.5 rounded-md border bg-background p-0.5"
+                        className="inline-flex shrink-0 items-center gap-0.5 rounded-md border border-primary/60 bg-background p-0.5"
                         role="group"
                         aria-label="Revision side"
                     >
                         <Button
                             variant={oldNewSide === "base" ? "secondary" : "ghost"}
                             size="sm"
-                            className="h-7 text-xs"
+                            className="h-7 rounded-sm text-xs"
                             onClick={() => setOldNewSide("base")}
                             aria-label="Old revision"
                             aria-pressed={oldNewSide === "base"}
@@ -1264,9 +1264,16 @@ export function ComparisonPresentationShell({
                             Old
                         </Button>
                         <Button
-                            variant={oldNewSide === "compare" ? "secondary" : "ghost"}
+                            variant="ghost"
                             size="sm"
-                            className="h-7 text-xs"
+                            className={cn(
+                                "h-7 rounded-sm text-xs",
+                                // New reads in the theme's primary color when it
+                                // is the active side, matching the blue-outlined
+                                // sheet selector.
+                                oldNewSide === "compare" &&
+                                    "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
+                            )}
                             onClick={() => setOldNewSide("compare")}
                             aria-label="New revision"
                             aria-pressed={oldNewSide === "compare"}

--- a/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
+++ b/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
@@ -1286,10 +1286,14 @@ export function ComparisonPresentationShell({
                         onOpenChange={setSchematicNavigatorOpen}
                     >
                         <PopoverTrigger asChild>
+                            {/* A primary-colored outline so the sheet selector
+                                reads as the main navigation control. Only the
+                                border is tinted; the text keeps its normal
+                                color so nothing competes with the board. */}
                             <Button
                                 variant="outline"
                                 size="sm"
-                                className="h-8 max-w-56 shrink-0"
+                                className="h-8 max-w-56 shrink-0 border-primary/60 hover:bg-primary/10 aria-expanded:bg-primary/10 dark:border-primary/60 dark:hover:bg-primary/15"
                             >
                                 <FileText className="mr-2 h-3.5 w-3.5 shrink-0" />
                                 <span className="truncate">


### PR DESCRIPTION
## Summary

Give the schematic sheet selector a primary-colored outline so it reads as the main navigation control in Design Comparison. Apply the same outline to the Old/New group; when New is active it fills with the theme primary color, Old stays a neutral fill.

Cherry-picked from #142 (@Keybored02).

## Test plan

- [ ] Open schematic compare: sheet selector has a primary outline
- [ ] Old/New group has the same outline; New fills primary when selected; Old stays neutral
- [ ] Quality gate on this PR

