### PR TITLE
Add Visualizer design search and a compact resizable inspector

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -24,7 +24,7 @@ and dangerous Git remote-helper transports.
 
 Project views include:
 
-- schematic and PCB viewers;
+- schematic and PCB viewers, with component and net search in the Visualizer header;
 - cross-probing between compatible schematic, PCB, and BOM identities;
 - WebGPU 3D board views;
 - engineering BOM, stackup, assembly, and Interactive HTML BOM outputs when

--- a/docs/PROJECT_WORKFLOWS.md
+++ b/docs/PROJECT_WORKFLOWS.md
@@ -84,6 +84,11 @@ When semantic identities are available, selecting a schematic symbol, PCB
 footprint, or BOM row highlights the corresponding object in compatible views.
 Identity generation may finish after the first schematic or PCB render.
 
+On Schematic and PCB, `/` or `⌘F` / `Ctrl+F` searches components and nets from
+the Visualizer header. `⌘K` / `Ctrl+K` remains the global command palette.
+Selecting a net or global label opens the inspector with Instances expanded so
+you can jump between occurrences, including labels that share a sheet.
+
 Treat cross-probe as navigation assistance, not an electrical-rule or
 manufacturing approval.
 

--- a/frontend/src/components/design-search-field.test.tsx
+++ b/frontend/src/components/design-search-field.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DesignSearchField } from "./design-search-field";
+import { VISUALIZER_DESIGN_SEARCH_SLOT_ID } from "@/lib/design-search";
+import type { PrismSemanticIndex } from "@/types/prism-selection";
+
+const index: PrismSemanticIndex = {
+    schema: "prism.semantic_index_a0",
+    sourceRevisionKey: "rev",
+    components: [
+        {
+            componentUid: "cmp:R12",
+            reference: "R12",
+            value: "10k",
+            footprint: "R_0402",
+        },
+        {
+            componentUid: "cmp:R13",
+            reference: "R13",
+            value: "10k",
+            footprint: "R_0402",
+        },
+        {
+            componentUid: "cmp:R14",
+            reference: "R14",
+            value: "10k",
+            footprint: "R_0402",
+        },
+    ],
+    nets: [{ netUid: "net:GND", name: "GND", netClass: "Power" }],
+    terminals: [],
+    indexes: {},
+};
+
+function Harness({
+    onPick,
+    loading,
+}: {
+    onPick: (title: string) => void;
+    loading?: boolean;
+}) {
+    const [picked, setPicked] = useState("");
+    return (
+        <>
+            <p>{picked ? `picked ${picked}` : "idle"}</p>
+            <DesignSearchField
+                semanticIndex={index}
+                loading={loading}
+                onPick={(hit) => {
+                    setPicked(hit.title);
+                    onPick(hit.title);
+                }}
+            />
+        </>
+    );
+}
+
+describe("DesignSearchField", () => {
+    beforeEach(() => {
+        const slot = document.createElement("div");
+        slot.id = VISUALIZER_DESIGN_SEARCH_SLOT_ID;
+        document.body.append(slot);
+    });
+
+    afterEach(() => {
+        document.getElementById(VISUALIZER_DESIGN_SEARCH_SLOT_ID)?.remove();
+    });
+
+    it("opens under the field, lists components and nets, and picks on click", () => {
+        const picked: string[] = [];
+        render(<Harness onPick={(title) => picked.push(title)} />);
+
+        const field = screen.getByRole("combobox", { name: "Find component or net" });
+        fireEvent.focus(field);
+        expect(screen.getByText("Reference, value, footprint, or net name")).toBeTruthy();
+
+        fireEvent.change(field, { target: { value: "r12" } });
+        fireEvent.click(screen.getByRole("option", { name: /R12/ }));
+        expect(picked).toEqual(["R12"]);
+        expect(screen.queryByRole("listbox")).toBeNull();
+        expect((field as HTMLInputElement).value).toBe("r12");
+    });
+
+    it("clears the query on a second Escape", () => {
+        render(<Harness onPick={() => undefined} />);
+        const field = screen.getByRole("combobox", { name: "Find component or net" });
+        fireEvent.focus(field);
+        fireEvent.change(field, { target: { value: "gnd" } });
+        expect(screen.getByRole("option", { name: /GND/ })).toBeTruthy();
+
+        fireEvent.keyDown(field, { key: "Escape" });
+        expect(screen.queryByRole("listbox")).toBeNull();
+        expect((field as HTMLInputElement).value).toBe("gnd");
+
+        fireEvent.keyDown(field, { key: "Escape" });
+        expect((field as HTMLInputElement).value).toBe("");
+    });
+
+    it("moves the highlight with arrows and jumps to the ends with Home/End", () => {
+        render(<Harness onPick={() => undefined} />);
+        const field = screen.getByRole("combobox", { name: "Find component or net" });
+        fireEvent.focus(field);
+        fireEvent.change(field, { target: { value: "10k" } });
+
+        fireEvent.keyDown(field, { key: "ArrowDown" });
+        expect(screen.getByRole("option", { name: /R13/ }).getAttribute("aria-selected")).toBe("true");
+
+        fireEvent.keyDown(field, { key: "ArrowUp" });
+        expect(screen.getByRole("option", { name: /R12/ }).getAttribute("aria-selected")).toBe("true");
+
+        fireEvent.keyDown(field, { key: "End" });
+        expect(screen.getByRole("option", { name: /R14/ }).getAttribute("aria-selected")).toBe("true");
+
+        fireEvent.keyDown(field, { key: "Home" });
+        expect(screen.getByRole("option", { name: /R12/ }).getAttribute("aria-selected")).toBe("true");
+    });
+
+    it("does not pretend there are no hits while the index is loading", () => {
+        render(<Harness onPick={() => undefined} loading />);
+        const field = screen.getByRole("combobox", { name: "Find component or net" });
+        fireEvent.focus(field);
+        fireEvent.change(field, { target: { value: "R12" } });
+        expect(screen.getByText("Loading design index…")).toBeTruthy();
+        expect(screen.queryByRole("option")).toBeNull();
+    });
+});

