### PR TITLE
Name the current branch in the selector and keep local/remote twins

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -505,17 +505,7 @@ def get_branches(repo_path: str, relative_path: str = None) -> dict[str, Any]:
             }
         )
 
-    # A local branch and its remote-tracking counterpart share a name
-    # (master / origin/master). When they point at the same commit the remote
-    # is redundant, so record each local branch's commit and drop a same-named
-    # remote that matches it. A diverged remote (ahead/behind) is kept so its
-    # distinct state can still be viewed.
-    local_commit_by_name: dict[str, str] = {}
     for branch in repo.heads:
-        try:
-            local_commit_by_name[branch.name] = repo.commit(branch.name).hexsha
-        except Exception:
-            pass
         add_branch(
             name=branch.name,
             ref=branch.name,
@@ -526,9 +516,6 @@ def get_branches(repo_path: str, relative_path: str = None) -> dict[str, Any]:
     for remote in repo.remotes:
         for remote_ref in remote.refs:
             if remote_ref.remote_head == "HEAD":
-                continue
-            local_commit = local_commit_by_name.get(remote_ref.remote_head)
-            if local_commit is not None and local_commit == _resolve_commit(repo, remote_ref.name).hexsha:
                 continue
             add_branch(
                 name=remote_ref.remote_head,

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -505,7 +505,17 @@ def get_branches(repo_path: str, relative_path: str = None) -> dict[str, Any]:
             }
         )
 
+    # A local branch and its remote-tracking counterpart share a name
+    # (master / origin/master). When they point at the same commit the remote
+    # is redundant, so record each local branch's commit and drop a same-named
+    # remote that matches it. A diverged remote (ahead/behind) is kept so its
+    # distinct state can still be viewed.
+    local_commit_by_name: dict[str, str] = {}
     for branch in repo.heads:
+        try:
+            local_commit_by_name[branch.name] = repo.commit(branch.name).hexsha
+        except Exception:
+            pass
         add_branch(
             name=branch.name,
             ref=branch.name,
@@ -516,6 +526,9 @@ def get_branches(repo_path: str, relative_path: str = None) -> dict[str, Any]:
     for remote in repo.remotes:
         for remote_ref in remote.refs:
             if remote_ref.remote_head == "HEAD":
+                continue
+            local_commit = local_commit_by_name.get(remote_ref.remote_head)
+            if local_commit is not None and local_commit == _resolve_commit(repo, remote_ref.name).hexsha:
                 continue
             add_branch(
                 name=remote_ref.remote_head,

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -123,6 +123,12 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
         () => branches.find((branch) => branch.ref === selectedBranchRef) || null,
         [branches, selectedBranchRef]
     );
+    // The empty-value option means "the branch the repo is checked out to".
+    // Show that branch's name rather than the generic "Current checkout".
+    const currentBranch = useMemo(
+        () => branches.find((branch) => branch.is_current) || null,
+        [branches]
+    );
     const activeCommit = currentCommit || selectedBranch?.commit || null;
     const comparisonUrl = useMemo(
         () => readComparisonUrlState(searchParams),
@@ -423,9 +429,19 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                         onChange={(event) => handleBranchChange(event.target.value)}
                         disabled={branchesLoading}
                         title={branchError || "View this project on another branch"}
-                        className="h-9 max-w-[260px] rounded-md border border-input bg-background px-3 text-sm text-foreground shadow-sm outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                        className="h-9 max-w-[260px] appearance-none rounded-md border border-input bg-background bg-no-repeat py-0 pl-3 pr-8 text-sm text-foreground shadow-sm outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                        style={{
+                            backgroundImage:
+                                "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23888888' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E\")",
+                            backgroundPosition: "right 0.5rem center",
+                            backgroundSize: "1rem",
+                        }}
                     >
-                        <option value="">{branchesLoading ? "Loading branches..." : "Current checkout"}</option>
+                        <option value="">
+                            {branchesLoading
+                                ? "Loading branches..."
+                                : currentBranch?.name || "Current checkout"}
+                        </option>
                         {branches.map((branch) => (
                             <option key={branch.ref} value={branch.ref}>
                                 {branch.source === "remote" ? branch.ref : branch.name}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -425,7 +425,15 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                 <div className="hidden min-w-0 items-center gap-2 md:flex">
                     <GitBranch className="h-4 w-4 text-muted-foreground" />
                     <select
-                        value={selectedBranchRef || ""}
+                        // An explicit ?branch= for the current branch has no
+                        // option of its own (it lives in the default entry), so
+                        // map it back to the default value to keep the select
+                        // in sync rather than falling through to the first item.
+                        value={
+                            selectedBranchRef && selectedBranchRef !== currentBranch?.ref
+                                ? selectedBranchRef
+                                : ""
+                        }
                         onChange={(event) => handleBranchChange(event.target.value)}
                         disabled={branchesLoading}
                         title={branchError || "View this project on another branch"}
@@ -442,12 +450,16 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                                 ? "Loading branches..."
                                 : currentBranch?.name || "Current checkout"}
                         </option>
-                        {branches.map((branch) => (
-                            <option key={branch.ref} value={branch.ref}>
-                                {branch.source === "remote" ? branch.ref : branch.name}
-                                {branch.is_current ? " (current)" : ""}
-                            </option>
-                        ))}
+                        {/* The default option above already represents the
+                            current branch by name, so skip it here rather than
+                            listing it a second time with a "(current)" suffix. */}
+                        {branches
+                            .filter((branch) => !branch.is_current)
+                            .map((branch) => (
+                                <option key={branch.ref} value={branch.ref}>
+                                    {branch.source === "remote" ? branch.ref : branch.name}
+                                </option>
+                            ))}
                     </select>
                 </div>
 


### PR DESCRIPTION
## Summary

Name the current branch in the project branch selector (fallback: "Current checkout" while loading). Use a custom chevron 8px in from the right. Do not list the current branch twice. Keep local and remote twins (`master` and `origin/master`).

Cherry-picked from #142 (@Keybored02).

## Test plan

- [ ] Selector label is the current branch name, not "Current checkout", once branches load
- [ ] Chevron sits next to the name, not on the far right edge
- [ ] Current branch is not duplicated further down the list
- [ ] Both `master` and `origin/master` remain when they exist
- [ ] Quality gate on this PR

