### PR TITLE
Stop the MPN backfill from publishing work in review

### DIFF
--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -1187,9 +1187,19 @@ class ComponentCatalogDomainService:
         *,
         manufacturer: str,
         mpn: str,
+        name: str = "",
         component_id: str = "",
         acquire_identity_lock: bool = True,
     ) -> None:
+        """Reject a second component that is indistinguishable from an existing one.
+
+        Identity is manufacturer, manufacturer part number and name together. A
+        library legitimately holds several components for one physical part --
+        symbol orientation variants, multi-part connectors split across sheets,
+        alternate footprints -- and those share a manufacturer part number by
+        definition. `name` is what separates them, so it belongs in the key;
+        without it a catalog cannot represent variants at all.
+        """
         if acquire_identity_lock:
             self._lock_component_identity(conn, manufacturer, mpn)
         existing = conn.execute(
@@ -1200,14 +1210,15 @@ class ComponentCatalogDomainService:
             WHERE component.is_active = 1
               AND lower(trim(revision.manufacturer)) = lower(trim(%s))
               AND lower(trim(revision.mpn)) = lower(trim(%s))
+              AND lower(trim(revision.name)) = lower(trim(%s))
               AND component.id <> %s
             LIMIT 1
             """,
-            (manufacturer, mpn, component_id),
+            (manufacturer, mpn, name, component_id),
         ).fetchone()
         if existing:
             raise ValueError(
-                "A component with this manufacturer and manufacturer part number already exists"
+                "A component with this manufacturer, manufacturer part number and name already exists"
             )
 
     def _component_row(self, conn: Any, component_id: str) -> dict[str, Any] | None:
@@ -3873,6 +3884,7 @@ class ComponentCatalogDomainService:
             conn,
             manufacturer=metadata["manufacturer"],
             mpn=metadata["mpn"],
+            name=metadata["name"],
             component_id=existing_component_id or "",
         )
         if existing_component_id:
@@ -4393,11 +4405,11 @@ class ComponentCatalogDomainService:
             fields[str(proposal["key"])] = {**proposal, "storage_kind": "extra", "storage_key": proposal["key"], "archived": False}
         valid_count = 0
         with self._connect() as conn:
-            identity_counts: dict[tuple[str, str], int] = {}
+            identity_counts: dict[tuple[str, str, str], int] = {}
             for raw_item in items:
                 component_id = str(raw_item.get("component_id") or "")
                 component = conn.execute(
-                    "SELECT cr.manufacturer, cr.mpn FROM components c "
+                    "SELECT cr.manufacturer, cr.mpn, cr.name FROM components c "
                     "JOIN component_revisions cr ON cr.id = c.current_revision_id "
                     "WHERE c.id = %s AND c.is_active = 1",
                     (component_id,),
@@ -4407,8 +4419,9 @@ class ComponentCatalogDomainService:
                 patch = dict(raw_item.get("patch") or {})
                 manufacturer = str(patch.get("manufacturer", component["manufacturer"]) or "").strip().casefold()
                 mpn = str(patch.get("mpn", component["mpn"]) or "").strip().casefold()
+                name = str(patch.get("name", component["name"]) or "").strip().casefold()
                 if manufacturer and mpn:
-                    identity = (manufacturer, mpn)
+                    identity = (manufacturer, mpn, name)
                     identity_counts[identity] = identity_counts.get(identity, 0) + 1
             duplicate_identities = {identity for identity, count in identity_counts.items() if count > 1}
             conn.execute(
@@ -4466,13 +4479,22 @@ class ComponentCatalogDomainService:
                             errors.append(f"{field['label']}: {required_error}")
                     target_manufacturer = normalized_patch.get("manufacturer", str(component["manufacturer"] or ""))
                     target_mpn = normalized_patch.get("mpn", str(component["mpn"] or ""))
-                    if (target_manufacturer.strip().casefold(), target_mpn.strip().casefold()) in duplicate_identities:
-                        errors.append("Multiple rows in this batch resolve to the same manufacturer and manufacturer part number")
+                    target_name = normalized_patch.get("name", str(component["name"] or ""))
+                    if (
+                        target_manufacturer.strip().casefold(),
+                        target_mpn.strip().casefold(),
+                        target_name.strip().casefold(),
+                    ) in duplicate_identities:
+                        errors.append(
+                            "Multiple rows in this batch resolve to the same manufacturer, "
+                            "manufacturer part number and name"
+                        )
                     try:
                         self._assert_component_identity_available(
                             conn,
                             manufacturer=target_manufacturer,
                             mpn=target_mpn,
+                            name=target_name,
                             component_id=component_id,
                             acquire_identity_lock=False,
                         )

--- a/scripts/backfill_database_library_mpn.py
+++ b/scripts/backfill_database_library_mpn.py
@@ -85,6 +85,7 @@ class BackfillStats:
     already_correct: int = 0
     updated: int = 0
     released: int = 0
+    repaired_in_workflow: int = 0
     skipped_not_place_ready: int = 0
     failed: int = 0
     mpn_recovered: int = 0
@@ -134,6 +135,15 @@ def _build_source_index(
 
 
 def _catalog_rows(conn: Any) -> list[dict[str, Any]]:
+    """Components that actually came from a database-library import.
+
+    Provenance is taken from the component's first revision, not its current
+    one, because repairing a component rewrites `created_by` on the revision it
+    creates -- keying off the current revision would make a second run find
+    nothing. Names are not evidence of origin: a component imported from a
+    symbol library can carry a name that happens to equal a database library's
+    part number, and repairing it would rewrite a part the library never owned.
+    """
     rows = conn.execute(
         """
         SELECT
@@ -148,8 +158,16 @@ def _catalog_rows(conn: Any) -> list[dict[str, Any]]:
         JOIN component_revisions revision ON revision.id = component.current_revision_id
         WHERE component.source = 'import'
           AND component.is_active = 1
+          AND EXISTS (
+              SELECT 1
+              FROM component_revisions origin
+              WHERE origin.component_id = component.id
+                AND origin.version = 1
+                AND origin.created_by = %s
+          )
         ORDER BY revision.name
-        """
+        """,
+        (importer.DATABASE_LIBRARY_IMPORT_ACTOR,),
     ).fetchall()
     return [dict(row) for row in rows]
 
