### PR TITLE
Simplify the project gallery pager to Previous / Page N of M / Next

### DIFF
--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -26,26 +26,6 @@ import { WorkspaceSection, ViewMode } from "./workspace/workspace-types";
 
 const WORKSPACE_PAGE_SIZE = 25;
 
-// The page numbers to show in the pager: always first and last, a window of
-// pages around the current one, and an ellipsis ("…") wherever a gap is
-// skipped. Keeps the control compact when there are many pages while still
-// letting you jump straight to one.
-function paginationRange(current: number, total: number): (number | "ellipsis")[] {
-  if (total <= 7) {
-    return Array.from({ length: total }, (_, index) => index + 1);
-  }
-  const pages = new Set<number>([1, total, current, current - 1, current + 1]);
-  const sorted = [...pages].filter((page) => page >= 1 && page <= total).sort((a, b) => a - b);
-  const result: (number | "ellipsis")[] = [];
-  let previous = 0;
-  for (const page of sorted) {
-    if (page - previous > 1) result.push("ellipsis");
-    result.push(page);
-    previous = page;
-  }
-  return result;
-}
-
 const ImportDialog = lazy(() =>
   import("./import-dialog").then((module) => ({ default: module.ImportDialog }))
 );
@@ -644,36 +624,14 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                           >
                             Previous
                           </Button>
-                          {paginationRange(currentPage, totalPages).map((page, index) =>
-                            page === "ellipsis" ? (
-                              <span
-                                key={`ellipsis-${index}`}
-                                className="px-1 text-[11px] text-muted-foreground"
-                                aria-hidden
-                              >
-                                …
-                              </span>
-                            ) : (
-                              <Button
-                                key={page}
-                                size="sm"
-                                variant={page === currentPage ? "default" : "outline"}
-                                className="h-7 min-w-7 px-2 text-[11px]"
-                                aria-current={page === currentPage ? "page" : undefined}
-                                onClick={() => setCurrentPage(page)}
-                              >
-                                {page}
-                              </Button>
-                            )
-                          )}
                           <Button
                             size="sm"
                             variant="outline"
                             className="h-7 px-2 text-[11px]"
                             disabled={currentPage >= totalPages}
-                            onClick={() => setCurrentPage(totalPages)}
+                            onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
                           >
-                            Last
+                            Next
                           </Button>
                         </div>
                       </div>

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -579,7 +579,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                       <div className="mb-4 flex items-center justify-between rounded-lg border bg-card/30 px-3 py-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <p className="text-xs text-muted-foreground">
-                            Page {currentPage} of {totalPages} · {pageLabel}
+                            {pageLabel}
                           </p>
                           {canManageProjects && listProjects.length > 0 && (
                             <Button
@@ -624,6 +624,9 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                           >
                             Previous
                           </Button>
+                          <span className="px-1 text-[11px] text-muted-foreground">
+                            Page {currentPage} of {totalPages}
+                          </span>
                           <Button
                             size="sm"
                             variant="outline"

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -26,6 +26,26 @@ import { WorkspaceSection, ViewMode } from "./workspace/workspace-types";
 
 const WORKSPACE_PAGE_SIZE = 25;
 
+// The page numbers to show in the pager: always first and last, a window of
+// pages around the current one, and an ellipsis ("…") wherever a gap is
+// skipped. Keeps the control compact when there are many pages while still
+// letting you jump straight to one.
+function paginationRange(current: number, total: number): (number | "ellipsis")[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, index) => index + 1);
+  }
+  const pages = new Set<number>([1, total, current, current - 1, current + 1]);
+  const sorted = [...pages].filter((page) => page >= 1 && page <= total).sort((a, b) => a - b);
+  const result: (number | "ellipsis")[] = [];
+  let previous = 0;
+  for (const page of sorted) {
+    if (page - previous > 1) result.push("ellipsis");
+    result.push(page);
+    previous = page;
+  }
+  return result;
+}
+
 const ImportDialog = lazy(() =>
   import("./import-dialog").then((module) => ({ default: module.ImportDialog }))
 );
@@ -620,28 +640,32 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
                             variant="outline"
                             className="h-7 px-2 text-[11px]"
                             disabled={currentPage <= 1}
-                            onClick={() => setCurrentPage(1)}
-                          >
-                            First
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="h-7 px-2 text-[11px]"
-                            disabled={currentPage <= 1}
                             onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
                           >
                             Previous
                           </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="h-7 px-2 text-[11px]"
-                            disabled={currentPage >= totalPages}
-                            onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
-                          >
-                            Next
-                          </Button>
+                          {paginationRange(currentPage, totalPages).map((page, index) =>
+                            page === "ellipsis" ? (
+                              <span
+                                key={`ellipsis-${index}`}
+                                className="px-1 text-[11px] text-muted-foreground"
+                                aria-hidden
+                              >
+                                …
+                              </span>
+                            ) : (
+                              <Button
+                                key={page}
+                                size="sm"
+                                variant={page === currentPage ? "default" : "outline"}
+                                className="h-7 min-w-7 px-2 text-[11px]"
+                                aria-current={page === currentPage ? "page" : undefined}
+                                onClick={() => setCurrentPage(page)}
+                              >
+                                {page}
+                              </Button>
+                            )
+                          )}
                           <Button
                             size="sm"
                             variant="outline"


### PR DESCRIPTION
## Summary

Replace First / Previous / Next / Last on the project gallery with Previous, **Page N of M**, and Next. The left label is just the item range for the page.

Overlaps `workspace.tsx` with #148 (gallery reflow). Merge one, then rebase the other.

Cherry-picked from #142 (@Keybored02).

## Test plan

- [ ] Gallery pager is Previous, Page N of M, Next — no First/Last
- [ ] Page label on the left is the item range only
- [ ] Quality gate on this PR

