### PR TITLE
Reflow project cards so the properties panel does not cover them

### DIFF
--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -575,7 +575,13 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                   />
 
                   <div className="relative mt-6 min-h-0 flex-1 overflow-hidden">
-                    <div className="h-full overflow-y-auto pr-1">
+                    <div
+                      className={`h-full overflow-y-auto pr-1 transition-[padding] duration-200 ${
+                        selectedProject !== null
+                          ? "md:pr-[376px] lg:pr-[416px] xl:pr-[476px]"
+                          : ""
+                      }`}
+                    >
                       <div className="mb-4 flex items-center justify-between rounded-lg border bg-card/30 px-3 py-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <p className="text-xs text-muted-foreground">

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -576,7 +576,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
 
                   <div className="relative mt-6 min-h-0 flex-1 overflow-hidden">
                     <div
-                      className={`h-full overflow-y-auto pr-1 transition-[padding] duration-200 ${
+                      className={`h-full overflow-y-auto pr-1 ${
                         selectedProject !== null
                           ? "md:pr-[376px] lg:pr-[416px] xl:pr-[476px]"
                           : ""

--- a/frontend/src/components/workspace/workspace-gallery-view.tsx
+++ b/frontend/src/components/workspace/workspace-gallery-view.tsx
@@ -108,7 +108,7 @@ export function WorkspaceGalleryView({
               {currentFolderId !== null && (
                 <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Folders</h3>
               )}
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+              <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
                 {visibleFolders.map((folder) => (
                   <div
                     key={folder.id}

--- a/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
+++ b/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
@@ -308,7 +308,8 @@ export function WorkspaceProjectPropertiesSheet({
     <aside
       className={cn(
         "flex h-full min-w-0 shrink-0 flex-col border-l bg-background/95 backdrop-blur-sm shadow-2xl",
-        "w-[360px] lg:w-[400px] xl:w-[460px]"
+        "w-[360px] lg:w-[400px] xl:w-[460px]",
+        "animate-in slide-in-from-right duration-200 ease-out"
       )}
       aria-label="Project properties panel"
     >

--- a/frontend/src/components/workspace/workspace-types.ts
+++ b/frontend/src/components/workspace/workspace-types.ts
@@ -1,4 +1,10 @@
 export type WorkspaceSection = "projects" | "library-manager";
 export type ViewMode = "gallery" | "list";
 
-export const PROJECT_GRID_CLASS = "grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5";
+// auto-fill with a fixed minimum column width, so the number of columns is
+// derived from the available width rather than pinned per breakpoint. When the
+// properties panel opens and the grid area narrows, cards keep their size and
+// the overflowing column wraps onto the next row instead of every card getting
+// squeezed thinner.
+export const PROJECT_GRID_CLASS =
+  "grid gap-5 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]";


### PR DESCRIPTION
## Summary

When a project is selected, the properties panel no longer covers the rightmost cards. The gallery reserves the panel width, cards keep a fixed minimum size, and overflow wraps to the next row in one layout step. The panel slides into the reserved space instead of animating the grid padding.

Cherry-picked from #142 (@Keybored02).

## Test plan

- [ ] Select a project on the gallery: rightmost cards wrap instead of hiding under the panel
- [ ] Deselect: grid uses the full width again
- [ ] Below the `md` breakpoint, layout is unchanged (panel does not leave room to reflow)
- [ ] Quality gate on this PR

