### PR TITLE
Selection inspector: flags, links, and view-aware card

### DIFF
--- a/backend/app/services/semantic_index_service.py
+++ b/backend/app/services/semantic_index_service.py
@@ -464,9 +464,14 @@ def _canonical_fields(component: dict[str, Any]) -> dict[str, str]:
         return ""
 
     dnp = _resolve_dnp(parameters, casefolded)
+    # KiCad's "in BOM" flag, parsed by kicad-monkey as kicad_in_bom. Surface it
+    # as a clean Yes/No field; absent flag defaults to Yes (KiCad's default).
+    in_bom_raw = casefolded.get("kicadinbom", "").strip()
+    in_bom = "No" if in_bom_raw and in_bom_raw.casefold() not in _TRUTHY_FLAGS else "Yes"
     required = {
         "Value": _string(component.get("value")) or pick("Value"),
         "DNP": dnp,
+        "In BOM": in_bom,
         "Description": _string(component.get("description")) or pick("Description"),
         "Datasheet": pick("Datasheet", "Data Sheet", "Datasheet URL", "Datasheet Link"),
         "Manufacturer": pick("Manufacturer", "MFR", "Mfr"),

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -1,11 +1,14 @@
+import type { ReactNode } from "react";
 import { useState } from "react";
 import {
+    Check,
     ChevronDown,
     ChevronLeft,
     ChevronRight,
     CircuitBoard,
     Cpu,
     Database,
+    ExternalLink,
     LibraryBig,
     LoaderCircle,
     Network,
@@ -80,14 +83,76 @@ function resolveTerminal(selection: PrismSelection, index: PrismSemanticIndex | 
     return atIndex(index.terminals, index.indexes.terminalByReferencePin?.[`${selection.reference}:${selection.pin}`]);
 }
 
-function PropertyRow({ label, value }: { label: string; value: string | number | undefined }) {
-    if (value === undefined || value === "") return null;
+function PropertyRow({ label, value }: { label: string; value: ReactNode }) {
+    if (value === undefined || value === null || value === "") return null;
     return (
         <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] gap-3 border-b py-2.5 last:border-b-0">
             <dt className="text-muted-foreground">{label}</dt>
-            <dd className="break-words text-right font-medium">{value}</dd>
+            <dd className="min-w-0 break-words text-right font-medium">{value}</dd>
         </div>
     );
+}
+
+// A Yes/No flag as a colored icon: green tick for the "good" state, red cross
+// for the other. `goodWhenYes` flips which value is the green one.
+function FlagValue({ value, goodWhenYes }: { value: string; goodWhenYes: boolean }) {
+    const yes = value.trim().toLowerCase() === "yes";
+    const good = goodWhenYes ? yes : !yes;
+    return (
+        <span className="inline-flex items-center justify-end gap-1.5">
+            {good ? (
+                <Check className="h-4 w-4 text-success" aria-hidden />
+            ) : (
+                <X className="h-4 w-4 text-destructive" aria-hidden />
+            )}
+            <span className="text-xs">{value}</span>
+        </span>
+    );
+}
+
+// A value that is a link: the text, followed by an external-link glyph, opening
+// in a new tab. Used for datasheet/other URLs and the formed LCSC part link.
+function LinkValue({ href, text }: { href: string; text: string }) {
+    return (
+        <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex min-w-0 items-center justify-end gap-1 text-primary hover:underline"
+            title={href}
+        >
+            <span className="truncate">{text}</span>
+            <ExternalLink className="h-3 w-3 shrink-0" aria-hidden />
+        </a>
+    );
+}
+
+const URL_PATTERN = /^(https?:\/\/|www\.)\S+$/i;
+
+function normalizeUrl(value: string): string | null {
+    const trimmed = value.trim();
+    if (!URL_PATTERN.test(trimmed)) return null;
+    return trimmed.startsWith("www.") ? `https://${trimmed}` : trimmed;
+}
+
+// The LCSC catalog URL for a part code like "C125977".
+function lcscUrl(part: string): string | null {
+    const code = part.trim().match(/^C\d+$/i)?.[0];
+    return code ? `https://www.lcsc.com/product-detail/${code.toUpperCase()}.html` : null;
+}
+
+// Decide how one field's value should render: DNP/In BOM as flags, an LCSC part
+// as a formed link, a URL as a link, otherwise plain text.
+function renderFieldValue(key: string, value: string): ReactNode {
+    if (key === "DNP") return <FlagValue value={value} goodWhenYes={false} />;
+    if (key === "In BOM") return <FlagValue value={value} goodWhenYes={true} />;
+    if (key === "LCSC Part") {
+        const href = lcscUrl(value);
+        return href ? <LinkValue href={href} text={value} /> : value;
+    }
+    const url = normalizeUrl(value);
+    if (url) return <LinkValue href={url} text={value} />;
+    return value;
 }
 
 const capitalizeFirst = (value: string): string =>
@@ -343,7 +408,9 @@ export function SelectionInspector({
                                     <PropertyRow label="Footprint" value={component.footprint} />
                                     {Object.entries(component.fields || {})
                                         .filter(([key, value]) => !["Reference", "Value", "Footprint"].includes(key) && !key.startsWith("_") && !key.startsWith("kicad_") && value !== "")
-                                        .map(([key, value]) => <PropertyRow key={key} label={key} value={String(value)} />)}
+                                        .map(([key, value]) => (
+                                            <PropertyRow key={key} label={key} value={renderFieldValue(key, String(value))} />
+                                        ))}
                                 </dl>
                             </CollapsibleSection>
                         </>

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -51,6 +51,8 @@ interface SelectionInspectorProps {
     onFocusLabelInstance?: (uuid: string) => void;
     navigatingLabelInstance?: boolean;
     embedded?: boolean;
+    /** Layer name -> swatch color, so the Layer row can show the layer's color. */
+    layerColors?: Record<string, string>;
 }
 
 const atIndex = <T,>(items: T[], index: number | undefined): T | undefined =>
@@ -282,6 +284,7 @@ export function SelectionInspector({
     onFocusLabelInstance,
     navigatingLabelInstance = false,
     embedded = false,
+    layerColors,
 }: SelectionInspectorProps) {
     if (!open || !selection) return null;
     const component = resolveComponent(selection, semanticIndex);
@@ -408,7 +411,21 @@ export function SelectionInspector({
                             <PropertyRow label="Net UID" value={selection.kind !== "component" ? selection.netUid : undefined} />
                             <PropertyRow label="Source UUID" value={selection.uuid || selection.anchor?.uuid} />
                             <PropertyRow label="Page" value={selection.anchor?.page} />
-                            <PropertyRow label="Layer" value={selection.anchor?.layer} />
+                            <PropertyRow
+                                label="Layer"
+                                value={selection.anchor?.layer && (
+                                    <span className="inline-flex items-center justify-end gap-1.5">
+                                        {layerColors?.[selection.anchor.layer] && (
+                                            <span
+                                                className="size-3 shrink-0 border"
+                                                style={{ backgroundColor: layerColors[selection.anchor.layer] }}
+                                                aria-hidden
+                                            />
+                                        )}
+                                        <span>{selection.anchor.layer}</span>
+                                    </span>
+                                )}
+                            />
                         </dl>
                     </CollapsibleSection>
 

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -419,8 +419,19 @@ export function SelectionInspector({
                                 <dl>
                                     <PropertyRow label="Value" value={component.value} />
                                     <PropertyRow label="Footprint" value={component.footprint} />
+                                    {/* DNP and BOM always show, as flags, right at
+                                        the top. Default to KiCad's defaults when
+                                        the parse did not carry the field. */}
+                                    <PropertyRow
+                                        label="DNP"
+                                        value={<FlagValue value={String(component.fields?.DNP ?? "No")} goodWhenYes={false} />}
+                                    />
+                                    <PropertyRow
+                                        label="BOM"
+                                        value={<FlagValue value={String(component.fields?.["In BOM"] ?? "Yes")} goodWhenYes={true} />}
+                                    />
                                     {Object.entries(component.fields || {})
-                                        .filter(([key, value]) => isDisplayableField(key, String(value)))
+                                        .filter(([key, value]) => key !== "DNP" && key !== "In BOM" && isDisplayableField(key, String(value)))
                                         .map(([key, value]) => (
                                             <PropertyRow key={key} label={key} value={renderFieldValue(key, String(value))} />
                                         ))}

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
-import { contextLabel, selectionLabel } from "@/lib/prism-selection";
+import { selectionLabel } from "@/lib/prism-selection";
 import type {
     PrismSelection,
     PrismSemanticIndex,
@@ -87,6 +87,9 @@ function PropertyRow({ label, value }: { label: string; value: string | number |
         </div>
     );
 }
+
+const capitalizeFirst = (value: string): string =>
+    value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
 
 const resolvedItemType = (selection: PrismSelection): string => {
     const raw = selection.anchor?.itemType?.trim();
@@ -202,16 +205,19 @@ export function SelectionInspector({
                         </Button>
                     )}
                 </div>
-                <div className="mt-4 flex items-start gap-3">
+                <div className="mt-4 flex items-center gap-3">
                     <div className="border bg-primary/10 p-2.5 text-primary">
                         <SelectionIcon className="h-5 w-5" />
                     </div>
-                    <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-1.5">
-                            <Badge variant="secondary">{contextLabel(selection.sourceContext)}</Badge>
-                            <Badge variant="outline">{resolvedItemType(selection)}</Badge>
+                    <div className="min-w-0 flex-1 leading-tight">
+                        <h2 className="truncate font-mono text-lg font-semibold" title={title}>{title}</h2>
+                        {/* Nudge just the tag up so its bottom lines up with the
+                            icon's bottom, without reflowing the icon or title. */}
+                        <div className="mt-2 flex flex-wrap items-center gap-1.5 -translate-y-1.5">
+                            <Badge variant="outline" className="px-2 py-0 text-[11px] font-medium">
+                                {capitalizeFirst(resolvedItemType(selection))}
+                            </Badge>
                         </div>
-                        <h2 className="mt-2 truncate font-mono text-lg font-semibold" title={title}>{title}</h2>
                     </div>
                 </div>
             </header>

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -212,11 +212,6 @@ export function SelectionInspector({
                             <Badge variant="outline">{resolvedItemType(selection)}</Badge>
                         </div>
                         <h2 className="mt-2 truncate font-mono text-lg font-semibold" title={title}>{title}</h2>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                            {selection.kind === "component" && "Component identity, sourcing, and library context"}
-                            {selection.kind === "terminal" && "Terminal identity and resolved connectivity"}
-                            {selection.kind === "net" && "Electrical connectivity across schematic, PCB, and 3D"}
-                        </p>
                     </div>
                 </div>
             </header>

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -461,10 +461,7 @@ export function SelectionInspector({
                         <>
                             <Separator />
                             <CollapsibleSection title="Library & sourcing">
-                                <p className="text-xs leading-relaxed text-muted-foreground">
-                                    Stage this project component with commit-pinned provenance before release review.
-                                </p>
-                                <div className="mt-2 border bg-card/40 px-3">
+                                <div className="border bg-card/40 px-3">
                                     {onImportComponent ? (
                                         <LibraryImportRow
                                             onImport={onImportComponent}

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -113,18 +113,31 @@ function FlagValue({ value, goodWhenYes }: { value: string; goodWhenYes: boolean
 // A value that is a link: the text, followed by an external-link glyph, opening
 // in a new tab. Used for datasheet/other URLs and the formed LCSC part link.
 function LinkValue({ href, text }: { href: string; text: string }) {
+    // Wrap long URLs onto new lines instead of overflowing the card. break-all
+    // lets the URL break mid-string; the glyph trails the last line inline.
     return (
         <a
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex min-w-0 items-center justify-end gap-1 text-primary hover:underline"
+            className="break-all text-primary hover:underline"
             title={href}
         >
-            <span className="truncate">{text}</span>
-            <ExternalLink className="h-3 w-3 shrink-0" aria-hidden />
+            {text}
+            <ExternalLink className="ml-1 inline-block h-3 w-3 shrink-0 align-text-bottom" aria-hidden />
         </a>
     );
+}
+
+// Fields shown separately or that are internal parser bookkeeping, not worth a
+// row on the component card: the reference/value/footprint (shown elsewhere),
+// KiCad's own attributes (kicad_*/ki_*/_source), and the sheet-location fields.
+const HIDDEN_FIELD_KEYS = new Set(["Reference", "Value", "Footprint", "Sheetfile", "Sheetname"]);
+
+function isDisplayableField(key: string, value: string): boolean {
+    if (HIDDEN_FIELD_KEYS.has(key)) return false;
+    if (key.startsWith("_") || key.startsWith("kicad_") || key.startsWith("ki_")) return false;
+    return value !== "";
 }
 
 const URL_PATTERN = /^(https?:\/\/|www\.)\S+$/i;
@@ -407,7 +420,7 @@ export function SelectionInspector({
                                     <PropertyRow label="Value" value={component.value} />
                                     <PropertyRow label="Footprint" value={component.footprint} />
                                     {Object.entries(component.fields || {})
-                                        .filter(([key, value]) => !["Reference", "Value", "Footprint"].includes(key) && !key.startsWith("_") && !key.startsWith("kicad_") && value !== "")
+                                        .filter(([key, value]) => isDisplayableField(key, String(value)))
                                         .map(([key, value]) => (
                                             <PropertyRow key={key} label={key} value={renderFieldValue(key, String(value))} />
                                         ))}

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import {
+    ChevronDown,
     ChevronLeft,
     ChevronRight,
     CircuitBoard,
@@ -128,6 +130,42 @@ function IntegrationRow({ icon: Icon, title, description }: {
     );
 }
 
+/**
+ * A card section whose body can be folded away. Cards with many fields get long
+ * fast, so each section collapses independently; the header stays as a compact
+ * row you can scan and click to expand. Defaults to open.
+ */
+function CollapsibleSection({
+    title,
+    icon: Icon,
+    defaultOpen = true,
+    children,
+}: {
+    title: string;
+    icon?: typeof CircuitBoard;
+    defaultOpen?: boolean;
+    children: React.ReactNode;
+}) {
+    const [open, setOpen] = useState(defaultOpen);
+    return (
+        <section>
+            <button
+                type="button"
+                className="flex w-full items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground"
+                onClick={() => setOpen((value) => !value)}
+                aria-expanded={open}
+            >
+                <ChevronDown
+                    className={cn("h-3.5 w-3.5 shrink-0 transition-transform", !open && "-rotate-90")}
+                />
+                {Icon && <Icon className="h-3.5 w-3.5 shrink-0" />}
+                <span>{title}</span>
+            </button>
+            {open && <div className="mt-1">{children}</div>}
+        </section>
+    );
+}
+
 function LibraryImportRow({ onImport, disabled, loading }: {
     onImport: () => void;
     disabled: boolean;
@@ -225,10 +263,7 @@ export function SelectionInspector({
             <ScrollArea className="min-h-0 flex-1">
                 <div className="space-y-5 p-4 text-xs">
                     {showLabelNav && (
-                        <section>
-                            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                Instances
-                            </h3>
+                        <CollapsibleSection title="Instances">
                             <div className="flex items-center justify-between gap-2 border bg-card/40 px-3 py-2">
                                 <Button
                                     type="button"
@@ -281,13 +316,10 @@ export function SelectionInspector({
                                     );
                                 })}
                             </ul>
-                        </section>
+                        </CollapsibleSection>
                     )}
 
-                    <section>
-                        <h3 className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                            <CircuitBoard className="h-3.5 w-3.5" /> Identity
-                        </h3>
+                    <CollapsibleSection title="Identity" icon={CircuitBoard}>
                         <dl>
                             {selection.kind !== "net" && <PropertyRow label="Reference" value={selection.reference} />}
                             {selection.kind === "terminal" && <PropertyRow label="Pin / pad" value={selection.pin} />}
@@ -300,13 +332,12 @@ export function SelectionInspector({
                             <PropertyRow label="Page" value={selection.anchor?.page} />
                             <PropertyRow label="Layer" value={selection.anchor?.layer} />
                         </dl>
-                    </section>
+                    </CollapsibleSection>
 
                     {component && (
                         <>
                             <Separator />
-                            <section>
-                                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Component data</h3>
+                            <CollapsibleSection title="Component data">
                                 <dl>
                                     <PropertyRow label="Value" value={component.value} />
                                     <PropertyRow label="Footprint" value={component.footprint} />
@@ -314,16 +345,15 @@ export function SelectionInspector({
                                         .filter(([key, value]) => !["Reference", "Value", "Footprint"].includes(key) && !key.startsWith("_") && !key.startsWith("kicad_") && value !== "")
                                         .map(([key, value]) => <PropertyRow key={key} label={key} value={String(value)} />)}
                                 </dl>
-                            </section>
+                            </CollapsibleSection>
                         </>
                     )}
 
                     {selection.kind !== "net" && (
                         <>
                             <Separator />
-                            <section>
-                                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Library & sourcing</h3>
-                                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                            <CollapsibleSection title="Library & sourcing">
+                                <p className="text-xs leading-relaxed text-muted-foreground">
                                     Stage this project component with commit-pinned provenance before release review.
                                 </p>
                                 <div className="mt-2 border bg-card/40 px-3">
@@ -338,15 +368,14 @@ export function SelectionInspector({
                                     )}
                                     <IntegrationRow icon={Database} title="Component database" description="Lifecycle, alternates, approved vendors, and organization metadata." />
                                 </div>
-                            </section>
+                            </CollapsibleSection>
                         </>
                     )}
 
                     {(terminal || net) && (
                         <>
                             <Separator />
-                            <section>
-                                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Connectivity</h3>
+                            <CollapsibleSection title="Connectivity">
                                 <dl>
                                     <PropertyRow label="Net" value={terminal?.netName || net?.name} />
                                     <PropertyRow label="Net class" value={net?.netClass} />
@@ -354,7 +383,7 @@ export function SelectionInspector({
                                     <PropertyRow label="Schematic pin UUID" value={terminal?.schematicPinUuid} />
                                     <PropertyRow label="PCB pad UUID" value={terminal?.pcbPadUuid} />
                                 </dl>
-                            </section>
+                            </CollapsibleSection>
                         </>
                     )}
 

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -104,11 +104,12 @@ function PropertyRow({ label, value }: { label: string; value: ReactNode }) {
 
 // A Yes/No flag as a colored icon: green tick for the "good" state, red cross
 // for the other. `goodWhenYes` flips which value is the green one.
-function FlagValue({ value, goodWhenYes }: { value: string | undefined; goodWhenYes: boolean }) {
-    if (value === undefined || value.trim() === "") {
+function FlagValue({ value, goodWhenYes }: { value: unknown; goodWhenYes: boolean }) {
+    if (value === undefined || value === null || String(value).trim() === "") {
         return <span className="text-xs text-muted-foreground">Unknown</span>;
     }
-    const yes = value.trim().toLowerCase() === "yes";
+    const text = String(value);
+    const yes = text.trim().toLowerCase() === "yes";
     const good = goodWhenYes ? yes : !yes;
     return (
         <span className="inline-flex items-center justify-end gap-1.5">
@@ -117,7 +118,7 @@ function FlagValue({ value, goodWhenYes }: { value: string | undefined; goodWhen
             ) : (
                 <X className="h-4 w-4 text-destructive" aria-hidden />
             )}
-            <span className="text-xs">{value}</span>
+            <span className="text-xs">{text}</span>
         </span>
     );
 }

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import { selectionLabel } from "@/lib/prism-selection";
 import type {
     PrismSelection,
+    PrismSelectionContext,
     PrismSemanticIndex,
     SemanticComponent,
     SemanticNet,
@@ -186,7 +187,7 @@ const capitalizeFirst = (value: string): string =>
 const effectiveContext = (
     selection: PrismSelection,
     viewContext?: "SCH" | "PCB",
-): "SCH" | "PCB" | undefined => viewContext ?? selection.sourceContext;
+): PrismSelectionContext | undefined => viewContext ?? selection.sourceContext;
 
 const resolvedItemType = (
     selection: PrismSelection,

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -104,7 +104,10 @@ function PropertyRow({ label, value }: { label: string; value: ReactNode }) {
 
 // A Yes/No flag as a colored icon: green tick for the "good" state, red cross
 // for the other. `goodWhenYes` flips which value is the green one.
-function FlagValue({ value, goodWhenYes }: { value: string; goodWhenYes: boolean }) {
+function FlagValue({ value, goodWhenYes }: { value: string | undefined; goodWhenYes: boolean }) {
+    if (value === undefined || value.trim() === "") {
+        return <span className="text-xs text-muted-foreground">Unknown</span>;
+    }
     const yes = value.trim().toLowerCase() === "yes";
     const good = goodWhenYes ? yes : !yes;
     return (
@@ -120,7 +123,7 @@ function FlagValue({ value, goodWhenYes }: { value: string; goodWhenYes: boolean
 }
 
 // A value that is a link: the text, followed by an external-link glyph, opening
-// in a new tab. Used for datasheet/other URLs and the formed LCSC part link.
+// in a new tab. Used for datasheet and other URL fields.
 function LinkValue({ href, text }: { href: string; text: string }) {
     // Wrap long URLs onto new lines instead of overflowing the card. break-all
     // lets the URL break mid-string; the glyph trails the last line inline.
@@ -139,9 +142,9 @@ function LinkValue({ href, text }: { href: string; text: string }) {
 }
 
 // Fields shown separately or that are internal parser bookkeeping, not worth a
-// row on the component card: the reference/value/footprint (shown elsewhere),
-// KiCad's own attributes (kicad_*/ki_*/_source), and the sheet-location fields.
-const HIDDEN_FIELD_KEYS = new Set(["Reference", "Value", "Footprint", "Sheetfile", "Sheetname"]);
+// row on the component card: the reference/value/footprint (shown elsewhere)
+// and KiCad's own attributes (kicad_*/ki_*/_source). Sheetfile/Sheetname stay.
+const HIDDEN_FIELD_KEYS = new Set(["Reference", "Value", "Footprint"]);
 
 function isDisplayableField(key: string, value: string): boolean {
     if (HIDDEN_FIELD_KEYS.has(key)) return false;
@@ -157,21 +160,11 @@ function normalizeUrl(value: string): string | null {
     return trimmed.startsWith("www.") ? `https://${trimmed}` : trimmed;
 }
 
-// The LCSC catalog URL for a part code like "C125977".
-function lcscUrl(part: string): string | null {
-    const code = part.trim().match(/^C\d+$/i)?.[0];
-    return code ? `https://www.lcsc.com/product-detail/${code.toUpperCase()}.html` : null;
-}
-
-// Decide how one field's value should render: DNP/In BOM as flags, an LCSC part
-// as a formed link, a URL as a link, otherwise plain text.
+// Decide how one field's value should render: DNP/In BOM as flags, a URL as a
+// link, otherwise plain text.
 function renderFieldValue(key: string, value: string): ReactNode {
     if (key === "DNP") return <FlagValue value={value} goodWhenYes={false} />;
     if (key === "In BOM") return <FlagValue value={value} goodWhenYes={true} />;
-    if (key === "LCSC Part") {
-        const href = lcscUrl(value);
-        return href ? <LinkValue href={href} text={value} /> : value;
-    }
     const url = normalizeUrl(value);
     if (url) return <LinkValue href={url} text={value} />;
     return value;
@@ -368,7 +361,7 @@ export function SelectionInspector({
             <ScrollArea className="min-h-0 flex-1">
                 <div className="space-y-5 p-4 text-xs">
                     {showLabelNav && (
-                        <CollapsibleSection title="Instances">
+                        <CollapsibleSection title="Instances" defaultOpen={false}>
                             <div className="flex items-center justify-between gap-2 border bg-card/40 px-3 py-2">
                                 <Button
                                     type="button"
@@ -424,7 +417,7 @@ export function SelectionInspector({
                         </CollapsibleSection>
                     )}
 
-                    <CollapsibleSection title="Identity" icon={CircuitBoard}>
+                    <CollapsibleSection title="Identity" icon={CircuitBoard} defaultOpen={false}>
                         <dl>
                             {selection.kind !== "net" && <PropertyRow label="Reference" value={selection.reference} />}
                             {selection.kind === "terminal" && <PropertyRow label="Pin / pad" value={selection.pin} />}
@@ -460,16 +453,16 @@ export function SelectionInspector({
                                 <dl>
                                     <PropertyRow label="Value" value={component.value} />
                                     <PropertyRow label="Footprint" value={component.footprint} />
-                                    {/* DNP and BOM always show, as flags, right at
-                                        the top. Default to KiCad's defaults when
-                                        the parse did not carry the field. */}
+                                    {/* DNP and BOM always show under Value and
+                                        Footprint. Missing parse → Unknown, never
+                                        a guessed KiCad default. */}
                                     <PropertyRow
                                         label="DNP"
-                                        value={<FlagValue value={String(component.fields?.DNP ?? "No")} goodWhenYes={false} />}
+                                        value={<FlagValue value={component.fields?.DNP} goodWhenYes={false} />}
                                     />
                                     <PropertyRow
                                         label="BOM"
-                                        value={<FlagValue value={String(component.fields?.["In BOM"] ?? "Yes")} goodWhenYes={true} />}
+                                        value={<FlagValue value={component.fields?.["In BOM"]} goodWhenYes={true} />}
                                     />
                                     {Object.entries(component.fields || {})
                                         .filter(([key, value]) => key !== "DNP" && key !== "In BOM" && isDisplayableField(key, String(value)))
@@ -504,7 +497,7 @@ export function SelectionInspector({
                     {(terminal || net) && (
                         <>
                             <Separator />
-                            <CollapsibleSection title="Connectivity">
+                            <CollapsibleSection title="Connectivity" defaultOpen={false}>
                                 <dl>
                                     <PropertyRow label="Net" value={terminal?.netName || net?.name} />
                                     <PropertyRow label="Net class" value={net?.netClass} />

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -53,6 +53,12 @@ interface SelectionInspectorProps {
     embedded?: boolean;
     /** Layer name -> swatch color, so the Layer row can show the layer's color. */
     layerColors?: Record<string, string>;
+    /**
+     * The view currently on screen. When set, the card presents the (cross-
+     * probed) selection as it belongs to this view, overriding the context the
+     * selection was originally made in.
+     */
+    viewContext?: "SCH" | "PCB";
 }
 
 const atIndex = <T,>(items: T[], index: number | undefined): T | undefined =>
@@ -173,19 +179,35 @@ function renderFieldValue(key: string, value: string): ReactNode {
 const capitalizeFirst = (value: string): string =>
     value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
 
-const resolvedItemType = (selection: PrismSelection): string => {
+// The context to present the selection in. When the reviewer switches views,
+// the same (cross-probed) component should read as belonging to the active
+// view, so the caller passes viewContext to override the selection's original
+// sourceContext for display.
+const effectiveContext = (
+    selection: PrismSelection,
+    viewContext?: "SCH" | "PCB",
+): "SCH" | "PCB" | undefined => viewContext ?? selection.sourceContext;
+
+const resolvedItemType = (
+    selection: PrismSelection,
+    viewContext?: "SCH" | "PCB",
+): string => {
+    const context = effectiveContext(selection, viewContext);
+    // The anchor's own itemType is view-specific, so ignore it when presenting
+    // the selection in a different view than the one it was made in.
+    const anchorMatchesView = !viewContext || viewContext === selection.sourceContext;
     const raw = selection.anchor?.itemType?.trim();
-    if (raw && raw.toLocaleLowerCase() !== "unknown") return raw;
+    if (anchorMatchesView && raw && raw.toLocaleLowerCase() !== "unknown") return raw;
     if (selection.kind === "component") {
-        if (selection.sourceContext === "SCH") return "Schematic symbol";
-        if (selection.sourceContext === "PCB") return "PCB footprint";
+        if (context === "SCH") return "Schematic symbol";
+        if (context === "PCB") return "PCB footprint";
         return "Component";
     }
     if (selection.kind === "terminal") {
-        return selection.sourceContext === "SCH" ? "Schematic pin" : "PCB pad";
+        return context === "SCH" ? "Schematic pin" : "PCB pad";
     }
-    if (selection.sourceContext === "SCH") return "Schematic net item";
-    if (selection.sourceContext === "PCB") return "PCB copper net";
+    if (context === "SCH") return "Schematic net item";
+    if (context === "PCB") return "PCB copper net";
     return "Net geometry";
 };
 
@@ -285,6 +307,7 @@ export function SelectionInspector({
     navigatingLabelInstance = false,
     embedded = false,
     layerColors,
+    viewContext,
 }: SelectionInspectorProps) {
     if (!open || !selection) return null;
     const component = resolveComponent(selection, semanticIndex);
@@ -334,7 +357,7 @@ export function SelectionInspector({
                             icon's bottom, without reflowing the icon or title. */}
                         <div className="mt-2 flex flex-wrap items-center gap-1.5 -translate-y-1.5">
                             <Badge variant="outline" className="px-2 py-0 text-[11px] font-medium">
-                                {capitalizeFirst(resolvedItemType(selection))}
+                                {capitalizeFirst(resolvedItemType(selection, viewContext))}
                             </Badge>
                         </div>
                     </div>
@@ -405,7 +428,7 @@ export function SelectionInspector({
                             {selection.kind !== "net" && <PropertyRow label="Reference" value={selection.reference} />}
                             {selection.kind === "terminal" && <PropertyRow label="Pin / pad" value={selection.pin} />}
                             {selection.kind === "net" && <PropertyRow label="Net" value={selection.netName} />}
-                            <PropertyRow label="Item type" value={resolvedItemType(selection)} />
+                            <PropertyRow label="Item type" value={resolvedItemType(selection, viewContext)} />
                             <PropertyRow label="Component UID" value={selection.kind !== "net" ? selection.componentUid : undefined} />
                             <PropertyRow label="Terminal UID" value={selection.kind === "terminal" ? selection.terminalUid : undefined} />
                             <PropertyRow label="Net UID" value={selection.kind !== "component" ? selection.netUid : undefined} />

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -279,6 +279,9 @@ function EcadViewerHost({
 export function Visualizer({ projectId, user, commit, active: viewerActive = true }: VisualizerProps) {
     const [schematicViewerElement, setSchematicViewerElement] = useState<ECadViewerElement | null>(null);
     const [pcbViewerElement, setPcbViewerElement] = useState<ECadViewerElement | null>(null);
+    // Layer name -> swatch color, read from the PCB viewer so the inspector can
+    // show a layer's color the same way the layer menu does.
+    const [layerColors, setLayerColors] = useState<Record<string, string>>({});
     const schematicViewerRef = useRef<ECadViewerElement | null>(null);
     const pcbViewerRef = useRef<ECadViewerElement | null>(null);
 
@@ -812,6 +815,28 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
             setRightRailTab((tab) => (tab === "selection" ? null : tab));
         }
     }, [globalSelection]);
+
+    // Refresh the layer color map when a selection carries a layer, so the
+    // inspector can show a swatch matching the layer menu. Read lazily from the
+    // PCB viewer; layer colors are stable for a board.
+    useEffect(() => {
+        if (!globalSelection?.anchor?.layer || !pcbViewerElement) return;
+        void customElements.whenDefined("ecad-viewer").then(() => {
+            const layers = pcbViewerElement.getPcbViewState?.()?.layers;
+            if (!layers?.length) return;
+            setLayerColors((previous) => {
+                const next: Record<string, string> = { ...previous };
+                let changed = false;
+                for (const layer of layers) {
+                    if (next[layer.name] !== layer.color) {
+                        next[layer.name] = layer.color;
+                        changed = true;
+                    }
+                }
+                return changed ? next : previous;
+            });
+        });
+    }, [globalSelection, pcbViewerElement]);
 
     useEffect(() => {
         const selection = globalSelection;
@@ -1398,6 +1423,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                                 open
                                 selection={globalSelection}
                                 semanticIndex={semanticIndex}
+                                layerColors={layerColors}
                                 onOpenChange={(open) => {
                                     if (!open) setRightRailTab(null);
                                 }}

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -361,6 +361,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
 
     const {
         selection: globalSelection,
+        isProbing: selectionIsProbing,
         select: selectGlobal,
         crossProbe: crossProbeGlobal,
         clear: clearGlobalSelection,
@@ -805,16 +806,33 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
         };
     }, [commit, pcbViewerElement, projectId, registerClient, schematicViewerElement, semanticIndex]);
 
+    // The active CAD view, or null on non-CAD tabs (3D, stackup, ...).
+    const activeViewContext: "SCH" | "PCB" | null =
+        activeTab === "pcb" ? "PCB" : activeTab === "sch" ? "SCH" : null;
+
+    // Whether the selection card belongs on the active view. A cross-probe
+    // (double-click focus) mirrors the item into both viewers, so its card
+    // follows whichever view is on screen. A plain single-view selection stays
+    // with its own view: switching away does not carry the card over.
+    const selectionVisibleInActiveView = Boolean(
+        globalSelection
+        && (
+            selectionIsProbing
+            || activeViewContext === null
+            || globalSelection.sourceContext === activeViewContext
+        ),
+    );
+
     useEffect(() => {
-        if (globalSelection) {
+        if (globalSelection && selectionVisibleInActiveView) {
             setRightRailTab("selection");
         } else {
-            // Selection cleared (deselect / click-away): close the selection panel
-            // so the side menu does not linger with nothing selected. Leave other
-            // rail tabs (comments) alone.
+            // No selection for this view (cleared, or a single-view selection
+            // that belongs to the other view): close the selection panel so it
+            // does not linger. Leave other rail tabs (comments) alone.
             setRightRailTab((tab) => (tab === "selection" ? null : tab));
         }
-    }, [globalSelection]);
+    }, [globalSelection, selectionVisibleInActiveView]);
 
     // Refresh the layer color map when a selection carries a layer, so the
     // inspector can show a swatch matching the layer menu. Read lazily from the
@@ -1418,13 +1436,13 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                                 highlightedId={selectedCommentId}
                                 embedded
                             />
-                        ) : globalSelection ? (
+                        ) : globalSelection && selectionVisibleInActiveView ? (
                             <SelectionInspector
                                 open
                                 selection={globalSelection}
                                 semanticIndex={semanticIndex}
                                 layerColors={layerColors}
-                                viewContext={activeTab === "pcb" ? "PCB" : activeTab === "sch" ? "SCH" : undefined}
+                                viewContext={selectionIsProbing ? (activeViewContext ?? undefined) : undefined}
                                 onOpenChange={(open) => {
                                     if (!open) setRightRailTab(null);
                                 }}

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -810,16 +810,15 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
     const activeViewContext: "SCH" | "PCB" | null =
         activeTab === "pcb" ? "PCB" : activeTab === "sch" ? "SCH" : null;
 
-    // Whether the selection card belongs on the active view. A cross-probe
-    // (double-click focus) mirrors the item into both viewers, so its card
-    // follows whichever view is on screen. A plain single-view selection stays
-    // with its own view: switching away does not carry the card over.
+    // Whether the selection card belongs on the active view.
+    // Single-click: stay on SCH and PCB; close on 3D/stackup/BOM.
+    // Double-click (cross-probe): stay on every tab.
     const selectionVisibleInActiveView = Boolean(
         globalSelection
         && (
             selectionIsProbing
-            || activeViewContext === null
-            || globalSelection.sourceContext === activeViewContext
+            || activeTab === "sch"
+            || activeTab === "pcb"
         ),
     );
 
@@ -1442,7 +1441,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                                 selection={globalSelection}
                                 semanticIndex={semanticIndex}
                                 layerColors={layerColors}
-                                viewContext={selectionIsProbing ? (activeViewContext ?? undefined) : undefined}
+                                viewContext={activeViewContext ?? undefined}
                                 onOpenChange={(open) => {
                                     if (!open) setRightRailTab(null);
                                 }}

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -1424,6 +1424,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                                 selection={globalSelection}
                                 semanticIndex={semanticIndex}
                                 layerColors={layerColors}
+                                viewContext={activeTab === "pcb" ? "PCB" : activeTab === "sch" ? "SCH" : undefined}
                                 onOpenChange={(open) => {
                                     if (!open) setRightRailTab(null);
                                 }}

--- a/frontend/src/hooks/use-prism-cross-probe.ts
+++ b/frontend/src/hooks/use-prism-cross-probe.ts
@@ -8,6 +8,11 @@ import type {
 
 interface PrismCrossProbeBus {
     selection: PrismSelection | null;
+    /**
+     * True when the current selection is a cross-probe (double-click focus that
+     * mirrors into the other viewer), false for a plain single-view selection.
+     */
+    isProbing: boolean;
     /** Panel-only: updates inspector state without mirroring into other viewers. */
     select: (selection: PrismSelection) => void;
     /** Full cross-probe: updates inspector and applies to other ready viewers. */
@@ -21,6 +26,7 @@ export function usePrismCrossProbe(
     semanticIndex: PrismSemanticIndex | null,
 ): PrismCrossProbeBus {
     const [selection, setSelection] = useState<PrismSelection | null>(null);
+    const [isProbing, setIsProbing] = useState(false);
     const selectionRef = useRef<PrismSelection | null>(null);
     const probingRef = useRef(false);
     const clientsRef = useRef(new Map<string, PrismViewerClient>());
@@ -54,6 +60,7 @@ export function usePrismCrossProbe(
     const select = useCallback((next: PrismSelection) => {
         const enriched = enrichPrismSelection(next, semanticIndex);
         probingRef.current = false;
+        setIsProbing(false);
         selectionRef.current = enriched;
         setSelection(enriched);
     }, [semanticIndex]);
@@ -61,6 +68,7 @@ export function usePrismCrossProbe(
     const crossProbe = useCallback((next: PrismSelection) => {
         const enriched = enrichPrismSelection(next, semanticIndex);
         probingRef.current = true;
+        setIsProbing(true);
         selectionRef.current = enriched;
         setSelection(enriched);
         dispatch(enriched);
@@ -68,6 +76,7 @@ export function usePrismCrossProbe(
 
     const clear = useCallback(() => {
         probingRef.current = false;
+        setIsProbing(false);
         selectionRef.current = null;
         setSelection(null);
         dispatch(null);
@@ -104,5 +113,5 @@ export function usePrismCrossProbe(
         if (probingRef.current) dispatch(enriched);
     }, [dispatch, semanticIndex]);
 
-    return { selection, select, crossProbe, clear, registerClient, notifyClientReady };
+    return { selection, isProbing, select, crossProbe, clear, registerClient, notifyClientReady };
 }


### PR DESCRIPTION
## Summary

Selection inspector cleanup from #142 (@Keybored02), with the behavior we agreed:

- Drop the grey descriptor, SCH/PCB badge, and Library & sourcing provenance blurb
- Type label follows the active view (`Schematic symbol` / `PCB footprint`)
- Single-click: card stays on SCH and PCB; closes on 3D/stackup/BOM
- Double-click cross-probe: card stays on every tab
- DNP and In BOM always sit under Value and Footprint; missing parse shows muted **Unknown**
- URL field values are links; no LCSC product-page special case
- Hide `ki_*` / `kicad_*` bookkeeping; keep Sheetfile and Sheetname
- Layer color swatch from the PCB viewer
- Collapsible defaults: Identity collapsed; Component data and Library & sourcing expanded; Connectivity and Instances collapsed

Catalog presence / harvest from the inspector is **not** in this PR.

Overlaps `selection-inspector.tsx` with #152 and `visualizer.tsx` with #153.

## Test plan

- [ ] Header is title + type badge only
- [ ] DNP/BOM Unknown when the parse omitted them; ticks/crosses when present
- [ ] Datasheet URL is a link; LCSC part number is plain text
- [ ] Sheetfile/Sheetname visible; ki_* hidden
- [ ] Single-click: switch SCH↔PCB keeps the card; 3D closes it
- [ ] Double-click: card remains on 3D/BOM as well
- [ ] Quality gate on this PR

