### PR TITLE
Open History PDFs and text files in the browser, not the visualizer

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1588,7 +1588,8 @@ async def get_project_commit_file(
     in the browser's own viewer rather than routing them to the visualizer.
 
     The mime type is guessed from the name, so a PDF is served as
-    application/pdf and the browser opens it inline.
+    application/pdf and the browser opens it inline. History only opens this
+    endpoint for PDF, CSV, text, and markdown; CAD files go to the visualizer.
     """
     project = get_project_for_role_or_404(project_id, user.role)
     repo_path, relative_path = _repo_context(project)

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1575,6 +1575,45 @@ async def get_project_commit_summary(
     )
 
 
+@router.get("/{project_id}/commits/{commit_hash}/file")
+async def get_project_commit_file(
+    project_id: str,
+    commit_hash: str,
+    path: str,
+    user: AuthenticatedUser = Depends(require_viewer),
+):
+    """
+    Serve one file from a commit as inline content, keyed by the repo-relative
+    path the commit summary returns. Used to open non-CAD files (PDFs, images)
+    in the browser's own viewer rather than routing them to the visualizer.
+
+    The mime type is guessed from the name, so a PDF is served as
+    application/pdf and the browser opens it inline.
+    """
+    project = get_project_for_role_or_404(project_id, user.role)
+    repo_path, relative_path = _repo_context(project)
+
+    # The summary path is already repo-relative (it includes the subproject
+    # prefix for Type-2 projects), so read it against the repo root with no
+    # extra prefix. Confine it to the project's own subtree so one subproject
+    # cannot read a sibling's files out of the shared parent repo.
+    normalized = posixpath.normpath(path).lstrip("/")
+    if normalized.startswith("..") or normalized == ".":
+        raise HTTPException(status_code=400, detail="Invalid file path")
+    if relative_path:
+        prefix = f"{posixpath.normpath(relative_path).strip('/')}/"
+        if not (normalized + "/").startswith(prefix):
+            raise HTTPException(status_code=404, detail="File not found")
+
+    commit_file = file_service.read_file_from_commit(
+        repo_path,
+        commit_hash,
+        normalized,
+        not_found_detail="File not found",
+    )
+    return _commit_file_response(commit_file, inline=True)
+
+
 @router.get("/{project_id}/schematic")
 async def get_project_schematic(
     project_id: str,

--- a/docs/PROJECT_WORKFLOWS.md
+++ b/docs/PROJECT_WORKFLOWS.md
@@ -62,6 +62,14 @@ Project sections include:
 | --- | --- |
 | Overview | README and project summary |
 | History | commits, tags, and comparison entry points |
+
+From an expanded commit's file list:
+
+- schematic, board, project, and library files (`.kicad_sch`, `.kicad_pcb`, `.kicad_pro`, `.kicad_sym`, `.kicad_mod`) open in the visualizer;
+- PDF, CSV, `.txt`, and Markdown open in a new browser tab, served from that commit with the file's real content type;
+- gerbers and other non-CAD files do nothing — they are listed, not visualized.
+
+A commit-file endpoint is confined to the project's own subtree so one subproject cannot read a sibling's files.
 | Visualizers | schematic, PCB, 3D, BOM, stackup, and assembly views |
 | Workflows | fixed KiCad design, manufacturing, and render jobs |
 | Assets | generated output browser |

--- a/frontend/src/components/history-file-open.test.ts
+++ b/frontend/src/components/history-file-open.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { historyFileOpenAction, visualizerTabForFile } from "./history-file-open";
+
+describe("historyFileOpenAction", () => {
+  it("opens KiCad design files in the visualizer", () => {
+    expect(historyFileOpenAction("board.kicad_pcb")).toBe("visualizer");
+    expect(historyFileOpenAction("sheet.kicad_sch")).toBe("visualizer");
+    expect(historyFileOpenAction("board.kicad_pro")).toBe("visualizer");
+    expect(historyFileOpenAction("Device.kicad_sym")).toBe("visualizer");
+    expect(historyFileOpenAction("R_0805.kicad_mod")).toBe("visualizer");
+  });
+
+  it("opens PDF, CSV, text, and markdown in a new browser tab", () => {
+    expect(historyFileOpenAction("notes.pdf")).toBe("browser");
+    expect(historyFileOpenAction("bom.csv")).toBe("browser");
+    expect(historyFileOpenAction("README.txt")).toBe("browser");
+    expect(historyFileOpenAction("NOTES.md")).toBe("browser");
+    expect(historyFileOpenAction("guide.markdown")).toBe("browser");
+  });
+
+  it("does nothing for gerbers, images, and other non-CAD files", () => {
+    expect(historyFileOpenAction("board.gbr")).toBe("none");
+    expect(historyFileOpenAction("board.gtl")).toBe("none");
+    expect(historyFileOpenAction("preview.png")).toBe("none");
+    expect(historyFileOpenAction("photo.jpg")).toBe("none");
+    expect(historyFileOpenAction("data.json")).toBe("none");
+  });
+});
+
+describe("visualizerTabForFile", () => {
+  it("routes boards and schematics to their visualizer tabs", () => {
+    expect(visualizerTabForFile("board.kicad_pcb")).toBe("pcb");
+    expect(visualizerTabForFile("root.kicad_sch")).toBe("sch");
+    expect(visualizerTabForFile("board.kicad_pro")).toBeUndefined();
+  });
+});

--- a/frontend/src/components/history-file-open.ts
+++ b/frontend/src/components/history-file-open.ts
@@ -1,0 +1,20 @@
+/** How a History file row should respond to a click. */
+
+const CAD_FILE = /\.(kicad_pcb|kicad_sch|kicad_pro|kicad_sym|kicad_mod)$/i;
+const BROWSER_FILE = /\.(pdf|csv|txt|md|markdown)$/i;
+
+export type HistoryFileOpenAction = "visualizer" | "browser" | "none";
+
+export function historyFileOpenAction(filename: string): HistoryFileOpenAction {
+  const name = filename.split(/[/\\]/).pop() || filename;
+  if (CAD_FILE.test(name)) return "visualizer";
+  if (BROWSER_FILE.test(name)) return "browser";
+  return "none";
+}
+
+export function visualizerTabForFile(filename: string): "pcb" | "sch" | undefined {
+  const name = filename.split(/[/\\]/).pop() || filename;
+  if (name.endsWith(".kicad_pcb")) return "pcb";
+  if (name.endsWith(".kicad_sch")) return "sch";
+  return undefined;
+}

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -163,6 +163,13 @@ function fileTypeIcon(filename: string): { Icon: typeof FileText; color: string 
     return { Icon: FileText, color: "text-muted-foreground" };
 }
 
+// Files the browser can display on its own (PDFs, images). These open in a new
+// tab against their raw bytes rather than the visualizer, which has no view for
+// them and would otherwise just fall back to the commit view.
+function opensInBrowser(filename: string): boolean {
+    return /\.(pdf|png|jpe?g|gif|svg|webp|bmp)$/i.test(filename);
+}
+
 // Which visualizer tab a changed file opens onto. Board and schematic have their
 // own views; anything else (project, libraries) just opens the visualizer on its
 // default tab, since there is no dedicated viewer for it.
@@ -420,11 +427,22 @@ function CommitItem({
                                     key={file.path}
                                     type="button"
                                     className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-xs hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                    onClick={() => onOpenVisualizer(
-                                        commit.full_hash,
-                                        visualizerTabForFile(file.filename),
-                                    )}
-                                    title={`Open ${file.filename} at this commit`}
+                                    onClick={() => {
+                                        if (opensInBrowser(file.filename)) {
+                                            const url = `/api/projects/${projectId}/commits/${commit.full_hash}/file?path=${encodeURIComponent(file.path)}`;
+                                            window.open(url, "_blank", "noopener");
+                                            return;
+                                        }
+                                        onOpenVisualizer(
+                                            commit.full_hash,
+                                            visualizerTabForFile(file.filename),
+                                        );
+                                    }}
+                                    title={
+                                        opensInBrowser(file.filename)
+                                            ? `Open ${file.filename} in a new tab`
+                                            : `Open ${file.filename} at this commit`
+                                    }
                                 >
                                     <span className={`flex items-center gap-1 shrink-0 ${STATUS_COLOR[file.status] ?? "text-muted-foreground"}`}>
                                         {STATUS_ICON[file.status]}

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -40,6 +40,7 @@ import {
     selectRevisionSlot,
     type RevisionRef,
 } from "./history-comparison-selection";
+import { historyFileOpenAction, visualizerTabForFile } from "./history-file-open";
 
 interface Release {
     tag: string;
@@ -163,21 +164,6 @@ function fileTypeIcon(filename: string): { Icon: typeof FileText; color: string 
     return { Icon: FileText, color: "text-muted-foreground" };
 }
 
-// Files the browser can display on its own (PDFs, images). These open in a new
-// tab against their raw bytes rather than the visualizer, which has no view for
-// them and would otherwise just fall back to the commit view.
-function opensInBrowser(filename: string): boolean {
-    return /\.(pdf|png|jpe?g|gif|svg|webp|bmp)$/i.test(filename);
-}
-
-// Which visualizer tab a changed file opens onto. Board and schematic have their
-// own views; anything else (project, libraries) just opens the visualizer on its
-// default tab, since there is no dedicated viewer for it.
-function visualizerTabForFile(filename: string): string | undefined {
-    if (filename.endsWith(".kicad_pcb")) return "pcb";
-    if (filename.endsWith(".kicad_sch")) return "sch";
-    return undefined;
-}
 
 // Small chip indicating that a commit (or file) touched N items of a given
 // kind. Renders nothing when count is 0 so rows without that kind of change
@@ -422,28 +408,10 @@ function CommitItem({
                         .sort((a, b) => fileSortRank(a.filename) - fileSortRank(b.filename))
                         .map((file) => {
                             const { Icon: TypeIcon, color: typeColor } = fileTypeIcon(file.filename);
-                            return (
-                                <button
-                                    key={file.path}
-                                    type="button"
-                                    className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-xs hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                    onClick={() => {
-                                        if (opensInBrowser(file.filename)) {
-                                            const url = `/api/projects/${projectId}/commits/${commit.full_hash}/file?path=${encodeURIComponent(file.path)}`;
-                                            window.open(url, "_blank", "noopener");
-                                            return;
-                                        }
-                                        onOpenVisualizer(
-                                            commit.full_hash,
-                                            visualizerTabForFile(file.filename),
-                                        );
-                                    }}
-                                    title={
-                                        opensInBrowser(file.filename)
-                                            ? `Open ${file.filename} in a new tab`
-                                            : `Open ${file.filename} at this commit`
-                                    }
-                                >
+                            const openAction = historyFileOpenAction(file.filename);
+                            const rowClassName = "flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-xs";
+                            const rowBody = (
+                                <>
                                     <span className={`flex items-center gap-1 shrink-0 ${STATUS_COLOR[file.status] ?? "text-muted-foreground"}`}>
                                         {STATUS_ICON[file.status]}
                                     </span>
@@ -462,6 +430,38 @@ function CommitItem({
                                             )}
                                         </span>
                                     )}
+                                </>
+                            );
+                            if (openAction === "none") {
+                                return (
+                                    <div key={file.path} className={rowClassName}>
+                                        {rowBody}
+                                    </div>
+                                );
+                            }
+                            return (
+                                <button
+                                    key={file.path}
+                                    type="button"
+                                    className={`${rowClassName} hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
+                                    onClick={() => {
+                                        if (openAction === "browser") {
+                                            const url = `/api/projects/${projectId}/commits/${commit.full_hash}/file?path=${encodeURIComponent(file.path)}`;
+                                            window.open(url, "_blank", "noopener");
+                                            return;
+                                        }
+                                        onOpenVisualizer(
+                                            commit.full_hash,
+                                            visualizerTabForFile(file.filename),
+                                        );
+                                    }}
+                                    title={
+                                        openAction === "browser"
+                                            ? `Open ${file.filename} in a new tab`
+                                            : `Open ${file.filename} at this commit`
+                                    }
+                                >
+                                    {rowBody}
                                 </button>
                             );
                         })}


### PR DESCRIPTION
## Summary

History file rows no longer send every non-CAD file to the visualizer.

- `.kicad_pcb`, `.kicad_sch`, `.kicad_pro`, `.kicad_sym`, `.kicad_mod` open the visualizer
- PDF, CSV, `.txt`, and Markdown open in a new browser tab via `GET /api/projects/{id}/commits/{hash}/file` (project-subtree confined)
- gerbers, images, and everything else are listed and do nothing

Cherry-picked from #142 (@Keybored02), with the click whitelist narrowed to the files the browser can actually render.

## Test plan

- [x] `history-file-open.test.ts` covers CAD / browser / none
- [ ] Expand a commit: click a schematic → visualizer; click a PDF → new tab; click a gerber → no navigation
- [ ] Quality gate on this PR

