### PR TITLE
Make the viewer side menu resizable (default 256px)

### DIFF
--- a/frontend/src/components/ecad-viewer-controls.tsx
+++ b/frontend/src/components/ecad-viewer-controls.tsx
@@ -139,7 +139,7 @@ export function EcadViewerControls({
         <aside
             ref={railRef}
             className={cn(
-                "absolute inset-y-0 left-0 z-30 flex w-80 flex-col border-r bg-background/95 shadow-lg backdrop-blur-sm transition-transform duration-200",
+                "absolute inset-y-0 left-0 z-30 flex w-64 flex-col border-r bg-background/95 shadow-lg backdrop-blur-sm transition-transform duration-200",
                 open ? "translate-x-0" : "-translate-x-[calc(100%_-_2.75rem)]",
             )}
             aria-label={context === "SCH" ? "Schematic pages" : "PCB display controls"}

--- a/frontend/src/components/ecad-viewer-controls.tsx
+++ b/frontend/src/components/ecad-viewer-controls.tsx
@@ -5,6 +5,7 @@ import {
     useMemo,
     useRef,
     useState,
+    type PointerEvent as ReactPointerEvent,
     type ReactNode,
 } from "react";
 import {
@@ -46,6 +47,10 @@ type EcadViewerControlsProps = {
     onVisibleWidthChange?: (width: number) => void;
 };
 
+const DEFAULT_RAIL_WIDTH = 256;
+const MIN_RAIL_WIDTH = 200;
+const MAX_RAIL_WIDTH = 420;
+
 const pcbPresets = [
     ["front", "Front"],
     ["back", "Back"],
@@ -63,6 +68,8 @@ export function EcadViewerControls({
     onVisibleWidthChange,
 }: EcadViewerControlsProps) {
     const [open, setOpen] = useState(true);
+    const [railWidth, setRailWidth] = useState(DEFAULT_RAIL_WIDTH);
+    const [resizing, setResizing] = useState(false);
     const railRef = useRef<HTMLElement | null>(null);
     const handleRef = useRef<HTMLDivElement | null>(null);
     const openRef = useRef(open);
@@ -133,17 +140,54 @@ export function EcadViewerControls({
         if (!onVisibleWidthChange) return;
         const target = open ? railRef.current : handleRef.current;
         onVisibleWidthChange(target?.getBoundingClientRect().width ?? 0);
-    }, [onVisibleWidthChange, open]);
+    }, [onVisibleWidthChange, open, railWidth]);
+
+    const onResizePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (!open) return;
+        event.preventDefault();
+        const pointerId = event.pointerId;
+        const startX = event.clientX;
+        const startWidth = railWidth;
+        const target = event.currentTarget;
+        setResizing(true);
+        target.setPointerCapture(pointerId);
+        const onMove = (move: PointerEvent) => {
+            const next = Math.min(
+                MAX_RAIL_WIDTH,
+                Math.max(MIN_RAIL_WIDTH, startWidth + (move.clientX - startX)),
+            );
+            setRailWidth(next);
+        };
+        const onUp = () => {
+            setResizing(false);
+            target.releasePointerCapture(pointerId);
+            target.removeEventListener("pointermove", onMove);
+            target.removeEventListener("pointerup", onUp);
+        };
+        target.addEventListener("pointermove", onMove);
+        target.addEventListener("pointerup", onUp);
+    };
 
     return (
         <aside
             ref={railRef}
             className={cn(
-                "absolute inset-y-0 left-0 z-30 flex w-64 flex-col border-r bg-background/95 shadow-lg backdrop-blur-sm transition-transform duration-200",
+                "absolute inset-y-0 left-0 z-30 flex flex-col border-r bg-background/95 shadow-lg backdrop-blur-sm",
+                !resizing && "transition-transform duration-200",
                 open ? "translate-x-0" : "-translate-x-[calc(100%_-_2.75rem)]",
             )}
+            style={{ width: railWidth }}
             aria-label={context === "SCH" ? "Schematic pages" : "PCB display controls"}
         >
+            {open && (
+                <div
+                    className="absolute inset-y-0 right-0 z-10 w-1.5 cursor-col-resize touch-none hover:bg-primary/20"
+                    onPointerDown={onResizePointerDown}
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-label="Resize side menu"
+                />
+            )}
             <div className="flex h-10 shrink-0 items-center border-b">
                 {/* Always reserve the leading flex area so the collapse handle stays on the
                     right edge of the panel. The closed transform keeps that right strip

--- a/frontend/src/components/ecad-viewer-controls.tsx
+++ b/frontend/src/components/ecad-viewer-controls.tsx
@@ -179,15 +179,6 @@ export function EcadViewerControls({
             style={{ width: railWidth }}
             aria-label={context === "SCH" ? "Schematic pages" : "PCB display controls"}
         >
-            {open && (
-                <div
-                    className="absolute inset-y-0 right-0 z-10 w-1.5 cursor-col-resize touch-none hover:bg-primary/20"
-                    onPointerDown={onResizePointerDown}
-                    role="separator"
-                    aria-orientation="vertical"
-                    aria-label="Resize side menu"
-                />
-            )}
             <div className="flex h-10 shrink-0 items-center border-b">
                 {/* Always reserve the leading flex area so the collapse handle stays on the
                     right edge of the panel. The closed transform keeps that right strip
@@ -313,6 +304,15 @@ export function EcadViewerControls({
                         </ScrollArea>
                     )}
                 </>
+            )}
+            {open && (
+                <div
+                    className="absolute inset-y-0 right-0 z-10 w-1.5 cursor-col-resize touch-none hover:bg-primary/20"
+                    onPointerDown={onResizePointerDown}
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-label="Resize side menu"
+                />
             )}
         </aside>
     );


### PR DESCRIPTION
## Summary

Viewer Schematic pages / Board display rail defaults to **256px** (Matteo in #142) and is **resizable** (200–420px) by dragging the right edge. The board/schematic inset already follows `onVisibleWidthChange`.

Cherry-picked from #142 (@Keybored02), plus the resize handle.

Overlaps `ecad-viewer-controls.tsx` with #152.

## Test plan

- [ ] Rail opens at 256px; longest PCB label still fits
- [ ] Drag the right edge; canvas inset follows
- [ ] Collapse still shows the chevron strip
- [ ] Quality gate on this PR

