### PR TITLE
Toggle commenting mode with the C key

### DIFF
--- a/docs/PROJECT_WORKFLOWS.md
+++ b/docs/PROJECT_WORKFLOWS.md
@@ -85,6 +85,10 @@ The schematic and PCB viewers support object and area comments. Designers and
 administrators can create, reply, resolve, and delete; viewers can read and
 navigate discussions.
 
+With nothing selected, `C` toggles commenting mode (the same as the toolbar
+button). With a selection, `C` opens the comment form for that element. Escape
+also leaves commenting mode.
+
 Comments support class, severity, and stored mentions. Mention storage does not
 currently send email or an in-product notification.
 

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -1125,7 +1125,9 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                     });
                     setShowCommentForm(true);
                 } else {
-                    setCommentMode(true);
+                    // No selection: C toggles commenting mode, so pressing it
+                    // again turns it back off.
+                    setCommentMode((enabled) => !enabled);
                 }
                 event.preventDefault();
                 return;


### PR DESCRIPTION
## Summary

With nothing selected, `C` toggles commenting mode on and off (same as the toolbar). With a selection, `C` still opens the comment form for that element.

Cherry-picked from #142 (@Keybored02). Overlaps `visualizer.tsx` with the inspector and rail PRs.

## Test plan

- [ ] Empty canvas: C enters comment mode; C again leaves it
- [ ] Selected symbol: C opens the comment form
- [ ] Quality gate on this PR

