### PR TITLE
Theme visualizer layer and inspector scrollbars

### DIFF
--- a/frontend/src/components/ecad-viewer-controls.tsx
+++ b/frontend/src/components/ecad-viewer-controls.tsx
@@ -207,7 +207,7 @@ export function EcadViewerControls({
                                     </SelectContent>
                                 </Select>
                             </div>
-                            <ScrollArea className="min-h-0 flex-1">
+                            <ScrollArea className="themed-scrollbar min-h-0 flex-1">
                                 <div className="p-2">
                                     <PcbLayerList
                                         layers={pcbState?.layers ?? []}

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -221,7 +221,7 @@ export function SelectionInspector({
                 </div>
             </header>
 
-            <ScrollArea className="min-h-0 flex-1">
+            <ScrollArea className="themed-scrollbar min-h-0 flex-1">
                 <div className="space-y-5 p-4 text-xs">
                     {showLabelNav && (
                         <section>
@@ -258,7 +258,7 @@ export function SelectionInspector({
                                     <ChevronRight className="h-4 w-4" />
                                 </Button>
                             </div>
-                            <ul className="mt-2 max-h-40 space-y-1 overflow-y-auto border bg-card/20 p-2">
+                            <ul className="themed-scrollbar mt-2 max-h-40 space-y-1 overflow-y-auto border bg-card/20 p-2">
                                 {labelInstances.map((instance) => {
                                     const active = instance.uuid === activeUuid;
                                     return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,4 +90,25 @@
   .bg-preview-surface {
     background-color: hsl(var(--preview-surface));
   }
+
+  /* A slim, theme-colored scrollbar so scrolling panels match the UI instead
+     of showing the OS default. Applied per-container rather than globally. */
+  .themed-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+  }
+  .themed-scrollbar::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  .themed-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .themed-scrollbar::-webkit-scrollbar-thumb {
+    background: hsl(var(--muted-foreground) / 0.3);
+    border-radius: 4px;
+  }
+  .themed-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / 0.5);
+  }
 }


### PR DESCRIPTION
## Summary

Theme the layer card and selection inspector scrollbars with a slim muted thumb on a transparent track. Adds a reusable `.themed-scrollbar` utility.

Overlaps `selection-inspector.tsx` with the upcoming inspector PR.

Cherry-picked from #142 (@Keybored02).

## Test plan

- [ ] Layer card and inspector scrollbars match the UI in light and dark
- [ ] Quality gate on this PR