--- a/frontend/src/components/design-search-field.tsx
+++ b/frontend/src/components/design-search-field.tsx
@@ -1,0 +1,329 @@
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import { Search } from "lucide-react";
+
+import { useHotkeys } from "@/hooks/use-hotkeys";
+import {
+    DESIGN_SEARCH_HINT,
+    searchDesignEntities,
+    VISUALIZER_DESIGN_SEARCH_SLOT_ID,
+    type DesignSearchHit,
+} from "@/lib/design-search";
+import { shortcutKeys } from "@/lib/shortcuts";
+import { cn } from "@/lib/utils";
+import type { PrismSemanticIndex } from "@/types/prism-selection";
+
+type DesignSearchFieldProps = {
+    semanticIndex: PrismSemanticIndex | null;
+    currentPage?: string | null;
+    loading?: boolean;
+    active?: boolean;
+    onPick: (hit: DesignSearchHit) => void;
+};
+
+function ShortcutCaps({ combo }: { combo: string }) {
+    return (
+        <span className="flex items-center gap-0.5">
+            {shortcutKeys(combo).map((key) => (
+                <kbd
+                    key={key}
+                    className="inline-flex h-5 min-w-[1.25rem] items-center justify-center border bg-muted px-1 font-sans text-[11px] font-medium text-muted-foreground"
+                >
+                    {key}
+                </kbd>
+            ))}
+        </span>
+    );
+}
+
+/** Scroll only the list, not the page, when the highlight moves off-screen. */
+function scrollListChildIntoView(list: HTMLElement, child: HTMLElement) {
+    const listRect = list.getBoundingClientRect();
+    const childRect = child.getBoundingClientRect();
+    if (childRect.bottom > listRect.bottom) {
+        list.scrollTop += childRect.bottom - listRect.bottom;
+    } else if (childRect.top < listRect.top) {
+        list.scrollTop -= listRect.top - childRect.top;
+    }
+}
+
+export function DesignSearchField({
+    semanticIndex,
+    currentPage,
+    loading = false,
+    active = true,
+    onPick,
+}: DesignSearchFieldProps) {
+    const listId = useId();
+    const rootRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const listRef = useRef<HTMLDivElement>(null);
+    const [slot, setSlot] = useState<HTMLElement | null>(null);
+    const [query, setQuery] = useState("");
+    const [open, setOpen] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(0);
+
+    const hits = useMemo(
+        () => searchDesignEntities(semanticIndex, query, { currentPage }),
+        [currentPage, query, semanticIndex],
+    );
+    const activeHit = hits[activeIndex];
+    const activeOptionId = activeHit ? `${listId}-opt-${activeIndex}` : undefined;
+
+    useLayoutEffect(() => {
+        if (!active) {
+            setSlot(null);
+            setOpen(false);
+            return;
+        }
+        setSlot(document.getElementById(VISUALIZER_DESIGN_SEARCH_SLOT_ID));
+    }, [active]);
+
+    const focusSearch = useCallback((event?: KeyboardEvent) => {
+        event?.stopPropagation();
+        setOpen(true);
+        const input = inputRef.current;
+        if (!input) return;
+        input.focus();
+        input.select();
+    }, []);
+
+    useHotkeys(
+        [
+            { combo: "/", handler: focusSearch },
+            { combo: "mod+f", handler: focusSearch, allowInInputs: true },
+        ],
+        { enabled: active, capture: true },
+    );
+
+    useEffect(() => {
+        if (!open) return;
+        const onPointerDown = (event: PointerEvent) => {
+            if (rootRef.current?.contains(event.target as Node)) return;
+            setOpen(false);
+        };
+        document.addEventListener("pointerdown", onPointerDown);
+        return () => document.removeEventListener("pointerdown", onPointerDown);
+    }, [open]);
+
+    useEffect(() => {
+        setActiveIndex(0);
+    }, [hits]);
+
+    useLayoutEffect(() => {
+        if (!open) return;
+        const list = listRef.current;
+        const activeRow = list?.querySelector("[data-active='true']");
+        if (list && activeRow instanceof HTMLElement) {
+            scrollListChildIntoView(list, activeRow);
+        }
+    }, [activeIndex, hits, open]);
+
+    const pick = useCallback(
+        (hit: DesignSearchHit) => {
+            onPick(hit);
+            setOpen(false);
+        },
+        [onPick],
+    );
+
+    const onInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setOpen(true);
+            if (hits.length) setActiveIndex((current) => (current + 1) % hits.length);
+            return;
+        }
+        if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setOpen(true);
+            if (hits.length) setActiveIndex((current) => (current - 1 + hits.length) % hits.length);
+            return;
+        }
+        if (event.key === "Home" && hits.length) {
+            event.preventDefault();
+            setOpen(true);
+            setActiveIndex(0);
+            return;
+        }
+        if (event.key === "End" && hits.length) {
+            event.preventDefault();
+            setOpen(true);
+            setActiveIndex(hits.length - 1);
+            return;
+        }
+        if (event.key === "Enter") {
+            const hit = hits[activeIndex];
+            if (!hit) return;
+            event.preventDefault();
+            pick(hit);
+            return;
+        }
+        if (event.key === "Escape") {
+            event.preventDefault();
+            event.stopPropagation();
+            if (open) {
+                setOpen(false);
+                return;
+            }
+            if (query) {
+                setQuery("");
+                return;
+            }
+            inputRef.current?.blur();
+        }
+    };
+
+    if (!slot) return null;
+
+    const trimmed = query.trim();
+    const showShortcuts = !trimmed;
+    const showHint = open && !loading && !trimmed;
+    const showLoading = open && loading;
+    const showEmpty = open && !loading && trimmed.length > 0 && hits.length === 0;
+    const showHits = open && !loading && hits.length > 0;
+
+    return createPortal(
+        <div ref={rootRef} className="relative mx-auto w-full max-w-xl">
+            <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                    ref={inputRef}
+                    type="text"
+                    value={query}
+                    autoComplete="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    data-shortcut-search
+                    aria-label="Find component or net"
+                    aria-expanded={open}
+                    aria-controls={listId}
+                    aria-autocomplete="list"
+                    aria-activedescendant={open ? activeOptionId : undefined}
+                    aria-busy={loading || undefined}
+                    role="combobox"
+                    placeholder="Search"
+                    className={cn(
+                        "h-9 w-full min-w-0 border border-input bg-muted/40 py-2 pl-9 text-sm outline-none placeholder:text-muted-foreground",
+                        "focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50",
+                        showShortcuts ? "pr-32" : "pr-3",
+                    )}
+                    onChange={(event) => {
+                        setQuery(event.target.value);
+                        setOpen(true);
+                    }}
+                    onFocus={() => setOpen(true)}
+                    onBlur={(event) => {
+                        if (rootRef.current?.contains(event.relatedTarget as Node)) return;
+                        setOpen(false);
+                    }}
+                    onKeyDown={onInputKeyDown}
+                />
+                {showShortcuts ? (
+                    <span className="pointer-events-none absolute right-2 top-1/2 hidden -translate-y-1/2 items-center gap-1 sm:flex">
+                        <ShortcutCaps combo="/" />
+                        <ShortcutCaps combo="mod+f" />
+                    </span>
+                ) : null}
+            </div>
+            {open ? (
+                <div
+                    ref={listRef}
+                    id={listId}
+                    role="listbox"
+                    aria-label="Design search results"
+                    className="absolute inset-x-0 top-full z-50 mt-1 max-h-80 overflow-y-auto border border-border bg-popover text-popover-foreground shadow-md"
+                >
+                    {showLoading ? (
+                        <p className="px-3 py-6 text-center text-sm text-muted-foreground">Loading design index…</p>
+                    ) : null}
+                    {showHint ? (
+                        <p className="px-3 py-6 text-center text-sm text-muted-foreground">{DESIGN_SEARCH_HINT}</p>
+                    ) : null}
+                    {showEmpty ? (
+                        <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                            No matches for “{trimmed}”
+                        </p>
+                    ) : null}
+                    {showHits ? (
+                        <ResultList
+                            listId={listId}
+                            hits={hits}
+                            activeIndex={activeIndex}
+                            onPick={pick}
+                            onHover={setActiveIndex}
+                        />
+                    ) : null}
+                </div>
+            ) : null}
+        </div>,
+        slot,
+    );
+}
+
+function ResultList({
+    listId,
+    hits,
+    activeIndex,
+    onPick,
+    onHover,
+}: {
+    listId: string;
+    hits: DesignSearchHit[];
+    activeIndex: number;
+    onPick: (hit: DesignSearchHit) => void;
+    onHover: (index: number) => void;
+}) {
+    let lastKind: DesignSearchHit["kind"] | null = null;
+    return (
+        <div className="p-1">
+            {hits.map((hit, index) => {
+                const heading = hit.kind === lastKind
+                    ? null
+                    : hit.kind === "component"
+                        ? "Components"
+                        : "Nets";
+                lastKind = hit.kind;
+                const isActive = index === activeIndex;
+                return (
+                    <div key={hit.id} data-active={isActive ? "true" : undefined}>
+                        {heading ? (
+                            <p className="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                {heading}
+                            </p>
+                        ) : null}
+                        <button
+                            type="button"
+                            id={`${listId}-opt-${index}`}
+                            role="option"
+                            aria-selected={isActive}
+                            className={cn(
+                                "flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm",
+                                isActive ? "bg-muted text-foreground" : "text-muted-foreground",
+                            )}
+                            onMouseMove={() => onHover(index)}
+                            onMouseDown={(event) => event.preventDefault()}
+                            onClick={() => onPick(hit)}
+                        >
+                            <span className="min-w-0 flex-1 truncate text-foreground">{hit.title}</span>
+                            {hit.subtitle ? (
+                                <span className="max-w-[55%] shrink-0 truncate text-xs text-muted-foreground">
+                                    {hit.subtitle}
+                                </span>
+                            ) : null}
+                        </button>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -31,8 +31,6 @@ import type {
     SemanticTerminal,
 } from "@/types/prism-selection";
 
-export type { LabelInstanceRef };
-
 interface SelectionInspectorProps {
     open: boolean;
     selection: PrismSelection | null;
@@ -91,7 +89,7 @@ function resolveTerminal(selection: PrismSelection, index: PrismSemanticIndex | 
 function PropertyRow({ label, value }: { label: string; value: ReactNode }) {
     if (value === undefined || value === null || value === "") return null;
     return (
-        <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] gap-3 border-b py-2.5 last:border-b-0">
+        <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)] gap-2 border-b py-1.5 last:border-b-0">
             <dt className="text-muted-foreground">{label}</dt>
             <dd className="min-w-0 break-words text-right font-medium">{value}</dd>
         </div>
@@ -208,8 +206,8 @@ function IntegrationRow({ icon: Icon, title, description }: {
     description: string;
 }) {
     return (
-        <div className="flex items-start gap-3 border-b py-3 last:border-b-0">
-            <div className="mt-0.5 border bg-muted/40 p-2">
+        <div className="flex items-start gap-2.5 border-b py-2 last:border-b-0">
+            <div className="mt-0.5 border bg-muted/40 p-1.5">
                 <Icon className="h-4 w-4 text-muted-foreground" />
             </div>
             <div className="min-w-0 flex-1">
@@ -265,8 +263,8 @@ function LibraryImportRow({ onImport, disabled, loading }: {
     loading: boolean;
 }) {
     return (
-        <div className="flex items-start gap-3 border-b py-3 last:border-b-0">
-            <div className="mt-0.5 border bg-muted/40 p-2">
+        <div className="flex items-start gap-2.5 border-b py-2 last:border-b-0">
+            <div className="mt-0.5 border bg-muted/40 p-1.5">
                 <LibraryBig className="h-4 w-4 text-muted-foreground" />
             </div>
             <div className="min-w-0 flex-1">
@@ -327,7 +325,7 @@ export function SelectionInspector({
             )}
             aria-label="Selection inspector"
         >
-            <header className="shrink-0 border-b bg-card/70 px-4 py-3">
+            <header className="shrink-0 border-b bg-card/70 px-3 py-2">
                 <div className="flex items-center justify-between gap-3">
                     <nav aria-label="Selection breadcrumb" className="flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
                         <span>Selection</span>
@@ -342,15 +340,13 @@ export function SelectionInspector({
                         </Button>
                     )}
                 </div>
-                <div className="mt-4 flex items-center gap-3">
-                    <div className="border bg-primary/10 p-2.5 text-primary">
-                        <SelectionIcon className="h-5 w-5" />
+                <div className="mt-2.5 flex items-center gap-2.5">
+                    <div className="border bg-primary/10 p-2 text-primary">
+                        <SelectionIcon className="h-4 w-4" />
                     </div>
                     <div className="min-w-0 flex-1 leading-tight">
-                        <h2 className="truncate font-mono text-lg font-semibold" title={title}>{title}</h2>
-                        {/* Nudge just the tag up so its bottom lines up with the
-                            icon's bottom, without reflowing the icon or title. */}
-                        <div className="mt-2 flex flex-wrap items-center gap-1.5 -translate-y-1.5">
+                        <h2 className="truncate font-mono text-base font-semibold" title={title}>{title}</h2>
+                        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
                             <Badge variant="outline" className="px-2 py-0 text-[11px] font-medium">
                                 {capitalizeFirst(resolvedItemType(selection, viewContext))}
                             </Badge>
@@ -360,7 +356,7 @@ export function SelectionInspector({
             </header>
 
             <ScrollArea className="themed-scrollbar min-h-0 flex-1">
-                <div className="space-y-5 p-4 text-xs">
+                <div className="space-y-3 p-3 text-xs">
                     {showLabelNav && (
                         <CollapsibleSection title="Instances">
                             <div className="flex items-center justify-between gap-2 border bg-card/40 px-3 py-2">
@@ -521,7 +517,7 @@ export function SelectionInspector({
                 </div>
             </ScrollArea>
 
-            <footer className="flex shrink-0 items-center justify-between gap-2 border-t bg-card/70 p-3">
+            <footer className="flex shrink-0 items-center justify-between gap-2 border-t bg-card/70 p-2">
                 <span className="text-xs text-muted-foreground">Esc clears selection</span>
                 <Button size="sm" variant="outline" onClick={onClear}>Clear</Button>
             </footer>

--- a/frontend/src/components/selection-inspector.tsx
+++ b/frontend/src/components/selection-inspector.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
+import { labelInstanceListLabel, type LabelInstanceRef } from "@/lib/label-instances";
 import { selectionLabel } from "@/lib/prism-selection";
 import type {
     PrismSelection,
@@ -30,12 +31,7 @@ import type {
     SemanticTerminal,
 } from "@/types/prism-selection";
 
-export interface LabelInstanceRef {
-    uuid: string;
-    sheet: string;
-    name: string;
-    kind?: "global" | "net" | "hierarchical";
-}
+export type { LabelInstanceRef };
 
 interface SelectionInspectorProps {
     open: boolean;
@@ -46,7 +42,7 @@ interface SelectionInspectorProps {
     onImportComponent?: () => void;
     canImportComponent?: boolean;
     importingComponent?: boolean;
-    /** Matching label instances for SCH label / global-label selections. */
+    /** Matching schematic label instances for net / global-label selections. */
     labelInstances?: LabelInstanceRef[];
     onNavigateLabelInstance?: (direction: -1 | 1) => void;
     onFocusLabelInstance?: (uuid: string) => void;
@@ -316,6 +312,10 @@ export function SelectionInspector({
         : -1;
     const showLabelNav = labelInstances.length >= 2 && Boolean(onNavigateLabelInstance);
     const labelOrdinal = labelIndex >= 0 ? labelIndex + 1 : 1;
+    const currentInstance = labelInstances[labelIndex >= 0 ? labelIndex : 0];
+    const currentInstanceLabel = currentInstance
+        ? labelInstanceListLabel(currentInstance, labelInstances)
+        : undefined;
 
     return (
         <aside
@@ -362,7 +362,7 @@ export function SelectionInspector({
             <ScrollArea className="themed-scrollbar min-h-0 flex-1">
                 <div className="space-y-5 p-4 text-xs">
                     {showLabelNav && (
-                        <CollapsibleSection title="Instances" defaultOpen={false}>
+                        <CollapsibleSection title="Instances">
                             <div className="flex items-center justify-between gap-2 border bg-card/40 px-3 py-2">
                                 <Button
                                     type="button"
@@ -378,9 +378,11 @@ export function SelectionInspector({
                                     <div className="font-medium tabular-nums">
                                         {labelOrdinal} / {labelInstances.length}
                                     </div>
-                                    <div className="mt-0.5 truncate text-muted-foreground" title={labelInstances[labelIndex]?.sheet}>
-                                        {labelInstances[labelIndex >= 0 ? labelIndex : 0]?.sheet}
-                                    </div>
+                                    {currentInstanceLabel && (
+                                        <div className="mt-0.5 truncate text-muted-foreground" title={currentInstanceLabel}>
+                                            {currentInstanceLabel}
+                                        </div>
+                                    )}
                                 </div>
                                 <Button
                                     type="button"
@@ -396,6 +398,7 @@ export function SelectionInspector({
                             <ul className="themed-scrollbar mt-2 max-h-40 space-y-1 overflow-y-auto border bg-card/20 p-2">
                                 {labelInstances.map((instance) => {
                                     const active = instance.uuid === activeUuid;
+                                    const label = labelInstanceListLabel(instance, labelInstances);
                                     return (
                                         <li key={instance.uuid}>
                                             <button
@@ -407,9 +410,9 @@ export function SelectionInspector({
                                                 }`}
                                                 disabled={navigatingLabelInstance || active}
                                                 onClick={() => onFocusLabelInstance?.(instance.uuid)}
-                                                title={`${instance.sheet}:${instance.name}`}
+                                                title={`${label}:${instance.name}`}
                                             >
-                                                {instance.sheet}
+                                                {label}
                                             </button>
                                         </li>
                                     );

--- a/frontend/src/components/ui/resizable-panel.tsx
+++ b/frontend/src/components/ui/resizable-panel.tsx
@@ -3,6 +3,7 @@ import {
     useEffect,
     useRef,
     useState,
+    type MutableRefObject,
     type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
@@ -35,6 +36,14 @@ export type ResizablePanelProps = {
     children: ReactNode;
 };
 
+export type UseResizableWidthOptions = {
+    side: "left" | "right";
+    storageKey: string;
+    defaultWidth: number;
+    minWidth?: number;
+    maxWidth?: number;
+};
+
 /** Horizontal room a panel must leave for the canvas and the other panel. */
 const RESERVED_FOR_CONTENT = 480;
 
@@ -50,16 +59,13 @@ function viewportCap(minWidth: number): number {
     return Math.max(minWidth, window.innerWidth - RESERVED_FOR_CONTENT);
 }
 
-export function ResizablePanel({
+export function useResizableWidth({
     side,
     storageKey,
     defaultWidth,
     minWidth = 240,
     maxWidth = 720,
-    className,
-    "aria-label": ariaLabel,
-    children,
-}: ResizablePanelProps) {
+}: UseResizableWidthOptions) {
     const clamp = useCallback(
         (value: number) => Math.min(maxWidth, Math.max(minWidth, value)),
         [maxWidth, minWidth],
@@ -71,7 +77,7 @@ export function ResizablePanel({
     );
     const [viewportMax, setViewportMax] = useState(() => viewportCap(minWidth));
     const [dragging, setDragging] = useState(false);
-    const panelRef = useRef<HTMLElement | null>(null);
+    const panelRef: MutableRefObject<HTMLElement | null> = useRef(null);
     const width = Math.round(Math.min(preferredWidth, viewportMax));
 
     useEffect(() => {
@@ -136,6 +142,52 @@ export function ResizablePanel({
         }
     };
 
+    return {
+        width,
+        minWidth,
+        maxWidth,
+        dragging,
+        panelRef,
+        separatorProps: {
+            role: "separator" as const,
+            "aria-orientation": "vertical" as const,
+            "aria-valuenow": width,
+            "aria-valuemin": minWidth,
+            "aria-valuemax": maxWidth,
+            tabIndex: 0,
+            onPointerDown: startDrag,
+            onPointerMove: onDrag,
+            onPointerUp: endDrag,
+            onPointerCancel: endDrag,
+            onKeyDown,
+            onDoubleClick: () => setPreferredWidth(clamp(defaultWidth)),
+        },
+    };
+}
+
+export function ResizablePanel({
+    side,
+    storageKey,
+    defaultWidth,
+    minWidth = 240,
+    maxWidth = 720,
+    className,
+    "aria-label": ariaLabel,
+    children,
+}: ResizablePanelProps) {
+    const {
+        width,
+        dragging,
+        panelRef,
+        separatorProps,
+    } = useResizableWidth({
+        side,
+        storageKey,
+        defaultWidth,
+        minWidth,
+        maxWidth,
+    });
+
     return (
         <aside
             ref={panelRef}
@@ -153,19 +205,8 @@ export function ResizablePanel({
                 {children}
             </div>
             <div
-                role="separator"
-                aria-orientation="vertical"
+                {...separatorProps}
                 aria-label={`Resize ${ariaLabel ?? "panel"}`}
-                aria-valuenow={width}
-                aria-valuemin={minWidth}
-                aria-valuemax={maxWidth}
-                tabIndex={0}
-                onPointerDown={startDrag}
-                onPointerMove={onDrag}
-                onPointerUp={endDrag}
-                onPointerCancel={endDrag}
-                onKeyDown={onKeyDown}
-                onDoubleClick={() => setPreferredWidth(clamp(defaultWidth))}
                 className={cn(
                     "absolute inset-y-0 z-20 w-1.5 cursor-col-resize transition-colors hover:bg-primary/40 focus-visible:bg-primary/60 focus-visible:outline-none",
                     dragging && "bg-primary/60",

--- a/frontend/src/components/viewer-overlay-rail.test.tsx
+++ b/frontend/src/components/viewer-overlay-rail.test.tsx
@@ -71,6 +71,35 @@ describe("viewer overlay rails", () => {
         await waitFor(() => expect(onWidth).toHaveBeenLastCalledWith(0));
     });
 
+    it("lets the selection inspector resize from a narrower default width", () => {
+        window.localStorage.clear();
+        const { getByRole } = render(
+            <div className="relative h-[600px] w-[900px]">
+                <ViewerOverlayRail
+                    activeTab="selection"
+                    tabs={[{ id: "selection", label: "Selection" }]}
+                    onTabChange={() => undefined}
+                    onClose={() => undefined}
+                    ariaLabel="Viewer details"
+                    resizable={{
+                        storageKey: "test.inspector.width",
+                        defaultWidth: 288,
+                        minWidth: 240,
+                        maxWidth: 480,
+                    }}
+                >
+                    Selection details
+                </ViewerOverlayRail>
+            </div>,
+        );
+
+        const rail = getByRole("complementary", { name: "Viewer details" });
+        expect(rail.style.width).toBe("288px");
+
+        fireEvent.keyDown(getByRole("separator"), { key: "ArrowLeft" });
+        expect(rail.style.width).toBe("304px");
+    });
+
     it("collapses the left controls by transform and retains a measured handle", async () => {
         vi.spyOn(HTMLElement.prototype, "getBoundingClientRect")
             .mockImplementation(function measuredRect(this: HTMLElement) {

--- a/frontend/src/components/viewer-overlay-rail.tsx
+++ b/frontend/src/components/viewer-overlay-rail.tsx
@@ -1,11 +1,16 @@
 import {
     useLayoutEffect,
     useRef,
+    type MutableRefObject,
     type ReactNode,
 } from "react";
 import { X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+    useResizableWidth,
+    type UseResizableWidthOptions,
+} from "@/components/ui/resizable-panel";
 import { cn } from "@/lib/utils";
 
 export type ViewerOverlayRailTab<T extends string> = {
@@ -13,6 +18,16 @@ export type ViewerOverlayRailTab<T extends string> = {
     label: string;
     icon?: ReactNode;
     badge?: ReactNode;
+};
+
+export type ViewerOverlayRailResize = Omit<UseResizableWidthOptions, "side">;
+
+/** Schematic/PCB Selection inspector: narrower than Comments, reviewer-resizable. */
+export const SELECTION_INSPECTOR_RAIL_RESIZE: ViewerOverlayRailResize = {
+    storageKey: "prism.visualizer.selection-inspector.width",
+    defaultWidth: 288,
+    minWidth: 240,
+    maxWidth: 480,
 };
 
 type ViewerOverlayRailProps<T extends string> = {
@@ -23,6 +38,12 @@ type ViewerOverlayRailProps<T extends string> = {
     onVisibleWidthChange?: (width: number) => void;
     ariaLabel: string;
     className?: string;
+    /**
+     * When set, the rail width is reviewer-controlled instead of the default
+     * `w-96`. Used for the Selection inspector on Schematic/PCB; omit it for
+     * Comments and other overlay tools so they keep a fixed width.
+     */
+    resizable?: ViewerOverlayRailResize;
     children: ReactNode;
 };
 
@@ -31,7 +52,40 @@ type ViewerOverlayRailProps<T extends string> = {
  * width is reported to the viewer camera as a safe-area inset; it never
  * participates in the canvas layout or calls resize().
  */
-export function ViewerOverlayRail<T extends string>({
+export function ViewerOverlayRail<T extends string>(props: ViewerOverlayRailProps<T>) {
+    if (props.resizable) {
+        return <ResizableViewerOverlayRail {...props} resizable={props.resizable} />;
+    }
+    return <ViewerOverlayRailFrame {...props} />;
+}
+
+function ResizableViewerOverlayRail<T extends string>({
+    resizable,
+    ariaLabel,
+    ...props
+}: ViewerOverlayRailProps<T> & { resizable: ViewerOverlayRailResize }) {
+    const sizing = useResizableWidth({ side: "right", ...resizable });
+    return (
+        <ViewerOverlayRailFrame
+            {...props}
+            ariaLabel={ariaLabel}
+            widthPx={sizing.width}
+            railRef={sizing.panelRef}
+            separator={
+                <div
+                    {...sizing.separatorProps}
+                    aria-label={`Resize ${ariaLabel}`}
+                    className={cn(
+                        "absolute inset-y-0 left-0 z-20 w-1.5 cursor-col-resize touch-none transition-colors hover:bg-primary/40 focus-visible:bg-primary/60 focus-visible:outline-none",
+                        sizing.dragging && "bg-primary/60",
+                    )}
+                />
+            }
+        />
+    );
+}
+
+function ViewerOverlayRailFrame<T extends string>({
     activeTab,
     tabs,
     onTabChange,
@@ -40,8 +94,16 @@ export function ViewerOverlayRail<T extends string>({
     ariaLabel,
     className,
     children,
-}: ViewerOverlayRailProps<T>) {
-    const railRef = useRef<HTMLElement | null>(null);
+    widthPx,
+    railRef: railRefProp,
+    separator,
+}: ViewerOverlayRailProps<T> & {
+    widthPx?: number;
+    railRef?: MutableRefObject<HTMLElement | null>;
+    separator?: ReactNode;
+}) {
+    const internalRef = useRef<HTMLElement | null>(null);
+    const railRef = railRefProp ?? internalRef;
     const activeTabRef = useRef(activeTab);
     activeTabRef.current = activeTab;
 
@@ -62,7 +124,7 @@ export function ViewerOverlayRail<T extends string>({
             observer?.disconnect();
             onVisibleWidthChange(0);
         };
-    }, [onVisibleWidthChange]);
+    }, [onVisibleWidthChange, railRef]);
 
     useLayoutEffect(() => {
         if (!onVisibleWidthChange) return;
@@ -71,28 +133,31 @@ export function ViewerOverlayRail<T extends string>({
                 ? railRef.current?.getBoundingClientRect().width ?? 0
                 : 0,
         );
-    }, [activeTab, onVisibleWidthChange]);
+    }, [activeTab, onVisibleWidthChange, railRef, widthPx]);
 
     useLayoutEffect(() => {
         const rail = railRef.current;
         if (!rail) return;
         if (activeTab) rail.removeAttribute("inert");
         else rail.setAttribute("inert", "");
-    }, [activeTab]);
+    }, [activeTab, railRef]);
 
     return (
         <aside
             ref={railRef}
             aria-label={ariaLabel}
             aria-hidden={!activeTab}
+            style={widthPx == null ? undefined : { width: `${widthPx}px` }}
             className={cn(
-                "absolute inset-y-0 right-0 z-40 flex w-96 flex-col border-l bg-background/95 shadow-xl backdrop-blur-sm transition-[transform,opacity] duration-200",
+                "absolute inset-y-0 right-0 z-40 flex min-w-0 flex-col overflow-hidden border-l bg-background/95 shadow-xl backdrop-blur-sm transition-[transform,opacity] duration-200",
+                widthPx == null && "w-96",
                 activeTab
                     ? "translate-x-0 opacity-100"
                     : "pointer-events-none translate-x-full opacity-0",
                 className,
             )}
         >
+            {separator}
             <div className="flex h-10 shrink-0 items-center gap-1 border-b bg-card/80 p-1">
                 {tabs.map((tab) => (
                     <Button
@@ -120,7 +185,7 @@ export function ViewerOverlayRail<T extends string>({
                     <X className="size-4" />
                 </Button>
             </div>
-            <div className="min-h-0 flex-1">{children}</div>
+            <div className="min-h-0 min-w-0 flex-1">{children}</div>
         </aside>
     );
 }

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -4,7 +4,8 @@ import { toast } from "sonner";
 import { Cpu, Box, FileText, CircuitBoard, Layers3, PackageCheck, MessageSquare, MessageSquarePlus, type LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { EngineeringBomTable } from "./engineering-bom-table";
-import { SelectionInspector, type LabelInstanceRef } from "./selection-inspector";
+import { SelectionInspector } from "./selection-inspector";
+import { filterLabelInstances, type LabelInstanceRef } from "@/lib/label-instances";
 import { WebGpu3dTab } from "./webgpu-3d-tab";
 import { EcadViewerControls } from "./ecad-viewer-controls";
 import { CommentForm, type CommentFormSubmitPayload } from "./comment-form";
@@ -896,37 +897,9 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
             return;
         }
 
-        const itemType = (selection.anchor?.itemType || "").toLowerCase();
-        if (itemType !== "global-label" && itemType !== "label") {
-            setLabelInstances([]);
-            return;
-        }
-
         const all = viewer.findLabelInstances(selection.netName);
-        const pageHint =
-            activeSchematicPage?.filename ||
-            selection.anchor?.page ||
-            selection.anchor?.sheet ||
-            undefined;
-        const sheetBase = (value: string) => {
-            const parts = value.split("/").filter(Boolean);
-            return parts[parts.length - 1] || value;
-        };
-        const sheetMatches = (sheet: string, page: string | undefined) => {
-            if (!page) return true;
-            if (sheet === page) return true;
-            return sheetBase(sheet) === sheetBase(page);
-        };
-
-        const filtered =
-            itemType === "global-label"
-                ? all.filter((instance) => instance.kind === "global")
-                : all.filter(
-                      (instance) =>
-                          instance.kind === "net" && sheetMatches(instance.sheet, pageHint),
-                  );
-        setLabelInstances(filtered);
-    }, [activeSchematicPage?.filename, globalSelection, schematicViewerElement]);
+        setLabelInstances(filterLabelInstances(all, selection.anchor?.itemType));
+    }, [globalSelection, schematicViewerElement]);
 
     const focusLabelInstance = useCallback(async (uuid: string) => {
         const viewer = schematicViewerRef.current;

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -15,6 +15,8 @@ import { fetchApi, readApiError } from "@/lib/api";
 import { throwIfJobFailed, watchPrismJob } from "@/lib/jobs";
 import { canWriteCatalog } from "@/lib/roles";
 import { crossProbeRequestForSelection, normalizeEcadSelection } from "@/lib/prism-selection";
+import { selectionFromDesignSearchHit, type DesignSearchHit } from "@/lib/design-search";
+import { DesignSearchField } from "./design-search-field";
 import { usePrismCrossProbe } from "@/hooks/use-prism-cross-probe";
 import type { User } from "@/types/auth";
 import type {
@@ -25,7 +27,7 @@ import type {
     EcadSemanticSelectionDetail,
     EcadViewportInsets,
 } from "@/types/ecad-viewer";
-import type { PrismSelection, PrismSemanticIndex } from "@/types/prism-selection";
+import type { PrismSelection, PrismSelectionContext, PrismSemanticIndex } from "@/types/prism-selection";
 import type { Comment, CommentContext, CommentLocation, CommentsFile, MentionCandidate } from "@/types/comments";
 import {
     DEFAULT_COMMENT_CLASS,
@@ -54,6 +56,13 @@ const VISUALIZER_TABS: { id: VisualizerTab; label: string; icon: LucideIcon }[] 
     { id: "stackup", label: "Stackup", icon: Layers3 },
     { id: "assembly", label: "Assembly Assistant", icon: PackageCheck },
 ];
+
+function selectionContextForTab(tab: VisualizerTab): PrismSelectionContext {
+    if (tab === "pcb") return "PCB";
+    if (tab === "3d" || tab === "stackup") return "3D";
+    if (tab === "bom" || tab === "assembly") return "BOM";
+    return "SCH";
+}
 
 const isAbortError = (error: unknown): boolean =>
     error instanceof DOMException && error.name === "AbortError";
@@ -806,6 +815,25 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
         };
     }, [commit, pcbViewerElement, projectId, registerClient, schematicViewerElement, semanticIndex]);
 
+    const handleDesignSearchPick = useCallback((hit: DesignSearchHit) => {
+        const sourceContext = selectionContextForTab(activeTab);
+        const currentPage = activeSchematicPage?.filename
+            || activeSchematicPage?.page
+            || activeSchematicPage?.projectPath
+            || null;
+        const selection = selectionFromDesignSearchHit(hit, sourceContext, currentPage);
+        if (!selection) return;
+        // Search is not a click inside a viewer, so the bus would skip the
+        // source SCH/PCB client. Probe everyone, then apply to the source too.
+        crossProbeGlobal(selection);
+        if (sourceContext !== "SCH" && sourceContext !== "PCB") return;
+        const viewer = sourceContext === "SCH" ? schematicViewerRef.current : pcbViewerRef.current;
+        if (typeof viewer?.requestCrossProbe !== "function") return;
+        void viewer.requestCrossProbe(
+            crossProbeRequestForSelection(selection, sourceContext, semanticIndex),
+        );
+    }, [activeSchematicPage, activeTab, crossProbeGlobal, semanticIndex]);
+
     // The active CAD view, or null on non-CAD tabs (3D, stackup, ...).
     const activeViewContext: "SCH" | "PCB" | null =
         activeTab === "pcb" ? "PCB" : activeTab === "sch" ? "SCH" : null;
@@ -1219,6 +1247,13 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
 
     return (
         <div className="relative flex h-full min-h-0 flex-col bg-background">
+            <DesignSearchField
+                semanticIndex={semanticIndex}
+                currentPage={activeSchematicPage?.filename || activeSchematicPage?.page || activeSchematicPage?.projectPath}
+                loading={semanticIndexLoading}
+                active={viewerActive}
+                onPick={handleDesignSearchPick}
+            />
             {/* Toolbar */}
             <div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b bg-muted/20 px-2 py-1">
                 {VISUALIZER_TABS.map((tab, index) => {

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -11,7 +11,7 @@ import { EcadViewerControls } from "./ecad-viewer-controls";
 import { CommentForm, type CommentFormSubmitPayload } from "./comment-form";
 import { CommentCard } from "./comment-card";
 import { CommentPanel } from "./comment-panel";
-import { ViewerOverlayRail } from "./viewer-overlay-rail";
+import { ViewerOverlayRail, SELECTION_INSPECTOR_RAIL_RESIZE } from "./viewer-overlay-rail";
 import { fetchApi, readApiError } from "@/lib/api";
 import { throwIfJobFailed, watchPrismJob } from "@/lib/jobs";
 import { canWriteCatalog } from "@/lib/roles";
@@ -1432,6 +1432,12 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                         onClose={() => setRightRailTab(null)}
                         onVisibleWidthChange={setRightRailInset}
                         ariaLabel="Viewer details"
+                        resizable={
+                            (activeTab === "sch" || activeTab === "pcb")
+                                && rightRailTab === "selection"
+                                ? SELECTION_INSPECTOR_RAIL_RESIZE
+                                : undefined
+                        }
                     >
                         {rightRailTab === "comments" ? (
                             <CommentPanel

--- a/frontend/src/lib/design-search.test.ts
+++ b/frontend/src/lib/design-search.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    searchDesignEntities,
+    selectionFromDesignSearchHit,
+} from "./design-search";
+import type { PrismSemanticIndex, SemanticComponent, SemanticNet } from "@/types/prism-selection";
+
+function index(components: SemanticComponent[], nets: SemanticNet[]): PrismSemanticIndex {
+    return {
+        schema: "prism.semantic_index_a0",
+        sourceRevisionKey: "rev",
+        components,
+        nets,
+        terminals: [],
+        indexes: {},
+    };
+}
+
+function component(partial: Partial<SemanticComponent> & { reference: string }): SemanticComponent {
+    return {
+        componentUid: partial.componentUid ?? `cmp:${partial.reference}`,
+        value: partial.value,
+        footprint: partial.footprint,
+        fields: partial.fields,
+        schematicRefs: partial.schematicRefs,
+        pcbRefs: partial.pcbRefs,
+        ...partial,
+        reference: partial.reference,
+    };
+}
+
+function net(partial: Partial<SemanticNet> & { name: string }): SemanticNet {
+    return {
+        netUid: partial.netUid ?? `net:${partial.name}`,
+        netClass: partial.netClass,
+        schematicRefs: partial.schematicRefs,
+        ...partial,
+        name: partial.name,
+    };
+}
+
+describe("searchDesignEntities", () => {
+    const board = index(
+        [
+            component({
+                reference: "R12",
+                value: "10k",
+                footprint: "R_0402",
+                fields: { "Manufacturer Part Number": "RC0402FR-0710KL" },
+                schematicRefs: [{ page: "power.kicad_sch" }],
+            }),
+            component({
+                reference: "R120",
+                value: "10k",
+                footprint: "R_0603",
+                schematicRefs: [{ page: "io.kicad_sch" }],
+            }),
+            component({ reference: "C4", value: "100n", footprint: "C_0402" }),
+        ],
+        [
+            net({ name: "GND", netClass: "Power" }),
+            net({ name: "GNDA", netClass: "Analog" }),
+            net({ name: "I2C_SDA", netClass: "Default" }),
+        ],
+    );
+
+    it("returns nothing for an empty query", () => {
+        expect(searchDesignEntities(board, "  ")).toEqual([]);
+        expect(searchDesignEntities(null, "R12")).toEqual([]);
+    });
+
+    it("lists each matching instance as its own component row", () => {
+        const hits = searchDesignEntities(board, "10k");
+        expect(hits.filter((hit) => hit.kind === "component").map((hit) => hit.title)).toEqual(["R12", "R120"]);
+    });
+
+    it("ranks an exact designator ahead of a prefix", () => {
+        const titles = searchDesignEntities(board, "r12").map((hit) => hit.title);
+        expect(titles[0]).toBe("R12");
+        expect(titles).toContain("R120");
+    });
+
+    it("matches footprint and MPN fields", () => {
+        expect(searchDesignEntities(board, "0402").map((hit) => hit.title).sort()).toEqual(["C4", "R12"]);
+        expect(searchDesignEntities(board, "RC0402").map((hit) => hit.title)).toEqual(["R12"]);
+    });
+
+    it("keeps nets grouped after components and matches net class", () => {
+        const hits = searchDesignEntities(board, "gnd");
+        expect(hits.map((hit) => `${hit.kind}:${hit.title}`)).toEqual([
+            "net:GND",
+            "net:GNDA",
+        ]);
+        expect(searchDesignEntities(board, "analog").map((hit) => hit.title)).toEqual(["GNDA"]);
+    });
+
+    it("fuzzy-matches net names the way workspace search matches projects", () => {
+        expect(searchDesignEntities(board, "i2c sda").map((hit) => hit.title)).toEqual(["I2C_SDA"]);
+        expect(searchDesignEntities(board, "i2csda").map((hit) => hit.title)).toEqual(["I2C_SDA"]);
+        expect(searchDesignEntities(board, "gnda").map((hit) => hit.title)[0]).toBe("GNDA");
+    });
+
+    it("omits the sheet name when the instance is on the current page", () => {
+        const onPower = searchDesignEntities(board, "R12", { currentPage: "power.kicad_sch" })[0];
+        expect(onPower.subtitle).toBe("10k · R_0402");
+        const elsewhere = searchDesignEntities(board, "R12", { currentPage: "io.kicad_sch" })[0];
+        expect(elsewhere.subtitle).toContain("power.kicad_sch");
+    });
+});
+
+describe("selectionFromDesignSearchHit", () => {
+    it("builds a component selection from the hit", () => {
+        const hit = searchDesignEntities(
+            index([component({ reference: "U1", schematicRefs: [{ symbolUuid: "sym-1", page: "root.kicad_sch" }] })], []),
+            "U1",
+        )[0];
+        expect(selectionFromDesignSearchHit(hit, "PCB")).toMatchObject({
+            kind: "component",
+            sourceContext: "PCB",
+            reference: "U1",
+            uuid: "sym-1",
+        });
+    });
+
+    it("builds a net selection from the hit", () => {
+        const hit = searchDesignEntities(index([], [net({ name: "GND", netCode: 0 })]), "GND")[0];
+        expect(selectionFromDesignSearchHit(hit, "SCH")).toMatchObject({
+            kind: "net",
+            sourceContext: "SCH",
+            netName: "GND",
+            netCode: 0,
+        });
+    });
+});

--- a/frontend/src/lib/design-search.ts
+++ b/frontend/src/lib/design-search.ts
@@ -1,0 +1,281 @@
+/**
+ * Design-entity search over the Visualizer semantic index.
+ *
+ * v1 is a header combobox (components + nets). Tab-specific find boxes
+ * (schematic pages, 3D Find, BOM filter) should call the same helpers when
+ * they are removed in v2, rather than growing a second query implementation.
+ *
+ * Matching uses Fuse with the same options as the workspace project search:
+ * `threshold: 0.35` and `ignoreLocation: true`. Net names also expose a compact
+ * form (`I2C_SDA` → `i2csda`) so punctuation does not hide a hit.
+ */
+
+import Fuse from "fuse.js";
+
+import type {
+    PrismSelection,
+    PrismSelectionContext,
+    PrismSemanticIndex,
+    SemanticComponent,
+    SemanticNet,
+} from "@/types/prism-selection";
+
+export const VISUALIZER_DESIGN_SEARCH_SLOT_ID = "visualizer-design-search-slot";
+
+export const DESIGN_SEARCH_HINT = "Reference, value, footprint, or net name";
+
+const DEFAULT_GROUP_LIMIT = 25;
+
+/** Nets use the workspace Fuse looseness. Components are tighter: short values like `10k` / `100n` collide at 0.35. */
+const COMPONENT_FUSE_OPTIONS = {
+    threshold: 0.2,
+    includeScore: true,
+    ignoreLocation: true,
+} as const;
+
+const NET_FUSE_OPTIONS = {
+    threshold: 0.35,
+    includeScore: true,
+    ignoreLocation: true,
+} as const;
+
+export type DesignSearchHitKind = "component" | "net";
+
+export interface DesignSearchHit {
+    kind: DesignSearchHitKind;
+    id: string;
+    title: string;
+    subtitle: string;
+    score: number;
+    component?: SemanticComponent;
+    net?: SemanticNet;
+}
+
+interface ComponentRecord {
+    component: SemanticComponent;
+    reference: string;
+    value: string;
+    footprint: string;
+    fields: string;
+}
+
+interface NetRecord {
+    net: SemanticNet;
+    name: string;
+    netClass: string;
+    aliases: string;
+    compact: string;
+    tokens: string;
+}
+
+const componentEngines = new WeakMap<PrismSemanticIndex, Fuse<ComponentRecord>>();
+const netEngines = new WeakMap<PrismSemanticIndex, Fuse<NetRecord>>();
+
+export function searchDesignEntities(
+    index: PrismSemanticIndex | null,
+    query: string,
+    options?: {
+        currentPage?: string | null;
+        limit?: number;
+    },
+): DesignSearchHit[] {
+    const needle = query.trim();
+    if (!index || !needle) return [];
+
+    const limit = options?.limit ?? DEFAULT_GROUP_LIMIT;
+    const currentPage = options?.currentPage ?? null;
+
+    const components = componentEngine(index)
+        .search(needle)
+        .slice(0, limit)
+        .map((result) => componentHit(result.item.component, fuseScore(result.score), currentPage));
+    const nets = netEngine(index)
+        .search(needle)
+        .slice(0, limit)
+        .map((result) => netHit(result.item.net, fuseScore(result.score)));
+    return [...components, ...nets];
+}
+
+export function selectionFromDesignSearchHit(
+    hit: DesignSearchHit,
+    sourceContext: PrismSelectionContext,
+    currentPage?: string | null,
+): PrismSelection | null {
+    if (hit.kind === "component") {
+        const component = hit.component;
+        if (!component) return null;
+        const schematic = preferredSchematicRef(component, currentPage ?? null);
+        return {
+            kind: "component",
+            sourceContext,
+            reference: component.reference,
+            componentUid: component.componentUid,
+            uuid: schematic?.symbolUuid,
+            anchor: {
+                context: sourceContext,
+                uuid: schematic?.symbolUuid,
+                page: schematic?.page,
+                sheet: schematic?.sheetInstancePath || schematic?.page,
+            },
+        };
+    }
+    const net = hit.net;
+    if (!net) return null;
+    return {
+        kind: "net",
+        sourceContext,
+        netName: net.name,
+        netUid: net.netUid,
+        netCode: net.netCode,
+        anchor: {
+            context: sourceContext,
+            page: net.schematicRefs?.[0]?.page,
+            sheet: net.schematicRefs?.[0]?.sheetInstancePath || net.schematicRefs?.[0]?.page,
+        },
+    };
+}
+
+function componentEngine(index: PrismSemanticIndex): Fuse<ComponentRecord> {
+    const cached = componentEngines.get(index);
+    if (cached) return cached;
+    const engine = new Fuse(
+        index.components.map((component) => {
+            const fields = Object.values(component.fields ?? {}).map(fieldText).filter(Boolean);
+            return {
+                component,
+                reference: component.reference,
+                value: component.value ?? "",
+                footprint: component.footprint ?? "",
+                fields: fields.join(" "),
+            };
+        }),
+        {
+            ...COMPONENT_FUSE_OPTIONS,
+            keys: [
+                { name: "reference", weight: 2 },
+                { name: "value", weight: 1.5 },
+                { name: "footprint", weight: 1 },
+                { name: "fields", weight: 1 },
+            ],
+        },
+    );
+    componentEngines.set(index, engine);
+    return engine;
+}
+
+function netEngine(index: PrismSemanticIndex): Fuse<NetRecord> {
+    const cached = netEngines.get(index);
+    if (cached) return cached;
+    const engine = new Fuse(
+        index.nets.map((net) => {
+            const aliases = netAliases(net);
+            return {
+                net,
+                name: net.name,
+                netClass: net.netClass ?? "",
+                aliases: aliases.join(" "),
+                compact: compactSearchText(net.name, ...aliases),
+                tokens: tokenSearchText(net.name, net.netClass, ...aliases),
+            };
+        }),
+        {
+            ...NET_FUSE_OPTIONS,
+            keys: [
+                { name: "name", weight: 2 },
+                { name: "compact", weight: 2 },
+                { name: "tokens", weight: 2 },
+                { name: "aliases", weight: 1.5 },
+                { name: "netClass", weight: 1 },
+            ],
+        },
+    );
+    netEngines.set(index, engine);
+    return engine;
+}
+
+function componentHit(
+    component: SemanticComponent,
+    score: number,
+    currentPage: string | null,
+): DesignSearchHit {
+    const pageLabel = pageSubtitle(component, currentPage);
+    const detail = [component.value, component.footprint, pageLabel].filter(Boolean).join(" · ");
+    return {
+        kind: "component",
+        id: `component:${component.componentUid || component.reference}`,
+        title: component.reference,
+        subtitle: detail,
+        score,
+        component,
+    };
+}
+
+function netHit(net: SemanticNet, score: number): DesignSearchHit {
+    return {
+        kind: "net",
+        id: `net:${net.netUid || net.name}`,
+        title: net.name,
+        subtitle: net.netClass ?? "",
+        score,
+        net,
+    };
+}
+
+function fuseScore(score: number | undefined): number {
+    return 1 - (score ?? 0);
+}
+
+function netAliases(net: SemanticNet): string[] {
+    return net.aliases ?? [];
+}
+
+function compactSearchText(...parts: Array<string | undefined>): string {
+    return parts
+        .map((part) => (part ?? "").toLowerCase().replace(/[^a-z0-9]+/g, ""))
+        .filter(Boolean)
+        .join(" ");
+}
+
+function tokenSearchText(...parts: Array<string | undefined>): string {
+    return parts
+        .map((part) => (part ?? "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim())
+        .filter(Boolean)
+        .join(" ");
+}
+
+function pageSubtitle(component: SemanticComponent, currentPage: string | null): string | undefined {
+    const refs = component.schematicRefs ?? [];
+    if (refs.length === 0) return undefined;
+    const onCurrent = currentPage
+        ? refs.some((reference) => pageMatches(reference.page, currentPage) || pageMatches(reference.sheetInstancePath, currentPage))
+        : false;
+    if (onCurrent) return undefined;
+    const first = refs[0];
+    const label = first.page || first.sheetInstancePath;
+    if (!label) return refs.length > 1 ? `${refs.length} pages` : undefined;
+    return refs.length > 1 ? `${label} · ${refs.length} pages` : label;
+}
+
+function preferredSchematicRef(
+    component: SemanticComponent,
+    currentPage: string | null,
+) {
+    const refs = component.schematicRefs ?? [];
+    if (currentPage) {
+        const match = refs.find((reference) =>
+            pageMatches(reference.page, currentPage) || pageMatches(reference.sheetInstancePath, currentPage)
+        );
+        if (match) return match;
+    }
+    return refs[0];
+}
+
+function pageMatches(value: string | undefined, currentPage: string): boolean {
+    if (!value) return false;
+    return value === currentPage || currentPage.endsWith(value) || value.endsWith(currentPage);
+}
+
+function fieldText(value: string | number | boolean | null | undefined): string {
+    if (value === null || value === undefined || value === "") return "";
+    return String(value);
+}

--- a/frontend/src/lib/label-instances.test.ts
+++ b/frontend/src/lib/label-instances.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    filterLabelInstances,
+    labelInstanceListLabel,
+    type LabelInstanceRef,
+} from "./label-instances";
+
+function instance(
+    partial: Partial<LabelInstanceRef> & { uuid: string; sheet: string },
+): LabelInstanceRef {
+    return {
+        name: "NET",
+        kind: "net",
+        ...partial,
+    };
+}
+
+describe("filterLabelInstances", () => {
+    const mixed: LabelInstanceRef[] = [
+        instance({ uuid: "g1", sheet: "power.kicad_sch", kind: "global" }),
+        instance({ uuid: "g2", sheet: "mcu.kicad_sch", kind: "global" }),
+        instance({ uuid: "n1", sheet: "mcu.kicad_sch", kind: "net" }),
+        instance({ uuid: "n2", sheet: "io.kicad_sch", kind: "net" }),
+        instance({ uuid: "h1", sheet: "mcu.kicad_sch", kind: "hierarchical" }),
+    ];
+
+    it("keeps every global label when a global label is selected", () => {
+        expect(filterLabelInstances(mixed, "global-label").map((row) => row.uuid)).toEqual(["g1", "g2"]);
+    });
+
+    it("keeps net labels on every sheet when a net label is selected", () => {
+        expect(filterLabelInstances(mixed, "label").map((row) => row.uuid)).toEqual(["n1", "n2"]);
+    });
+
+    it("prefers net labels for wire and search hits when both kinds have multiple instances", () => {
+        expect(filterLabelInstances(mixed, "wire").map((row) => row.uuid)).toEqual(["n1", "n2"]);
+        expect(filterLabelInstances(mixed, undefined).map((row) => row.uuid)).toEqual(["n1", "n2"]);
+    });
+
+    it("falls back to global labels when a net has no net-label instances", () => {
+        const globalsOnly = mixed.filter((row) => row.kind === "global");
+        expect(filterLabelInstances(globalsOnly, "wire").map((row) => row.uuid)).toEqual(["g1", "g2"]);
+    });
+});
+
+describe("labelInstanceListLabel", () => {
+    it("uses the sheet name when the label is unique on that sheet", () => {
+        const instances = [
+            instance({ uuid: "a", sheet: "mcu.kicad_sch" }),
+            instance({ uuid: "b", sheet: "io.kicad_sch" }),
+        ];
+        expect(labelInstanceListLabel(instances[0], instances)).toBe("mcu.kicad_sch");
+    });
+
+    it("adds an ordinal when several labels share a sheet", () => {
+        const instances = [
+            instance({ uuid: "a", sheet: "mcu.kicad_sch" }),
+            instance({ uuid: "b", sheet: "mcu.kicad_sch" }),
+            instance({ uuid: "c", sheet: "io.kicad_sch" }),
+        ];
+        expect(labelInstanceListLabel(instances[0], instances)).toBe("mcu.kicad_sch · 1");
+        expect(labelInstanceListLabel(instances[1], instances)).toBe("mcu.kicad_sch · 2");
+        expect(labelInstanceListLabel(instances[2], instances)).toBe("io.kicad_sch");
+    });
+});

--- a/frontend/src/lib/label-instances.ts
+++ b/frontend/src/lib/label-instances.ts
@@ -1,0 +1,53 @@
+/**
+ * Schematic label instances used by the Selection inspector Next/Prev control.
+ *
+ * The viewer indexes every global, net, and hierarchical label by text. Prism
+ * then keeps one kind at a time so a GND global does not mix with a local net
+ * label that happens to share the same name.
+ */
+
+export type LabelInstanceKind = "global" | "net" | "hierarchical";
+
+export interface LabelInstanceRef {
+    uuid: string;
+    sheet: string;
+    name: string;
+    kind?: LabelInstanceKind;
+}
+
+/**
+ * Pick the instance set that matches how the net was selected.
+ *
+ * Global labels stay global-only. Net labels stay net-only and are not limited
+ * to the current sheet. Wire clicks and search hits have no label item type, so
+ * we keep whichever kind actually has multiple occurrences.
+ */
+export function filterLabelInstances(
+    all: LabelInstanceRef[],
+    itemType: string | undefined,
+): LabelInstanceRef[] {
+    const type = (itemType || "").toLowerCase();
+    const globals = all.filter((instance) => instance.kind === "global");
+    const nets = all.filter((instance) => instance.kind === "net");
+
+    if (type === "global-label") return globals;
+    if (type === "label") return nets;
+
+    if (nets.length >= 2 && nets.length >= globals.length) return nets;
+    if (globals.length >= 2) return globals;
+    return nets.length ? nets : globals;
+}
+
+/**
+ * List rows are sheet names. When two labels share a sheet, append an ordinal
+ * so Next/Prev and the instance list stay distinguishable.
+ */
+export function labelInstanceListLabel(
+    instance: LabelInstanceRef,
+    instances: LabelInstanceRef[],
+): string {
+    const sameSheet = instances.filter((other) => other.sheet === instance.sheet);
+    if (sameSheet.length <= 1) return instance.sheet;
+    const ordinal = sameSheet.findIndex((other) => other.uuid === instance.uuid) + 1;
+    return `${instance.sheet} · ${ordinal}`;
+}

--- a/frontend/src/lib/shortcuts.ts
+++ b/frontend/src/lib/shortcuts.ts
@@ -132,6 +132,7 @@ export const SHORTCUT_REFERENCE: ShortcutGroupDoc[] = [
     title: "Project viewer",
     shortcuts: [
       { keys: ["1", "–", "6"], description: "Switch between Schematic, PCB, 3D, BOM, Stackup, Assembly" },
+      { keys: ["/", "–", ...shortcutKeys("mod+f")], description: "Find component or net" },
       { combo: "c", description: "Comment on the current selection" },
       { keys: ["[", "]"], description: "Previous / next schematic page" },
       { combo: "alt+backspace", description: "Go up to the parent sheet" },

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -19,6 +19,7 @@ import {
     type ProjectSection,
 } from "./project-section-cache";
 
+import { VISUALIZER_DESIGN_SEARCH_SLOT_ID } from "@/lib/design-search";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 
 const AssetsPortal = lazy(() =>
@@ -417,10 +418,26 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                     <ArrowLeft className="h-4 w-4 mr-2" />
                     Back
                 </Button>
-                <div className="flex-1">
-                    <h1 className="text-xl font-bold truncate max-w-[200px] md:max-w-none">{project ? getDisplayName(project) : ''}</h1>
-                    <p className="text-sm text-muted-foreground hidden md:block">{project?.description}</p>
+                <div className={cn("min-w-0", activeSection === "visualizers" ? "shrink-0" : "flex-1")}>
+                    <h1 className={cn(
+                        "text-xl font-bold truncate",
+                        activeSection === "visualizers" ? "max-w-[140px] md:max-w-[220px]" : "max-w-[200px] md:max-w-none",
+                    )}>
+                        {project ? getDisplayName(project) : ""}
+                    </h1>
+                    <p className={cn(
+                        "text-sm text-muted-foreground",
+                        activeSection === "visualizers" ? "hidden" : "hidden md:block",
+                    )}>
+                        {project?.description}
+                    </p>
                 </div>
+                {activeSection === "visualizers" ? (
+                    <div
+                        id={VISUALIZER_DESIGN_SEARCH_SLOT_ID}
+                        className="flex min-w-0 flex-1 justify-center px-2"
+                    />
+                ) : null}
 
                 <div className="hidden min-w-0 items-center gap-2 md:flex">
                     <GitBranch className="h-4 w-4 text-muted-foreground" />

--- a/frontend/src/types/prism-selection.ts
+++ b/frontend/src/types/prism-selection.ts
@@ -100,6 +100,7 @@ export interface SemanticNet {
     name: string;
     netCode?: number;
     netClass?: string;
+    aliases?: string[];
     schematicRefs?: SemanticSchematicRef[];
     pcbRefs?: SemanticPcbRef[];
     webgpuRefs?: SemanticWebGpuRef[];


### PR DESCRIPTION
## Problem

Reviewing a schematic or board meant hunting for a reference or net by eye, then expanding collapsed inspector sections to jump between label occurrences. The Selection inspector was also a fixed 384px overlay that took more canvas than it needed.

## Solution

- Add a Visualizer header search for components and nets (`/`, `⌘F` / `Ctrl+F`). Picking a hit cross-probes without changing tabs. `⌘K` stays the command palette.
- Open inspector Instances by default. Net labels now jump across sheets the same way as global labels. Same-sheet duplicates are numbered.
- Make the Schematic/PCB Selection inspector narrower (288px) and resizable. Comments and 3D keep the previous overlay width.

## User and operator impact

Visualizer-only review UX. No backend, config, or migration changes. Chosen inspector width is stored in `localStorage` under `prism.visualizer.selection-inspector.width`.

## Validation

- [x] Relevant frontend checks
- [ ] Relevant backend checks
- [ ] Relevant semantic-viewer checks
- [ ] Compose configuration validation
- [x] Manual verification, when needed

```bash
cd frontend && npm test -- src/lib/design-search.test.ts src/lib/label-instances.test.ts src/components/design-search-field.test.tsx src/components/viewer-overlay-rail.test.tsx src/components/ui/resizable-panel.test.tsx
cd frontend && npm run lint && npm run build
```

Manual: on Schematic/PCB, search a component and a net, jump net-label and global-label instances (including two on one sheet), resize the inspector, confirm Comments stays 384px and 3D is unchanged.

## Documentation and release

- [x] Documentation is updated or not required.
- [x] No secrets, private design data, generated output, or local caches are included.
- [x] Breaking changes and feature-freeze exceptions have explicit approval.
- [x] This branch contains one coherent change and targets `dev`.

Updated `docs/OVERVIEW.md` and `docs/PROJECT_WORKFLOWS.md` for Visualizer search and instance jumping.

## Test plan

- [ ] `/` and `⌘F`/`Ctrl+F` open Visualizer search; `⌘K` still opens the command palette
- [ ] Picking a component or net highlights it and keeps the current tab
- [ ] Inspector Instances starts open; next/prev works for global labels and net labels across sheets
- [ ] Two labels on the same sheet show as `sheet · 1` / `sheet · 2`
- [ ] Schematic/PCB inspector starts narrower and can be dragged; Comments and 3D width are unchanged


Made with [Cursor](https://cursor.com)