### PR TITLE
[Feature] Add Settings tab for Viewer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
 import { ApiHttpError, fetchApi } from '@/lib/api';
 import { fetchAuthConfig, fetchCurrentUser, isAuthCallbackPath } from '@/lib/auth';
+import { setActiveViewerUser } from '@/lib/viewer-settings';
 import { IS_APPLE_PLATFORM } from '@/lib/shortcuts';
 import { useHotkeys } from '@/hooks/use-hotkeys';
 import { CommandPalette } from '@/components/command-palette';
@@ -53,6 +54,12 @@ function App() {
     const isAuthCallbackRoute = typeof window !== "undefined" && isAuthCallbackPath();
     const [paletteOpen, setPaletteOpen] = useState(false);
     const [shortcutsOpen, setShortcutsOpen] = useState(false);
+
+    // Publish the signed-in user so deep viewer components can read their
+    // per-user settings without prop-drilling the user object.
+    useEffect(() => {
+        setActiveViewerUser(user?.email);
+    }, [user]);
 
     /**
      * Screens mark their own search box with `data-shortcut-search`. "/" focuses

--- a/frontend/src/components/design-comparison/comparison-review-noise.test.ts
+++ b/frontend/src/components/design-comparison/comparison-review-noise.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { prepareChangesForReview } from "./comparison-review-noise";
+import type { ChangeItem } from "./types";
+
+function change(overrides: Partial<ChangeItem>): ChangeItem {
+    return {
+        id: "c1",
+        kind: "changed",
+        domain: "schematic",
+        category: "nets",
+        classification: "primary",
+        ...overrides,
+    } as ChangeItem;
+}
+
+// A rename between two auto-generated net names is pure noise: dropped by
+// default, so it never reaches the listing.
+const generatedRename = change({
+    id: "gen-rename",
+    reasons: ["net-renamed"],
+    object_kind: "label",
+    fields: { name: { old: "unconnected-(A-Pad1)", new: "Net-(B-Pad2)" } },
+});
+
+const realEdit = change({
+    id: "real",
+    reasons: ["properties-changed"],
+    object_kind: "symbol",
+    fields: { Value: { old: "10k", new: "22k" } },
+});
+
+describe("prepareChangesForReview show-all setting", () => {
+    it("drops follow-on noise by default", () => {
+        const result = prepareChangesForReview([realEdit, generatedRename]);
+        expect(result.suppressedCount).toBe(1);
+        expect(result.changes.map((item) => item.id)).toEqual(["real"]);
+    });
+
+    it("keeps suppressed changes as secondary when show-all is on", () => {
+        const result = prepareChangesForReview([realEdit, generatedRename], {
+            keepSuppressed: true,
+        });
+        // Still counted as suppressed, but retained rather than removed so it
+        // runs through the same grouping and geometry steps as any change.
+        expect(result.suppressedCount).toBe(1);
+        const kept = result.changes.find((item) => item.id === "gen-rename");
+        expect(kept).toBeDefined();
+        expect(kept?.classification).toBe("secondary");
+        // The genuine edit is untouched and stays primary.
+        const real = result.changes.find((item) => item.id === "real");
+        expect(real?.classification).toBe("primary");
+    });
+
+    it("does not change the primary set", () => {
+        const off = prepareChangesForReview([realEdit, generatedRename]);
+        const on = prepareChangesForReview([realEdit, generatedRename], {
+            keepSuppressed: true,
+        });
+        const primaries = (result: { changes: ChangeItem[] }) =>
+            result.changes.filter((item) => item.classification !== "secondary").map((item) => item.id);
+        expect(primaries(on)).toEqual(primaries(off));
+    });
+});

--- a/frontend/src/components/design-comparison/comparison-review-noise.ts
+++ b/frontend/src/components/design-comparison/comparison-review-noise.ts
@@ -135,12 +135,19 @@ function isGeneratedNetRenameOnly(change: ChangeItem): boolean {
  * Convert parser-level events into reviewer-level evidence. Pins that merely
  * follow a symbol are derivative, while same-page geometry is retained as an
  * optional secondary audit trail instead of flooding the primary review list.
+ *
+ * With `keepSuppressed`, nothing is dropped: an event that would normally be
+ * removed as a follow-on write is kept and marked `secondary` instead, so it
+ * flows through the same grouping, geometry, and visual-target steps as a
+ * primary change and shows in the listing behind the layout section. This backs
+ * the per-user "show all changes" setting.
  */
 export function prepareChangesForReview(
     changes: ChangeItem[],
-    options: { netRenames?: Set<string> } = {},
+    options: { netRenames?: Set<string>; keepSuppressed?: boolean } = {},
 ): PreparedReviewChanges {
     const netRenames = options.netRenames ?? new Set<string>();
+    const keepSuppressed = options.keepSuppressed ?? false;
     const parentSymbolEvents = new Set(
         changes
             .filter((change) => change.domain === "schematic" && objectKind(change) === "symbol")
@@ -148,6 +155,15 @@ export function prepareChangesForReview(
     );
     const prepared: ChangeItem[] = [];
     let suppressedCount = 0;
+    // Either drop the change (default) or keep it as secondary evidence
+    // (show-all). Always returns true so a caller can `if (…) { suppress(); continue; }`.
+    const suppress = (change: ChangeItem): true => {
+        suppressedCount += 1;
+        if (keepSuppressed) {
+            prepared.push({ ...change, classification: "secondary" });
+        }
+        return true;
+    };
     const netRenameKeys = semanticNetRenameKeys(changes);
     const parentFootprintEvents = new Set(
         changes
@@ -166,19 +182,19 @@ export function prepareChangesForReview(
             || isDuplicateNativeLabelRename(change, netRenameKeys)
             || isGeneratedNetRenameOnly(change)
         ) {
-            suppressedCount += 1;
+            suppress(change);
             continue;
         }
         if (change.domain === "schematic" && kind === "pin") {
             if (isSamePageLayoutOnly(change)) {
-                suppressedCount += 1;
+                suppress(change);
                 continue;
             }
             if (
                 (change.kind === "added" || change.kind === "removed")
                 && parentSymbolEvents.has(parentSymbolKey(change))
             ) {
-                suppressedCount += 1;
+                suppress(change);
                 continue;
             }
             if (
@@ -188,7 +204,7 @@ export function prepareChangesForReview(
                     ([name]) => name.trim().toLocaleLowerCase() === "reference",
                 )
             ) {
-                suppressedCount += 1;
+                suppress(change);
                 continue;
             }
         }
@@ -200,7 +216,7 @@ export function prepareChangesForReview(
             && (change.kind === "added" || change.kind === "removed")
             && parentFootprintEvents.has(parentSymbolKey(change))
         ) {
-            suppressedCount += 1;
+            suppress(change);
             continue;
         }
 

--- a/frontend/src/components/design-comparison/comparison-viewer-host.tsx
+++ b/frontend/src/components/design-comparison/comparison-viewer-host.tsx
@@ -9,6 +9,7 @@ import type {
     ECadViewerElement,
     EcadViewportInsets,
 } from "@/types/ecad-viewer";
+import { useViewerSettings } from "@/lib/viewer-settings";
 
 type ComparisonViewerHostProps = {
     viewerKey: string;
@@ -27,6 +28,12 @@ export function ComparisonViewerHost({
 }: ComparisonViewerHostProps) {
     const [viewer, setViewer] = useState<ECadViewerElement | null>(null);
     const latestViewerRef = useRef<ECadViewerElement | null>(null);
+    // Per-user greyscale preference. Read here (rather than prop-drilled) via the
+    // active-user fallback, so the deep viewer stays decoupled from auth. The
+    // vendored viewer reads the `grayscale` attribute; the companion ecad-viewer
+    // branch acts on it. Off by default, so full colour is the current behaviour.
+    const { settings } = useViewerSettings(undefined);
+    const greyscale = settings.greyscale;
     const viewportLeft = viewportInsets.left ?? 0;
     const viewportRight = viewportInsets.right ?? 0;
     const viewportTop = viewportInsets.top ?? 0;
@@ -101,6 +108,17 @@ export function ComparisonViewerHost({
             cancelled = true;
         };
     }, [active, viewer]);
+
+    useEffect(() => {
+        if (!viewer) return;
+        // Reflect the preference as an attribute so a viewer that mounts later,
+        // or a preference toggled while mounted, both land on the same state.
+        if (greyscale) {
+            viewer.setAttribute("grayscale", "true");
+        } else {
+            viewer.removeAttribute("grayscale");
+        }
+    }, [greyscale, viewer]);
 
     useLayoutEffect(() => {
         if (!viewer) return;

--- a/frontend/src/components/design-comparison/design-comparison-workspace.tsx
+++ b/frontend/src/components/design-comparison/design-comparison-workspace.tsx
@@ -24,6 +24,7 @@ import {
 import { ResizablePanel } from "@/components/ui/resizable-panel";
 import { downloadCsv } from "@/lib/csv";
 import { cn } from "@/lib/utils";
+import { useViewerSettings } from "@/lib/viewer-settings";
 import { DifferencesPane } from "./differences-pane";
 import { useDesignCompareJob } from "./use-design-compare-job";
 import { useComparisonComments } from "./use-comparison-comments";
@@ -202,9 +203,13 @@ export function DesignComparisonWorkspace({
     };
 
     const domain = activeTab === "pcb" ? "pcb" : "schematic";
+    // Per-user "show all changes": keep the follow-on writes that are normally
+    // dropped as noise, so they run through the same review steps as any change.
+    const { settings: viewerSettings } = useViewerSettings(undefined);
+    const keepSuppressed = viewerSettings.showAllChanges;
     const schematicReview = useMemo(
-        () => prepareChangesForReview(result?.schematic.changes ?? []),
-        [result?.schematic.changes],
+        () => prepareChangesForReview(result?.schematic.changes ?? [], { keepSuppressed }),
+        [keepSuppressed, result?.schematic.changes],
     );
     // Read from the raw schematic changes, not the prepared ones: the board's
     // rewritten net references are derivative even where the schematic pass
@@ -214,8 +219,8 @@ export function DesignComparisonWorkspace({
         [result?.schematic.changes],
     );
     const pcbReview = useMemo(
-        () => prepareChangesForReview(result?.pcb.changes ?? [], { netRenames }),
-        [netRenames, result?.pcb.changes],
+        () => prepareChangesForReview(result?.pcb.changes ?? [], { netRenames, keepSuppressed }),
+        [keepSuppressed, netRenames, result?.pcb.changes],
     );
     const domainReview = activeTab === "sch"
         ? schematicReview

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -5,11 +5,13 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/compone
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
-import { GitBranch, Copy, FileCode, Shield, Plus, Trash2 } from "lucide-react";
+import { GitBranch, Copy, FileCode, Shield, Plus, Trash2, Eye } from "lucide-react";
 import { User, UserRole } from "@/types/auth";
 import { fetchApi, readApiError } from "@/lib/api";
 import { ROLE_OPTIONS, roleLabel } from "@/lib/roles";
+import { useViewerSettings } from "@/lib/viewer-settings";
 
 interface SettingsDialogProps {
     open: boolean;
@@ -17,7 +19,7 @@ interface SettingsDialogProps {
     user: User | null;
 }
 
-type SettingsTab = "git" | "access" | "general";
+type SettingsTab = "git" | "access" | "viewer" | "general";
 
 interface RoleAssignment {
     email: string;
@@ -61,6 +63,15 @@ export function SettingsDialog({ open, onOpenChange, user }: SettingsDialogProps
                     </Button>
 
                     <Button
+                        variant={activeTab === "viewer" ? "secondary" : "ghost"}
+                        className="justify-start"
+                        onClick={() => setActiveTab("viewer")}
+                    >
+                        <Eye className="mr-2 h-4 w-4" />
+                        Viewer
+                    </Button>
+
+                    <Button
                         variant={activeTab === "general" ? "secondary" : "ghost"}
                         className="justify-start opacity-50 cursor-not-allowed"
                         title="Coming soon"
@@ -73,6 +84,7 @@ export function SettingsDialog({ open, onOpenChange, user }: SettingsDialogProps
                 <div className="flex-1 overflow-y-auto p-6">
                     {activeTab === "git" && <GitSettings user={user} />}
                     {activeTab === "access" && <AccessControlSettings isAdmin={isAdmin} />}
+                    {activeTab === "viewer" && <ViewerSettings user={user} />}
                     {activeTab === "general" && (
                         <div className="flex items-center justify-center h-full text-muted-foreground">
                             General settings coming soon.
@@ -499,6 +511,36 @@ function GitSettings({ user }: { user: User | null }) {
                 busyLabel="Generating…"
                 onConfirm={() => void generateKey()}
             />
+        </div>
+    );
+}
+
+function ViewerSettings({ user }: { user: User | null }) {
+    const { settings, update } = useViewerSettings(user?.email);
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-medium">Viewer</h3>
+                <p className="text-sm text-muted-foreground">
+                    How boards and schematics render for you. These preferences are saved to this
+                    browser.
+                </p>
+            </div>
+
+            <label className="flex items-start gap-3 border rounded-lg p-4 bg-card cursor-pointer">
+                <Checkbox
+                    className="mt-0.5"
+                    checked={settings.greyscale}
+                    onCheckedChange={(checked) => update({ greyscale: checked === true })}
+                />
+                <div className="space-y-0.5">
+                    <Label className="text-base cursor-pointer">Make all views greyscale</Label>
+                    <p className="text-sm text-muted-foreground">
+                        Render every viewer without colour. Off by default.
+                    </p>
+                </div>
+            </label>
         </div>
     );
 }

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -523,8 +523,8 @@ function ViewerSettings({ user }: { user: User | null }) {
             <div>
                 <h3 className="text-lg font-medium">Viewer</h3>
                 <p className="text-sm text-muted-foreground">
-                    How boards and schematics render for you. These preferences are saved to this
-                    browser.
+                    How boards, schematics, and comparisons show up for you. These preferences are
+                    saved to this browser.
                 </p>
             </div>
 
@@ -538,6 +538,21 @@ function ViewerSettings({ user }: { user: User | null }) {
                     <Label className="text-base cursor-pointer">Make all views greyscale</Label>
                     <p className="text-sm text-muted-foreground">
                         Render every viewer without colour. Off by default.
+                    </p>
+                </div>
+            </label>
+
+            <label className="flex items-start gap-3 border rounded-lg p-4 bg-card cursor-pointer">
+                <Checkbox
+                    className="mt-0.5"
+                    checked={settings.showAllChanges}
+                    onCheckedChange={(checked) => update({ showAllChanges: checked === true })}
+                />
+                <div className="space-y-0.5">
+                    <Label className="text-base cursor-pointer">Show all changes in comparisons</Label>
+                    <p className="text-sm text-muted-foreground">
+                        Include follow-on writes normally hidden as noise. They appear under
+                        the comparison's layout and documentation section. Off by default.
                     </p>
                 </div>
             </label>

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -551,8 +551,8 @@ function ViewerSettings({ user }: { user: User | null }) {
                 <div className="space-y-0.5">
                     <Label className="text-base cursor-pointer">Show all changes in comparisons</Label>
                     <p className="text-sm text-muted-foreground">
-                        Include follow-on writes normally hidden as noise. They appear under
-                        the comparison's layout and documentation section. Off by default.
+                        Show changes previously hidden, such as a pins, a
+                        renamed auto-generated net, or labels.
                     </p>
                 </div>
             </label>

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -15,6 +15,7 @@ import { fetchApi, readApiError } from "@/lib/api";
 import { throwIfJobFailed, watchPrismJob } from "@/lib/jobs";
 import { canWriteCatalog } from "@/lib/roles";
 import { crossProbeRequestForSelection, normalizeEcadSelection } from "@/lib/prism-selection";
+import { useViewerSettings } from "@/lib/viewer-settings";
 import { usePrismCrossProbe } from "@/hooks/use-prism-cross-probe";
 import type { User } from "@/types/auth";
 import type {
@@ -173,6 +174,10 @@ function EcadViewerHost({
 }: EcadViewerHostProps) {
     const hostRef = useRef<ECadViewerElement | null>(null);
     const replaceReadyRef = useRef<Promise<void>>(Promise.resolve());
+    // Per-user greyscale preference, mirrored onto the `grayscale` attribute so
+    // this view honours the same global setting as the comparison viewer.
+    const { settings } = useViewerSettings(undefined);
+    const greyscale = settings.greyscale;
     const rootSource = sources[0];
     const appendedSources = useMemo(() => sources.slice(1), [sources]);
     const viewportLeft = viewportInsets.left ?? 0;
@@ -264,6 +269,16 @@ function EcadViewerHost({
         });
         return () => { cancelled = true; };
     }, [viewportBottom, viewportLeft, viewportRight, viewportTop]);
+
+    useEffect(() => {
+        const viewer = hostRef.current;
+        if (!viewer) return;
+        if (greyscale) {
+            viewer.setAttribute("grayscale", "true");
+        } else {
+            viewer.removeAttribute("grayscale");
+        }
+    }, [greyscale]);
 
     return (
         <ecad-viewer

--- a/frontend/src/lib/viewer-settings.test.ts
+++ b/frontend/src/lib/viewer-settings.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { setActiveViewerUser, useViewerSettings } from "./viewer-settings";
+
+beforeEach(() => {
+    window.localStorage.clear();
+    setActiveViewerUser(null);
+});
+
+describe("viewer settings", () => {
+    it("defaults greyscale to off", () => {
+        const { result } = renderHook(() => useViewerSettings("a@example.com"));
+        expect(result.current.settings.greyscale).toBe(false);
+    });
+
+    it("persists a change and reloads it", () => {
+        const first = renderHook(() => useViewerSettings("a@example.com"));
+        act(() => first.result.current.update({ greyscale: true }));
+        expect(first.result.current.settings.greyscale).toBe(true);
+
+        const second = renderHook(() => useViewerSettings("a@example.com"));
+        expect(second.result.current.settings.greyscale).toBe(true);
+    });
+
+    it("keeps preferences separate per user", () => {
+        const a = renderHook(() => useViewerSettings("a@example.com"));
+        act(() => a.result.current.update({ greyscale: true }));
+
+        const b = renderHook(() => useViewerSettings("b@example.com"));
+        expect(b.result.current.settings.greyscale).toBe(false);
+    });
+
+    it("is case-insensitive on the email key", () => {
+        const upper = renderHook(() => useViewerSettings("A@Example.com"));
+        act(() => upper.result.current.update({ greyscale: true }));
+
+        const lower = renderHook(() => useViewerSettings("a@example.com"));
+        expect(lower.result.current.settings.greyscale).toBe(true);
+    });
+
+    it("falls back to the active user when no email is passed", () => {
+        setActiveViewerUser("a@example.com");
+        const explicit = renderHook(() => useViewerSettings("a@example.com"));
+        act(() => explicit.result.current.update({ greyscale: true }));
+
+        const fallback = renderHook(() => useViewerSettings(undefined));
+        expect(fallback.result.current.settings.greyscale).toBe(true);
+    });
+
+    it("broadcasts a change to another mounted reader", () => {
+        const writer = renderHook(() => useViewerSettings("a@example.com"));
+        const reader = renderHook(() => useViewerSettings("a@example.com"));
+        act(() => writer.result.current.update({ greyscale: true }));
+        expect(reader.result.current.settings.greyscale).toBe(true);
+    });
+});

--- a/frontend/src/lib/viewer-settings.ts
+++ b/frontend/src/lib/viewer-settings.ts
@@ -11,10 +11,17 @@ import { useCallback, useEffect, useState } from "react";
 export interface ViewerSettings {
     /** Render every viewer in greyscale instead of full colour. */
     greyscale: boolean;
+    /**
+     * Show every change in the comparison listing, including follow-on writes
+     * normally dropped as noise. They run through the same review steps as any
+     * other change and appear behind the layout section.
+     */
+    showAllChanges: boolean;
 }
 
 const DEFAULTS: ViewerSettings = {
     greyscale: false,
+    showAllChanges: false,
 };
 
 const STORAGE_PREFIX = "prism.viewer-settings";

--- a/frontend/src/lib/viewer-settings.ts
+++ b/frontend/src/lib/viewer-settings.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Per-user viewer preferences, stored in the browser.
+ *
+ * These are display choices, not workspace data: the server does nothing with
+ * them, so they live in localStorage keyed by the signed-in user rather than in
+ * the database. Keying by email keeps two people sharing a browser from
+ * inheriting each other's viewer preferences.
+ */
+export interface ViewerSettings {
+    /** Render every viewer in greyscale instead of full colour. */
+    greyscale: boolean;
+}
+
+const DEFAULTS: ViewerSettings = {
+    greyscale: false,
+};
+
+const STORAGE_PREFIX = "prism.viewer-settings";
+// Fired on the same tab after a write, so every mounted reader updates without
+// waiting for another component to poll. The native `storage` event only fires
+// in *other* tabs, which is why this exists alongside it.
+const CHANGE_EVENT = "prism:viewer-settings-change";
+
+// The signed-in user's email, published once by the app shell. Deep viewer
+// components read their per-user settings without threading the user object
+// through every intermediate prop; `useViewerSettings(email)` with an explicit
+// email (e.g. the settings dialog) still takes precedence.
+let activeUserEmail: string | null = null;
+
+export function setActiveViewerUser(userEmail: string | null | undefined): void {
+    activeUserEmail = userEmail?.toLowerCase() || null;
+    if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event(CHANGE_EVENT));
+    }
+}
+
+function resolveEmail(userEmail: string | null | undefined): string {
+    return (userEmail ?? activeUserEmail)?.toLowerCase() || "anon";
+}
+
+function storageKey(userEmail: string | null | undefined): string {
+    return `${STORAGE_PREFIX}.${resolveEmail(userEmail)}`;
+}
+
+function readSettings(userEmail: string | null | undefined): ViewerSettings {
+    if (typeof window === "undefined") return DEFAULTS;
+    try {
+        const raw = window.localStorage.getItem(storageKey(userEmail));
+        if (!raw) return DEFAULTS;
+        const parsed = JSON.parse(raw) as Partial<ViewerSettings>;
+        return { ...DEFAULTS, ...parsed };
+    } catch {
+        return DEFAULTS;
+    }
+}
+
+/**
+ * Read and update the current user's viewer settings. Every hook instance stays
+ * in sync: a write from one broadcasts to the others (this tab and any other).
+ */
+export function useViewerSettings(userEmail: string | null | undefined) {
+    const key = storageKey(userEmail);
+    const [settings, setSettings] = useState<ViewerSettings>(() => readSettings(userEmail));
+
+    useEffect(() => {
+        setSettings(readSettings(userEmail));
+        const sync = () => setSettings(readSettings(userEmail));
+        const onStorage = (event: StorageEvent) => {
+            if (event.key === null || event.key === key) sync();
+        };
+        window.addEventListener(CHANGE_EVENT, sync);
+        window.addEventListener("storage", onStorage);
+        return () => {
+            window.removeEventListener(CHANGE_EVENT, sync);
+            window.removeEventListener("storage", onStorage);
+        };
+    }, [key, userEmail]);
+
+    const update = useCallback(
+        (patch: Partial<ViewerSettings>) => {
+            const next = { ...readSettings(userEmail), ...patch };
+            try {
+                window.localStorage.setItem(key, JSON.stringify(next));
+            } catch {
+                // A full or unavailable localStorage should not break the UI;
+                // the change simply will not persist across reloads.
+            }
+            window.dispatchEvent(new Event(CHANGE_EVENT));
+            setSettings(next);
+        },
+        [key, userEmail],
+    );
+
+    return { settings, update };
+}


### PR DESCRIPTION
## Problem

This PR tackles the issue #141. Currently compare viewers default to greyscale for all, and hide certain objects types changes without options to resurface them.

## Solution

Gate Greyscale for all and Object surfacing behind a checkbox, under a new Settings tab. This PR also involves an ecad-viewer API update available in https://github.com/Keybored02/ecad-viewer/tree/feat/greyscale-gating. 

## User and operator impact

Users can now choose their preferred viewing method. Settings are stored locally, per-user.

<img width="1147" height="772" alt="image" src="https://github.com/user-attachments/assets/e4ef6f69-6825-4e40-bf10-bd26f7d290ac" />


## Validation

- [x] Relevant frontend checks
- [x] Relevant backend checks
- [ ] Relevant semantic-viewer checks
- [ ] Compose configuration validation
- [x] Manual verification, when needed

List exact commands and results:

## Documentation and release

- [x] Documentation is updated or not required.
- [x] No secrets, private design data, generated output, or local caches are included.
- [ ] Breaking changes and feature-freeze exceptions have explicit approval.
- [x] This branch contains one coherent change and targets `dev`.