@@ -384,15 +402,20 @@ def _repair_component(
     stats: BackfillStats,
 ) -> bool:
     component_id = str(row["component_id"])
-    place_ready, missing = _is_place_ready(service, conn, str(row["revision_id"]))
-    if not place_ready and not force:
-        stats.skipped_not_place_ready += 1
-        _record_error(
-            stats,
-            f"{row['name']}: not place-ready ({', '.join(missing) or 'unknown'}); "
-            "rerun with --force to release anyway",
-        )
-        return False
+    parent_status = str(row["release_status"] or "")
+    # Completeness only gates publishing. A component still moving through the
+    # workflow is expected to be incomplete, and its metadata is repaired without
+    # ever being released, so there is nothing here for the check to protect.
+    if parent_status == "released" and not force:
+        place_ready, missing = _is_place_ready(service, conn, str(row["revision_id"]))
+        if not place_ready:
+            stats.skipped_not_place_ready += 1
+            _record_error(
+                stats,
+                f"{row['name']}: not place-ready ({', '.join(missing) or 'unknown'}); "
+                "rerun with --force to release anyway",
+            )
+            return False
 
     revision = service._clone_revision(  # type: ignore[attr-defined]
         conn,
@@ -412,16 +435,28 @@ def _repair_component(
         actor=actor,
         now=now,
     )
-    _release_revision(
-        conn,
-        service,
-        component_id=component_id,
-        revision_id=revision_id,
-        actor=actor,
-        now=now,
-    )
+    if parent_status == "released":
+        _release_revision(
+            conn,
+            service,
+            component_id=component_id,
+            revision_id=revision_id,
+            actor=actor,
+            now=now,
+        )
+        stats.released += 1
+    else:
+        # Work that was still moving through the workflow keeps moving. Publishing
+        # it here would bypass whatever review it was waiting on, and the clone
+        # carries the author's content forward, so the only thing to preserve is
+        # the stage it was sitting at. `_clone_revision` demotes `done` to
+        # `in_progress`, so the stage is restored explicitly rather than inherited.
+        conn.execute(
+            "UPDATE component_revisions SET release_status = %s, updated_at = %s WHERE id = %s",
+            (parent_status, now, revision_id),
+        )
+        stats.repaired_in_workflow += 1
     stats.updated += 1
-    stats.released += 1
     return True
 
 

--- a/scripts/import_database_library.py
+++ b/scripts/import_database_library.py
@@ -119,6 +119,11 @@ class ImportStats:
     mpn_fallback: int = 0
 
 
+# Actor recorded on revisions this importer creates. Downstream tooling uses it
+# to tell components that came from a database library apart from components
+# that merely share a name with one.
+DATABASE_LIBRARY_IMPORT_ACTOR = "system:import_database_library"
+
 # The database library carries the real manufacturer part number in its own
 # column; the "Part Number" column is the library's internal part number. Older
 # imports wrote the internal number into `mpn`, which made every component
@@ -417,7 +422,7 @@ def _insert_import_component(
             summary, keywords, extra_fields, search_document, created_at, updated_at
         )
         VALUES (
-            %s, %s, 1, '', 'import', 'Imported from database library', 'system:import_database_library',
+            %s, %s, 1, '', 'import', 'Imported from database library', %s,
             '', %s, 'open', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s, %s, %s
         )
@@ -425,6 +430,7 @@ def _insert_import_component(
         (
             revision_id,
             component_id,
+            DATABASE_LIBRARY_IMPORT_ACTOR,
             REVISION_MANIFEST_A2,
             metadata["name"],
             metadata["value"],
@@ -767,7 +773,7 @@ def _import_plans(
         service._ensure_extra_field_definitions(  # type: ignore[attr-defined]
             target_conn,
             sorted(discovered_keys),
-            actor="system:import_database_library",
+            actor=DATABASE_LIBRARY_IMPORT_ACTOR,
         )
 
     for plan in plans:


### PR DESCRIPTION
Follow-up to #162, from running it on the live workstation catalog.

## What happened

The backfill releases whatever it repairs. On my test catalog every component was already released, so that was invisible. On the deployed catalog it was not: a revision sitting in **`qa_review`** got published, bypassing the review it was waiting on.

```
TL1431MDREP
 v1  released     system:import_footprint_library
 v2  in_progress  catalog-repair
 v3  in_progress  rajesh@…
 v4  in_progress  rajesh@…
 v5  qa_review    rajesh@…                              ← submitted for review
 v6  released     system:backfill_database_library_mpn  ← published over it
```

Already reverted in place on the deployment (`v6` back to `qa_review`, `released_revision_id` restored to `v1`). This PR fixes the causes.

## Three faults

**1. Matching by name.** `TL1431MDREP`'s v1 is `system:import_footprint_library` — it is not a database-library component at all. It was repaired purely because its name equals a CERN `Part Number`. Provenance now comes from the component's **first** revision.

Reading provenance from the *current* revision would have been the obvious thing and would have been wrong: repairing a component rewrites `created_by` on the revision it creates, so a second run would match nothing. Verified idempotent — a re-run against the repaired catalog still finds all 23,969 and reports them already correct.

**2. Publishing unconditionally.** Release is now conditional on the parent revision already being `released`. Anything mid-workflow keeps its stage. The clone carries the author's content forward, so the stage is the only thing that needs preserving — and it is set explicitly, because `_clone_revision` demotes `done` to `in_progress` rather than preserving it.

**3. Completeness gating the wrong thing.** The place-ready check now applies only when publishing. A component in the workflow is *expected* to be incomplete. Four in-progress drafts missing symbols were skipped outright on the live run; they will now have their metadata repaired without being published.

## Component identity

Separate but surfaced by the same run. `_assert_component_identity_available` enforced uniqueness on `(manufacturer, mpn)`. That invariant only ever held **by accident** — because `mpn` contained an internal part number, which is unique.

Real manufacturer part numbers are not unique. A component library holds several components per physical part, and they share an MPN by definition:

```
CIRRUS LOGIC/APEX  PA94          x6   PA94_h, PA94_hflip, PA94_v …
HARWIN             D01-9922046   x5   D01-9922046_1OF20, _8OF20 …
```

**3,894 collisions** on the deployed catalog, every one unable to be edited through Library Manager or the metadata-batch path. Identity is now `(manufacturer, mpn, name)`. The batch path's in-batch duplicate detection is widened to match, so the two cannot disagree.

## Verification

Against a repaired 24k catalog:

| check | before | after |
|---|---|---|
| symbol-library components considered | 2 (matched by name) | **0** |
| re-run on repaired catalog | 23,969 already correct | 23,969 already correct — idempotency holds |
| `qa_review` component | repaired **and released** | repaired, left `qa_review`, released head untouched (`released: 0`, `repaired_in_workflow: 1`) |
| identical `(mfr, mpn, name)` | rejected | rejected |
| same `(mfr, mpn)`, different name | **rejected** | allowed |
| same `(mfr, name)`, different mpn | allowed | allowed |

New `repaired_in_workflow` counter in the report distinguishes repaired-and-published from repaired-in-place.