### PR TITLE
Make the component workspace asset flows hold up at library scale

### DIFF
--- a/backend/app/api/catalog_admin.py
+++ b/backend/app/api/catalog_admin.py
@@ -1533,12 +1533,14 @@ async def import_inventory_csv(
 @router.get("/assets/browse")
 def browse_library_assets(
     asset_type: str = Query(...),
+    q: str = Query("", max_length=200),
+    limit: int = Query(50, ge=1, le=500),
     user: AuthenticatedUser = Depends(require_catalog_writer),
 ):
     _ = user
     try:
-        files = catalog_service.browse_library_assets(asset_type)
-        return {"files": files}
+        result = catalog_service.browse_library_assets(asset_type, q=q, limit=limit)
+        return {"files": result["files"], "total": result["total"]}
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -34,6 +34,10 @@ DEFAULT_STORE_DIRNAME = ".kicad-prism"
 DBL_EXPORT_DIRNAME = "kicad-dbl"
 KLC_VALIDATION_DIRNAME = "klc"
 
+# The asset browser reuses one sorted directory walk per asset type for this
+# long, so repeated dialog opens do not rescan the whole store.
+_ASSET_BROWSE_CACHE_TTL_SECONDS = 30.0
+
 PREVIEW_KIND_SYMBOL = "symbol"
 PREVIEW_KIND_FOOTPRINT = "footprint"
 PREVIEW_STATUS_READY = "ready"
@@ -512,6 +516,8 @@ class ComponentCatalogDomainService:
         self._category_cache_ts: float = 0.0
         self._CATEGORY_CACHE_TTL: float = 60.0
         self._fts_available = False
+        self._browse_cache: dict[str, tuple[float, list[str]]] = {}
+        self._browse_cache_lock = threading.Lock()
 
     def _database_path(self, database_url: str | None) -> Path:
         _ = database_url
@@ -5766,18 +5772,42 @@ class ComponentCatalogDomainService:
             conn.commit()
         return {"updated": updated, "not_found": not_found, "errors": errors}
 
-    def browse_library_assets(self, asset_type: str) -> list[str]:
+    def browse_library_assets(
+        self,
+        asset_type: str,
+        q: str = "",
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """List stored asset files without walking the store on every request.
+
+        The recursive walk over the symbol/footprint trees is expensive once
+        libraries hold thousands of files, so the sorted listing is cached per
+        asset type and reused across requests. ``q`` filters the cached listing
+        and ``limit`` bounds the response so the picker never renders the whole
+        store.
+        """
         self.initialize()
         root = self._asset_root(asset_type)
-        if asset_type == "symbol":
-            paths = root.rglob("*.kicad_sym")
-        elif asset_type == "footprint":
-            paths = root.rglob("*.kicad_mod")
-        elif asset_type == "3dmodel":
-            paths = [*root.rglob("*.step"), *root.rglob("*.stp")]
-        else:
-            paths = root.rglob("*")
-        return sorted(path.relative_to(root).as_posix() for path in paths if path.is_file())
+        now = time.monotonic()
+        with self._browse_cache_lock:
+            cached = self._browse_cache.get(asset_type)
+            if cached is None or now - cached[0] > _ASSET_BROWSE_CACHE_TTL_SECONDS:
+                if asset_type == "symbol":
+                    paths = root.rglob("*.kicad_sym")
+                elif asset_type == "footprint":
+                    paths = root.rglob("*.kicad_mod")
+                elif asset_type == "3dmodel":
+                    paths = [*root.rglob("*.step"), *root.rglob("*.stp")]
+                else:
+                    paths = root.rglob("*")
+                files = sorted(path.relative_to(root).as_posix() for path in paths if path.is_file())
+                self._browse_cache[asset_type] = (now, files)
+                all_files = files
+            else:
+                all_files = cached[1]
+        needle = q.strip().lower()
+        matches = [path for path in all_files if needle in path.lower()] if needle else list(all_files)
+        return {"files": matches[: max(1, limit)], "total": len(matches)}
 
     def _attach_asset_revision(
         self,

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -517,7 +517,15 @@ class ComponentCatalogDomainService:
         self._CATEGORY_CACHE_TTL: float = 60.0
         self._fts_available = False
         self._browse_cache: dict[str, tuple[float, list[str]]] = {}
+        # One lock per asset type. Walking the footprint tree takes seconds on a
+        # large store, and a shared lock would make that block a symbol browse
+        # that could have been answered from cache. Serializing within a type is
+        # still wanted: it collapses a burst of concurrent misses into one walk.
+        self._browse_cache_locks: dict[str, threading.Lock] = {}
         self._browse_cache_lock = threading.Lock()
+        # Bumped on every store write so a walk that started before it does not
+        # reinstate the listing it took.
+        self._browse_cache_generation = 0
 
     def _database_path(self, database_url: str | None) -> Path:
         _ = database_url
@@ -2876,6 +2884,14 @@ class ComponentCatalogDomainService:
         `revision_assets` is a join table onto content-addressed `assets`, so linking
         an existing row is a genuine reference: one 0603 footprint is shared by every
         component that uses it rather than duplicated per import.
+
+        Ordering by usage means the counts have to exist before LIMIT can apply, which
+        costs an aggregate over every matching asset. That is affordable once a search
+        term has narrowed the set, but not for the empty query the picker fires the
+        moment it opens: on a store of ~17k assets that aggregate reads the whole
+        revision_assets join and took ~500ms. The unfiltered listing therefore orders
+        by the columns idx_assets_kind already covers and counts usage only for the
+        page it returns.
         """
         self.initialize()
         normalized_type = str(asset_type or "").strip().lower()
@@ -2886,36 +2902,50 @@ class ComponentCatalogDomainService:
         like = f"%{term.lower()}%"
         bounded_limit = max(1, min(int(limit or 25), 100))
 
+        usage_count_lateral = """
+            LEFT JOIN LATERAL (
+                SELECT COUNT(DISTINCT c.id) AS usage_count
+                FROM revision_assets ra
+                JOIN component_revisions r ON r.id = ra.revision_id
+                JOIN components c ON c.id = r.component_id AND c.is_active = 1
+                WHERE ra.asset_id = a.id
+            ) usage_stats ON true
+        """
+
         with self._connect() as conn:
-            rows = conn.execute(
-                """
-                SELECT
-                    a.id,
-                    a.asset_type,
-                    a.name,
-                    a.target_library,
-                    a.target_name,
-                    a.sha256,
-                    a.size_bytes,
-                    COUNT(DISTINCT c.id) AS usage_count
-                FROM assets a
-                LEFT JOIN revision_assets ra ON ra.asset_id = a.id
-                LEFT JOIN component_revisions r ON r.id = ra.revision_id
-                LEFT JOIN components c ON c.id = r.component_id AND c.is_active = 1
-                WHERE a.asset_type = %s
-                  AND (
-                    %s = ''
-                    OR lower(a.name) LIKE %s
-                    OR lower(a.target_name) LIKE %s
-                    OR lower(a.target_library) LIKE %s
-                  )
-                GROUP BY a.id, a.asset_type, a.name, a.target_library, a.target_name,
-                         a.sha256, a.size_bytes
-                ORDER BY usage_count DESC, lower(a.target_name), a.name
-                LIMIT %s
-                """,
-                (normalized_type, term.lower(), like, like, like, bounded_limit),
-            ).fetchall()
+            if term:
+                rows = conn.execute(
+                    f"""
+                    SELECT
+                        a.id, a.asset_type, a.name, a.target_library, a.target_name,
+                        a.sha256, a.size_bytes, usage_stats.usage_count
+                    FROM assets a
+                    {usage_count_lateral}
+                    WHERE a.asset_type = %s
+                      AND (
+                        lower(a.name) LIKE %s
+                        OR lower(a.target_name) LIKE %s
+                        OR lower(a.target_library) LIKE %s
+                      )
+                    ORDER BY usage_stats.usage_count DESC, lower(a.target_name), a.name
+                    LIMIT %s
+                    """,
+                    (normalized_type, like, like, like, bounded_limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    f"""
+                    SELECT
+                        a.id, a.asset_type, a.name, a.target_library, a.target_name,
+                        a.sha256, a.size_bytes, usage_stats.usage_count
+                    FROM assets a
+                    {usage_count_lateral}
+                    WHERE a.asset_type = %s
+                    ORDER BY a.target_library, a.target_name, a.name
+                    LIMIT %s
+                    """,
+                    (normalized_type, bounded_limit),
+                ).fetchall()
 
         return [
             {
@@ -5772,6 +5802,23 @@ class ComponentCatalogDomainService:
             conn.commit()
         return {"updated": updated, "not_found": not_found, "errors": errors}
 
+    def _browse_cache_lock_for(self, asset_type: str) -> threading.Lock:
+        with self._browse_cache_lock:
+            return self._browse_cache_locks.setdefault(asset_type, threading.Lock())
+
+    def _invalidate_browse_cache(self) -> None:
+        """Drop the stored-file listings after the store on disk changes.
+
+        Called from the one place bytes land in the store, so the asset picker
+        never offers a file that has just been rewritten elsewhere, nor hides
+        one that has just arrived. Clearing every type is deliberate: the
+        listings are rebuilt lazily on the next browse, and a write does not
+        reliably tell us which tree it touched.
+        """
+        with self._browse_cache_lock:
+            self._browse_cache.clear()
+            self._browse_cache_generation += 1
+
     def browse_library_assets(
         self,
         asset_type: str,
@@ -5784,13 +5831,16 @@ class ComponentCatalogDomainService:
         libraries hold thousands of files, so the sorted listing is cached per
         asset type and reused across requests. ``q`` filters the cached listing
         and ``limit`` bounds the response so the picker never renders the whole
-        store.
+        store. Writes into the store drop the cache, so the TTL is a backstop
+        for changes made outside this process rather than the freshness bound.
         """
         self.initialize()
         root = self._asset_root(asset_type)
         now = time.monotonic()
-        with self._browse_cache_lock:
-            cached = self._browse_cache.get(asset_type)
+        with self._browse_cache_lock_for(asset_type):
+            with self._browse_cache_lock:
+                cached = self._browse_cache.get(asset_type)
+                generation = self._browse_cache_generation
             if cached is None or now - cached[0] > _ASSET_BROWSE_CACHE_TTL_SECONDS:
                 if asset_type == "symbol":
                     paths = root.rglob("*.kicad_sym")
@@ -5801,7 +5851,13 @@ class ComponentCatalogDomainService:
                 else:
                     paths = root.rglob("*")
                 files = sorted(path.relative_to(root).as_posix() for path in paths if path.is_file())
-                self._browse_cache[asset_type] = (now, files)
+                with self._browse_cache_lock:
+                    # A write that landed while this walk was running already
+                    # cleared the cache. Storing the result now would reinstate a
+                    # listing taken before that write and hide it for a full TTL,
+                    # so leave the cache empty and let the next browse rebuild it.
+                    if self._browse_cache_generation == generation:
+                        self._browse_cache[asset_type] = (now, files)
                 all_files = files
             else:
                 all_files = cached[1]
@@ -5977,8 +6033,10 @@ class ComponentCatalogDomainService:
                     raise ValueError(f"Immutable asset hash collision at {immutable_destination}")
                 return immutable_destination
             immutable_destination.write_bytes(payload)
+            self._invalidate_browse_cache()
             return immutable_destination
         destination.write_bytes(payload)
+        self._invalidate_browse_cache()
         return destination
 
     def _symbol_destination(self, target_library: str, target_name: str) -> Path:

--- a/backend/app/services/component_catalog_service_postgres.py
+++ b/backend/app/services/component_catalog_service_postgres.py
@@ -21,7 +21,7 @@ CATALOG_SCHEMA_EPOCH = "2"
 
 # Derived state. Each is rebuilt when its version changes, so these deliberately
 # stay outside the migration ladder, which records a migration as run once.
-POSTGRES_SEARCH_VERSION = "catalog-search-v2"
+POSTGRES_SEARCH_VERSION = "catalog-search-v3"
 POSTGRES_INTEGRITY_GUARDS_VERSION = "catalog-integrity-guards-v4"
 POSTGRES_HEAD_PROJECTION_VERSION = "catalog-component-heads-v5"
 POSTGRES_REMOTE_HEAD_PROJECTION_VERSION = "catalog-remote-heads-v4"
@@ -772,6 +772,27 @@ class ComponentCatalogPostgresService(ComponentCatalogDomainService):
                     "CREATE INDEX IF NOT EXISTS idx_remote_heads_mpn_trgm "
                     "ON remote_component_heads USING GIN (lower(mpn) gin_trgm_ops)"
                 )
+                # The asset link picker searches with leading wildcards, which no
+                # btree index can serve, so without these it sequentially scans
+                # every asset on each keystroke.
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_assets_name_trgm "
+                    "ON assets USING GIN (lower(name) gin_trgm_ops)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_assets_target_name_trgm "
+                    "ON assets USING GIN (lower(target_name) gin_trgm_ops)"
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_assets_target_library_trgm "
+                    "ON assets USING GIN (lower(target_library) gin_trgm_ops)"
+                )
+                # A new index is invisible to the planner until the table has
+                # statistics that justify it: measured on ~17k assets, the search
+                # kept seq scanning until this ran, then dropped from 27ms to
+                # under 1ms. Waiting for autovacuum would leave every deploy slow
+                # for as long as that takes to come around.
+                conn.execute("ANALYZE assets")
                 conn.execute(
                     """
                     INSERT INTO catalog_meta (key, value) VALUES (%s, %s)

--- a/backend/tests/test_catalog_asset_browse.py
+++ b/backend/tests/test_catalog_asset_browse.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import inspect
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 from fastapi import HTTPException
@@ -134,22 +136,16 @@ class AssetBrowseListingTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.service.browse_library_assets("gerber")
 
-    def test_listing_is_served_from_cache_until_the_ttl_lapses(self) -> None:
-        """Files written after a listing stay invisible for the cache window.
-
-        This is the known cost of not rescanning the store per request: there
-        is no invalidation hook on the asset write paths, so a freshly stored
-        file is missing from the picker until the entry ages out.
-        """
+    def test_repeat_calls_are_served_from_cache(self) -> None:
+        """The whole point of the cache: one walk serves the keystrokes after it."""
         self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
         self.assertEqual(self.service.browse_library_assets("symbol")["total"], 1)
 
-        self._write("symbol", "Sensors/OPA187.kicad_sym")
-        self.assertEqual(
-            self.service.browse_library_assets("symbol")["total"],
-            1,
-            "a second call inside the TTL must not pay for another store walk",
-        )
+        # Slipped in behind the cache, without going through the write path that
+        # invalidates it, so a second call must not have paid for another walk.
+        stray = self.service._asset_root("symbol") / "Sensors" / "OPA187.kicad_sym"
+        stray.write_text("(kicad_symbol_lib)", encoding="utf-8")
+        self.assertEqual(self.service.browse_library_assets("symbol")["total"], 1)
 
         cached_at, files = self.service._browse_cache["symbol"]
         self.service._browse_cache["symbol"] = (
@@ -157,9 +153,102 @@ class AssetBrowseListingTests(unittest.TestCase):
             files,
         )
 
+        # The TTL remains the backstop for changes made outside this process.
         refreshed = self.service.browse_library_assets("symbol")
         self.assertEqual(refreshed["total"], 2)
         self.assertIn("Sensors/OPA187.kicad_sym", refreshed["files"])
+
+    def test_storing_a_file_makes_it_listable_immediately(self) -> None:
+        """A file written through the store shows up on the next browse.
+
+        Without this the picker offers a stale listing for a full TTL: a
+        just-imported symbol is missing, and a file the store has replaced is
+        still offered and then fails at link time.
+        """
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+        self.assertEqual(self.service.browse_library_assets("symbol")["total"], 1)
+
+        destination = self.service._asset_root("symbol") / "Sensors" / "OPA187.kicad_sym"
+        self.service._write_canonical_file(destination, b"(kicad_symbol_lib)")
+
+        listing = self.service.browse_library_assets("symbol")
+        self.assertEqual(listing["total"], 2)
+        self.assertIn("Sensors/OPA187.kicad_sym", listing["files"])
+
+    def test_a_write_during_a_walk_does_not_reinstate_the_old_listing(self) -> None:
+        """A walk that started before a write must not cache its stale result.
+
+        Otherwise the invalidation is silently undone and the new file stays
+        hidden for a full TTL — the exact window the write hook exists to close.
+        """
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+        real_rglob = Path.rglob
+
+        def write_midway(self_path: Path, pattern: str):  # type: ignore[no-untyped-def]
+            results = list(real_rglob(self_path, pattern))
+            # Stand in for another request storing a file while this walk runs.
+            destination = service._asset_root("symbol") / "Sensors" / "OPA187.kicad_sym"
+            destination.write_bytes(b"(kicad_symbol_lib)")
+            service._invalidate_browse_cache()
+            return iter(results)
+
+        service = self.service
+        with patch.object(Path, "rglob", write_midway):
+            stale = service.browse_library_assets("symbol")
+        self.assertEqual(stale["total"], 1)
+        self.assertNotIn("symbol", service._browse_cache)
+
+        # Nothing was cached, so the next browse walks again and sees the write.
+        self.assertEqual(service.browse_library_assets("symbol")["total"], 2)
+
+    def test_one_asset_type_does_not_block_another(self) -> None:
+        """A slow footprint walk must not hold up a cached symbol listing.
+
+        The store walk takes seconds on a large library; behind a single shared
+        lock that latency would land on every picker rather than the one type
+        actually being rescanned.
+        """
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+        self._write("footprint", "SMD/SOT65P210X110-5N.kicad_mod")
+        self.service.browse_library_assets("symbol")  # warm the symbol entry
+
+        release = threading.Event()
+        walking = threading.Event()
+        real_rglob = Path.rglob
+
+        def block_footprints(self_path: Path, pattern: str):  # type: ignore[no-untyped-def]
+            if pattern == "*.kicad_mod":
+                walking.set()
+                release.wait(timeout=5)
+            return real_rglob(self_path, pattern)
+
+        symbols: dict[str, Any] = {}
+        served = threading.Event()
+
+        def read_symbols() -> None:
+            symbols.update(self.service.browse_library_assets("symbol"))
+            served.set()
+
+        with patch.object(Path, "rglob", block_footprints):
+            slow = threading.Thread(target=self.service.browse_library_assets, args=("footprint",))
+            slow.start()
+            try:
+                self.assertTrue(walking.wait(timeout=5), "footprint walk never started")
+                reader = threading.Thread(target=read_symbols)
+                reader.start()
+                # The assertion that matters: the symbol read completes *while*
+                # the footprint walk is still parked. Under a single shared lock
+                # it would sit here until the walk released, and time out.
+                self.assertTrue(
+                    served.wait(timeout=2),
+                    "a cached symbol listing waited on an unrelated footprint walk",
+                )
+                self.assertEqual(symbols["total"], 1)
+            finally:
+                release.set()
+                slow.join(timeout=5)
+                reader.join(timeout=5)
+        self.assertFalse(slow.is_alive())
 
     def test_each_asset_type_is_cached_independently(self) -> None:
         self._write("symbol", "Sensors/LMT86DCK.kicad_sym")

--- a/backend/tests/test_catalog_asset_browse.py
+++ b/backend/tests/test_catalog_asset_browse.py
@@ -1,0 +1,228 @@
+"""Coverage for the stored-asset browser behind the "Link existing" picker.
+
+The picker sends `q` and `limit` and renders `{files, total}`; nothing else
+pins that contract, so these tests cover the filtering, the response shape,
+and the cache window the listing is served from.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.api import catalog_admin  # noqa: E402
+from app.core.security import AuthenticatedUser  # noqa: E402
+from app.services.component_catalog_domain import (  # noqa: E402
+    _ASSET_BROWSE_CACHE_TTL_SECONDS,
+    ComponentCatalogDomainService,
+)
+
+
+class _FilesystemOnlyCatalogService(ComponentCatalogDomainService):
+    """browse_library_assets reads the store on disk and nothing else.
+
+    The base class routes initialize() to the Postgres subclass, but the
+    browser never touches the database, so creating the store directories is
+    the whole of the setup it needs.
+    """
+
+    def initialize(self) -> None:
+        self._ensure_storage_dirs()
+
+
+class AssetBrowseListingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.store = Path(self.tempdir.name) / "components"
+        self.service = _FilesystemOnlyCatalogService(store_root=self.store)
+        self.service.initialize()
+
+    def _write(self, asset_type: str, relative_path: str) -> Path:
+        path = self.service._asset_root(asset_type) / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("(kicad_symbol_lib)", encoding="utf-8")
+        return path
+
+    def test_listing_is_sorted_and_scoped_to_the_asset_type(self) -> None:
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+        self._write("symbol", "Amplifiers/OPA187.kicad_sym")
+        self._write("symbol", "Sensors/notes.txt")
+        self._write("footprint", "SMD/SOT65P210X110-5N.kicad_mod")
+
+        symbols = self.service.browse_library_assets("symbol")
+
+        # Sorted, store-relative, POSIX, and nothing that is not a symbol file.
+        self.assertEqual(
+            symbols["files"],
+            ["Amplifiers/OPA187.kicad_sym", "Sensors/LMT86DCK.kicad_sym"],
+        )
+        self.assertEqual(symbols["total"], 2)
+
+        footprints = self.service.browse_library_assets("footprint")
+        self.assertEqual(footprints["files"], ["SMD/SOT65P210X110-5N.kicad_mod"])
+
+    def test_three_d_models_cover_both_step_extensions(self) -> None:
+        self._write("3dmodel", "Sensors/LMT86DCKT.step")
+        self._write("3dmodel", "Sensors/OPA187.stp")
+        self._write("3dmodel", "Sensors/readme.md")
+
+        result = self.service.browse_library_assets("3dmodel")
+
+        self.assertEqual(
+            result["files"], ["Sensors/LMT86DCKT.step", "Sensors/OPA187.stp"]
+        )
+
+    def test_query_matches_the_whole_relative_path_case_insensitively(self) -> None:
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+        self._write("symbol", "Amplifiers/OPA187.kicad_sym")
+
+        # Case folds both ways.
+        self.assertEqual(
+            self.service.browse_library_assets("symbol", q="lmt86")["files"],
+            ["Sensors/LMT86DCK.kicad_sym"],
+        )
+        # The directory is part of the haystack, not just the file name.
+        self.assertEqual(
+            self.service.browse_library_assets("symbol", q="AMPLIFIERS/")["files"],
+            ["Amplifiers/OPA187.kicad_sym"],
+        )
+        # Surrounding whitespace is trimmed rather than failing every match.
+        self.assertEqual(
+            self.service.browse_library_assets("symbol", q="  opa  ")["files"],
+            ["Amplifiers/OPA187.kicad_sym"],
+        )
+        # A blank query is not a filter.
+        self.assertEqual(self.service.browse_library_assets("symbol", q="   ")["total"], 2)
+
+    def test_no_match_returns_an_empty_page_rather_than_everything(self) -> None:
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+
+        result = self.service.browse_library_assets("symbol", q="no-such-part")
+
+        self.assertEqual(result["files"], [])
+        self.assertEqual(result["total"], 0)
+
+    def test_limit_caps_the_page_while_total_counts_every_match(self) -> None:
+        for index in range(5):
+            self._write("symbol", f"Sensors/PART{index}.kicad_sym")
+
+        page = self.service.browse_library_assets("symbol", limit=2)
+
+        # total is what the footer counts down from, so it must survive the cap.
+        self.assertEqual(page["files"], ["Sensors/PART0.kicad_sym", "Sensors/PART1.kicad_sym"])
+        self.assertEqual(page["total"], 5)
+
+        # The cap applies after filtering, not before it.
+        filtered = self.service.browse_library_assets("symbol", q="PART3", limit=2)
+        self.assertEqual(filtered["files"], ["Sensors/PART3.kicad_sym"])
+        self.assertEqual(filtered["total"], 1)
+
+        # A limit past the end is not an error and does not pad.
+        everything = self.service.browse_library_assets("symbol", limit=500)
+        self.assertEqual(len(everything["files"]), 5)
+
+    def test_unsupported_asset_type_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self.service.browse_library_assets("gerber")
+
+    def test_listing_is_served_from_cache_until_the_ttl_lapses(self) -> None:
+        """Files written after a listing stay invisible for the cache window.
+
+        This is the known cost of not rescanning the store per request: there
+        is no invalidation hook on the asset write paths, so a freshly stored
+        file is missing from the picker until the entry ages out.
+        """
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+        self.assertEqual(self.service.browse_library_assets("symbol")["total"], 1)
+
+        self._write("symbol", "Sensors/OPA187.kicad_sym")
+        self.assertEqual(
+            self.service.browse_library_assets("symbol")["total"],
+            1,
+            "a second call inside the TTL must not pay for another store walk",
+        )
+
+        cached_at, files = self.service._browse_cache["symbol"]
+        self.service._browse_cache["symbol"] = (
+            cached_at - _ASSET_BROWSE_CACHE_TTL_SECONDS - 1,
+            files,
+        )
+
+        refreshed = self.service.browse_library_assets("symbol")
+        self.assertEqual(refreshed["total"], 2)
+        self.assertIn("Sensors/OPA187.kicad_sym", refreshed["files"])
+
+    def test_each_asset_type_is_cached_independently(self) -> None:
+        self._write("symbol", "Sensors/LMT86DCK.kicad_sym")
+        self.service.browse_library_assets("symbol")
+
+        # Warming symbols must not make footprints answer from the wrong entry.
+        self._write("footprint", "SMD/SOT65P210X110-5N.kicad_mod")
+        self.assertEqual(
+            self.service.browse_library_assets("footprint")["files"],
+            ["SMD/SOT65P210X110-5N.kicad_mod"],
+        )
+
+
+class AssetBrowseEndpointTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.user = AuthenticatedUser(
+            email="designer@example.com", name="Designer", role="designer"
+        )
+
+    def test_search_and_limit_reach_the_service_and_totals_reach_the_client(self) -> None:
+        listing = {"files": ["Sensors/LMT86DCK.kicad_sym"], "total": 41}
+        with patch.object(
+            catalog_admin.catalog_service, "browse_library_assets", return_value=listing
+        ) as browse:
+            response = catalog_admin.browse_library_assets(
+                asset_type="symbol", q="lmt", limit=25, user=self.user
+            )
+
+        browse.assert_called_once_with("symbol", q="lmt", limit=25)
+        # The picker needs total to say "showing 1 of 41"; dropping it would
+        # silently present a capped page as the whole store.
+        self.assertEqual(response, {"files": ["Sensors/LMT86DCK.kicad_sym"], "total": 41})
+
+    def test_service_failures_surface_as_400(self) -> None:
+        with patch.object(
+            catalog_admin.catalog_service,
+            "browse_library_assets",
+            side_effect=ValueError("Unsupported asset type"),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                catalog_admin.browse_library_assets(
+                    asset_type="gerber", q="", limit=50, user=self.user
+                )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertEqual(raised.exception.detail, "Unsupported asset type")
+
+    def test_query_and_limit_are_bounded_at_the_route(self) -> None:
+        """The caps are the only thing keeping a crafted request from asking
+        for the whole store, so pin them rather than the defaults alone."""
+        parameters = inspect.signature(catalog_admin.browse_library_assets).parameters
+        limit = parameters["limit"].default
+        query = parameters["q"].default
+
+        self.assertEqual(limit.default, 50)
+        limit_bounds = {type(item).__name__: item for item in limit.metadata}
+        self.assertEqual(limit_bounds["Ge"].ge, 1)
+        self.assertEqual(limit_bounds["Le"].le, 500)
+
+        self.assertEqual(query.default, "")
+        query_bounds = {type(item).__name__: item for item in query.metadata}
+        self.assertEqual(query_bounds["MaxLen"].max_length, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,12 +6,13 @@ import { Toaster } from 'sonner';
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
 import { ApiHttpError, fetchApi } from '@/lib/api';
-import { fetchAuthConfig, fetchCurrentUser, isAuthCallbackPath } from '@/lib/auth';
+import { fetchAuthConfig, fetchCurrentUser, isAuthCallbackPath, stashCurrentLocation } from '@/lib/auth';
 import { IS_APPLE_PLATFORM } from '@/lib/shortcuts';
 import { useHotkeys } from '@/hooks/use-hotkeys';
 import { CommandPalette } from '@/components/command-palette';
 import { KeyboardShortcutsDialog } from '@/components/keyboard-shortcuts-dialog';
 import { RoleAuthorityPopover } from '@/components/role-authority-popover';
+import { SessionExpiredBanner, SESSION_BANNER_HEIGHT } from '@/components/session-expired-banner';
 import prismLogoMark from './assets/branding/kicad-prism/kicad-prism-icon.svg';
 
 const LoginPage = lazy(() =>
@@ -53,6 +54,9 @@ function App() {
     const isAuthCallbackRoute = typeof window !== "undefined" && isAuthCallbackPath();
     const [paletteOpen, setPaletteOpen] = useState(false);
     const [shortcutsOpen, setShortcutsOpen] = useState(false);
+    // Set when a data endpoint 401s mid-session. The app stays mounted so the
+    // user keeps their context; the banner routes them through sign-in.
+    const [sessionExpired, setSessionExpired] = useState(false);
 
     /**
      * Screens mark their own search box with `data-shortcut-search`. "/" focuses
@@ -130,6 +134,14 @@ function App() {
             const customEvent = event as CustomEvent<{ status?: number; url?: string }>;
             const status = customEvent.detail?.status;
             const url = customEvent.detail?.url ?? "";
+            if (status === 401 && !url.includes('/api/auth/')) {
+                // A data endpoint rejected the session mid-work. Do not tear the
+                // workspace down: stash the current URL so sign-in returns here,
+                // and let the session-expired banner explain what happened.
+                stashCurrentLocation();
+                setSessionExpired(true);
+                return;
+            }
             if (status === 401) {
                 setUser(null);
                 return;
@@ -146,12 +158,14 @@ function App() {
         void fetchApi('/api/auth/logout', { method: 'POST' }).finally(() => {
             setUser(null);
             setAuthError(null);
+            setSessionExpired(false);
         });
     };
 
     const handleAuthCodeSuccess = (currentUser: User) => {
         setUser(currentUser);
         setAuthError(null);
+        setSessionExpired(false);
     };
 
     // Show loading state while fetching auth config
@@ -184,6 +198,7 @@ function App() {
                     onLoginSuccess={(signedIn) => {
                         setUser(signedIn);
                         setAuthError(null);
+                        setSessionExpired(false);
                     }}
                 />
             </Suspense>
@@ -197,6 +212,22 @@ function App() {
     // User is authenticated or auth is disabled - show app
     return (
         <BrowserRouter>
+            {/* The banner sits in normal flow and route layouts subtract its
+                height through --app-chrome-offset, so it never covers the
+                sticky header underneath it. */}
+            <div
+                style={sessionExpired
+                    ? ({ '--app-chrome-offset': SESSION_BANNER_HEIGHT } as React.CSSProperties)
+                    : undefined}
+            >
+            {sessionExpired ? (
+                <SessionExpiredBanner
+                    authConfig={authConfig}
+                    email={user.email}
+                    onReauthenticated={(restored) => { setUser(restored); setSessionExpired(false); }}
+                    onFullSignIn={() => { stashCurrentLocation(); setUser(null); }}
+                />
+            ) : null}
             <Toaster richColors position="top-right" />
             <CommandPalette
                 open={paletteOpen}
@@ -208,7 +239,7 @@ function App() {
             <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
             <Routes>
                 <Route path="/" element={
-                    <div className="min-h-screen bg-background text-foreground">
+                    <div className="min-h-app-viewport bg-background text-foreground">
                         <header className="border-b sticky top-0 bg-background/95 backdrop-blur z-10">
                             <div className="grid h-16 grid-cols-[auto_1fr_auto] items-center gap-4 px-3 md:px-4">
                                 <div className="flex items-center gap-2 text-primary">
@@ -262,7 +293,7 @@ function App() {
                             </div>
                         </header>
 
-                        <main className="h-[calc(100vh-4rem)]">
+                        <main className="h-app-main">
                             <Suspense fallback={<RouteFallback />}>
                                 <Workspace
                                     searchQuery={deferredWorkspaceSearchQuery}
@@ -282,6 +313,7 @@ function App() {
                 />
                 <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
+            </div>
         </BrowserRouter>
     );
 }

--- a/frontend/src/components/session-expired-banner.tsx
+++ b/frontend/src/components/session-expired-banner.tsx
@@ -1,0 +1,171 @@
+import { useState } from "react";
+import { TriangleAlert, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { loginWithPassword, startOidcLogin, stashCurrentLocation } from "@/lib/auth";
+import type { AuthConfig, User } from "@/types/auth";
+
+/**
+ * Height of the banner. App.tsx feeds the same value into --app-chrome-offset
+ * so viewport-sized route layouts shrink by exactly this much; keeping one
+ * constant is what stops the banner from covering the header it sits above.
+ */
+export const SESSION_BANNER_HEIGHT = "2.5rem";
+
+interface SessionExpiredBannerProps {
+    authConfig: AuthConfig;
+    /** Signed-in address, prefilled so re-auth is one password away. */
+    email: string;
+    /** Session restored in place — the app was never unmounted. */
+    onReauthenticated: (user: User) => void;
+    /** Escape hatch to the full login page for flows this bar cannot carry. */
+    onFullSignIn: () => void;
+}
+
+/**
+ * Mid-session 401 notice.
+ *
+ * Password sign-in is completed here, in a dialog over the still-mounted app,
+ * so nothing is unmounted and no reload happens — the reason the app is kept
+ * alive on a 401 in the first place. OIDC cannot work that way: it is a
+ * full-page redirect to the identity provider, so that path says so plainly
+ * rather than promising the page survives.
+ */
+export function SessionExpiredBanner({
+    authConfig,
+    email,
+    onReauthenticated,
+    onFullSignIn,
+}: SessionExpiredBannerProps) {
+    const passwordAuth = Boolean(authConfig.password_auth_enabled);
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [emailValue, setEmailValue] = useState(email);
+    const [password, setPassword] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const startRedirectSignIn = async () => {
+        setSubmitting(true);
+        try {
+            stashCurrentLocation();
+            window.location.href = await startOidcLogin();
+        } catch (reason) {
+            setSubmitting(false);
+            toast.error(reason instanceof Error ? reason.message : "Failed to start sign-in");
+        }
+    };
+
+    const submitPassword = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setSubmitting(true);
+        setError(null);
+        try {
+            const result = await loginWithPassword(emailValue, password, false);
+            if (result.must_change_password) {
+                // A forced password change needs the full login page; this bar
+                // has nowhere to put that flow.
+                onFullSignIn();
+                return;
+            }
+            setPassword("");
+            setDialogOpen(false);
+            onReauthenticated({
+                email: result.email,
+                name: result.name,
+                picture: result.picture,
+                role: result.role,
+            });
+        } catch (reason) {
+            setError(reason instanceof Error ? reason.message : "Sign-in failed");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <>
+            <div
+                role="status"
+                style={{ height: SESSION_BANNER_HEIGHT }}
+                className="border-warning/30 bg-warning/10 text-warning flex shrink-0 items-center justify-between gap-3 border-b px-4 text-xs"
+            >
+                <span className="flex min-w-0 items-center gap-2">
+                    <TriangleAlert className="h-3.5 w-3.5 shrink-0" />
+                    <span className="truncate">
+                        {passwordAuth
+                            ? "Your session expired. Sign in to carry on — this page stays exactly as it is."
+                            : "Your session expired. Signing in redirects you to your identity provider and reloads this page."}
+                    </span>
+                </span>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="shrink-0"
+                    disabled={submitting}
+                    onClick={() => (passwordAuth ? setDialogOpen(true) : void startRedirectSignIn())}
+                >
+                    {submitting && !dialogOpen ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                    Sign in
+                </Button>
+            </div>
+
+            <Dialog open={dialogOpen} onOpenChange={(next) => { if (!submitting) setDialogOpen(next); }}>
+                <DialogContent className="sm:max-w-sm">
+                    <DialogHeader>
+                        <DialogTitle>Sign in again</DialogTitle>
+                        <DialogDescription>
+                            Your session expired. Signing in here restores it without leaving the page,
+                            so anything you have open stays open.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <form className="space-y-4" onSubmit={(event) => void submitPassword(event)}>
+                        <div className="space-y-2">
+                            <Label htmlFor="session-reauth-email">Email</Label>
+                            <Input
+                                id="session-reauth-email"
+                                type="email"
+                                autoComplete="username"
+                                value={emailValue}
+                                onChange={(event) => setEmailValue(event.target.value)}
+                                disabled={submitting}
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="session-reauth-password">Password</Label>
+                            <Input
+                                id="session-reauth-password"
+                                type="password"
+                                autoComplete="current-password"
+                                autoFocus
+                                value={password}
+                                onChange={(event) => setPassword(event.target.value)}
+                                disabled={submitting}
+                            />
+                        </div>
+                        {error ? <p className="text-destructive text-xs">{error}</p> : null}
+                        <DialogFooter>
+                            <Button type="button" variant="outline" disabled={submitting} onClick={onFullSignIn}>
+                                Use the full sign-in page
+                            </Button>
+                            <Button type="submit" disabled={submitting || !emailValue || !password}>
+                                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                                Sign in
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/frontend/src/components/ui/file-input.tsx
+++ b/frontend/src/components/ui/file-input.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+import { Upload, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * File picker that reads as one control: a real button segment, a divider, and
+ * the chosen filename.
+ *
+ * The native input is kept in the DOM as `sr-only` rather than replaced by a
+ * click-through button, so it stays focusable, Space/Enter opens the OS dialog
+ * exactly as on a bare `<input type="file">`, and assistive tech still sees a
+ * file upload control. The wrapper mirrors its focus ring with `has-`.
+ */
+function FileInput({
+  id,
+  className,
+  value,
+  onValueChange,
+  buttonLabel = "Choose file",
+  placeholder = "No file selected",
+  disabled,
+  ...props
+}: Omit<React.ComponentProps<"input">, "type" | "value" | "onChange"> & {
+  value: File | null
+  onValueChange: (file: File | null) => void
+  buttonLabel?: string
+  placeholder?: string
+}) {
+  const generatedId = React.useId()
+  const inputId = id ?? generatedId
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  // Clearing only the React value would leave the native FileList in place, so
+  // re-picking the same file afterwards would not fire `change`.
+  React.useEffect(() => {
+    if (!value && inputRef.current?.value) inputRef.current.value = ""
+  }, [value])
+
+  return (
+    <div
+      data-slot="file-input"
+      className={cn(
+        "border-input dark:bg-input/30 flex h-9 w-full min-w-0 items-center border transition-colors",
+        "has-[:focus-visible]:border-ring has-[:focus-visible]:ring-ring/50 has-[:focus-visible]:ring-1",
+        disabled && "cursor-not-allowed opacity-50",
+        className
+      )}
+    >
+      <input
+        {...props}
+        ref={inputRef}
+        id={inputId}
+        type="file"
+        disabled={disabled}
+        className="peer sr-only"
+        onChange={(event) => onValueChange(event.target.files?.[0] ?? null)}
+      />
+      <label
+        htmlFor={inputId}
+        className={cn(
+          "border-input bg-muted text-foreground hover:bg-muted/70 dark:hover:bg-input/60 inline-flex h-full shrink-0 cursor-pointer items-center gap-1.5 border-r px-3 text-xs font-medium transition-colors",
+          disabled && "pointer-events-none"
+        )}
+      >
+        <Upload className="h-3.5 w-3.5" />
+        {buttonLabel}
+      </label>
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate px-3 text-xs",
+          value ? "text-foreground" : "text-muted-foreground"
+        )}
+        title={value?.name}
+      >
+        {value ? value.name : placeholder}
+      </span>
+      {value && !disabled ? (
+        <button
+          type="button"
+          aria-label="Clear selected file"
+          onClick={() => onValueChange(null)}
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring mr-1 shrink-0 p-1 transition-colors focus-visible:outline-none focus-visible:ring-1"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+export { FileInput }

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -2,13 +2,15 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+// Typed inputs only. File pickers use `FileInput`, which composes a real button
+// segment instead of trying to dress up the native ::file-selector-button.
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-9 rounded-none border bg-transparent px-3 py-2 text-xs leading-none transition-colors file:h-7 file:rounded-none file:border file:border-input file:bg-muted file:px-2.5 file:text-xs file:font-medium focus-visible:ring-1 aria-invalid:ring-1 md:text-xs file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-9 rounded-none border bg-transparent px-3 py-2 text-xs leading-none transition-colors focus-visible:ring-1 aria-invalid:ring-1 md:text-xs placeholder:text-muted-foreground w-full min-w-0 outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/workspace/async-search-picker.test.tsx
+++ b/frontend/src/components/workspace/async-search-picker.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AsyncSearchPicker } from "./async-search-picker";
+
+interface Row {
+  id: string;
+  label: string;
+}
+
+const ROWS: Row[] = [
+  { id: "a", label: "Sensors/LMT86DCK" },
+  { id: "b", label: "Amplifiers/OPA187" },
+  { id: "c", label: "Passives/R_0603" },
+];
+
+function Harness({
+  onSelect,
+  fetchPage,
+  selectedId = "",
+}: {
+  onSelect: (row: Row) => void;
+  fetchPage?: (query: string, signal: AbortSignal) => Promise<{ items: Row[]; total?: number }>;
+  selectedId?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <AsyncSearchPicker<Row>
+      id="picker"
+      open={open}
+      onOpenChange={setOpen}
+      trigger={<button type="button">Open picker</button>}
+      fetchPage={
+        fetchPage ??
+        ((query) =>
+          Promise.resolve({
+            items: ROWS.filter((row) => row.label.toLowerCase().includes(query.toLowerCase())),
+            total: 9,
+          }))
+      }
+      getKey={(row) => row.id}
+      isSelected={(row) => row.id === selectedId}
+      onSelect={onSelect}
+      renderItem={(row) => <span>{row.label}</span>}
+      searchPlaceholder="Search things"
+      listLabel="Things"
+      emptyMessage="Nothing matches."
+      renderFooter={({ shown, total }) =>
+        total > shown ? <p>{`Showing ${shown} of ${total}`}</p> : null
+      }
+    />
+  );
+}
+
+async function openPicker() {
+  fireEvent.click(screen.getByRole("button", { name: "Open picker" }));
+  await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(3));
+  return screen.getByRole("combobox");
+}
+
+describe("AsyncSearchPicker", () => {
+  it("selects with the keyboard without ever leaving the search box", async () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    const search = await openPicker();
+
+    // The whole point of aria-activedescendant: focus stays put while the
+    // highlight moves, so reaching row N never costs N tab stops.
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    expect(search).toHaveAttribute("aria-activedescendant", "picker-option-1");
+    expect(document.activeElement).toBe(search);
+
+    fireEvent.keyDown(search, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].id).toBe("b");
+  });
+
+  it("wraps at both ends and jumps with Home and End", async () => {
+    const onSelect = vi.fn();
+    render(<Harness onSelect={onSelect} />);
+    const search = await openPicker();
+
+    fireEvent.keyDown(search, { key: "ArrowUp" });
+    expect(search).toHaveAttribute("aria-activedescendant", "picker-option-2");
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    expect(search).toHaveAttribute("aria-activedescendant", "picker-option-0");
+    fireEvent.keyDown(search, { key: "End" });
+    expect(search).toHaveAttribute("aria-activedescendant", "picker-option-2");
+    fireEvent.keyDown(search, { key: "Home" });
+    expect(search).toHaveAttribute("aria-activedescendant", "picker-option-0");
+  });
+
+  it("exposes the results as a listbox rather than loose buttons", async () => {
+    render(<Harness onSelect={vi.fn()} />);
+    const search = await openPicker();
+
+    const listbox = screen.getByRole("listbox", { name: "Things" });
+    expect(search).toHaveAttribute("aria-controls", listbox.id);
+    // Exactly one option carries aria-selected, and it is the active one.
+    const selected = screen.getAllByRole("option", { selected: true });
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe("picker-option-0");
+  });
+
+  it("opens on the current selection so it is not scrolled past", async () => {
+    render(<Harness onSelect={vi.fn()} selectedId="c" />);
+    const search = await openPicker();
+
+    expect(search).toHaveAttribute("aria-activedescendant", "picker-option-2");
+  });
+
+  it("surfaces a failed search instead of showing an empty list", async () => {
+    render(
+      <Harness onSelect={vi.fn()} fetchPage={() => Promise.reject(new Error("Backend is down"))} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open picker" }));
+
+    expect(await screen.findByText("Backend is down")).toBeInTheDocument();
+    expect(screen.queryByText("Nothing matches.")).not.toBeInTheDocument();
+  });
+
+  it("reports how much of the match set is on screen", async () => {
+    render(<Harness onSelect={vi.fn()} />);
+    await openPicker();
+
+    expect(screen.getByText("Showing 3 of 9")).toBeInTheDocument();
+  });
+
+  // Note this covers request *supersession*, not the debounce interval: the
+  // pending timer is cleared and the in-flight request aborted on every
+  // keystroke, which is what keeps a burst to one request. The 180ms itself is
+  // a tuning constant and asserting it would only pin the number.
+  it("issues one request per settled term rather than one per keystroke", async () => {
+    const seen: string[] = [];
+    const fetchPage = vi.fn((query: string) => {
+      seen.push(query);
+      return Promise.resolve({ items: ROWS, total: 3 });
+    });
+    render(<Harness onSelect={vi.fn()} fetchPage={fetchPage} />);
+    const search = await openPicker();
+
+    fireEvent.change(search, { target: { value: "l" } });
+    fireEvent.change(search, { target: { value: "lm" } });
+    fireEvent.change(search, { target: { value: "lmt" } });
+
+    await waitFor(() => expect(seen).toContain("lmt"));
+    expect(seen.filter((term) => term.startsWith("l"))).toEqual(["lmt"]);
+  });
+
+  it("abandons an in-flight search when the term moves on", async () => {
+    const signals: AbortSignal[] = [];
+    const fetchPage = vi.fn(
+      (query: string, signal: AbortSignal) =>
+        new Promise<{ items: Row[] }>((resolve) => {
+          signals.push(signal);
+          // Never settles for the first term, so the abort is the only way out.
+          if (query === "lmt") resolve({ items: ROWS });
+        })
+    );
+    render(<Harness onSelect={vi.fn()} fetchPage={fetchPage} />);
+    fireEvent.click(screen.getByRole("button", { name: "Open picker" }));
+    await waitFor(() => expect(signals).toHaveLength(1));
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "lmt" } });
+
+    await waitFor(() => expect(signals[0].aborted).toBe(true));
+    // A late resolution from the abandoned request must not repopulate the list.
+    await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(3));
+  });
+});

--- a/frontend/src/components/workspace/async-search-picker.tsx
+++ b/frontend/src/components/workspace/async-search-picker.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { Loader2, Search } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+/** Results plus the unfiltered match count, when the source can report one. */
+export interface AsyncSearchPage<T> {
+  items: T[];
+  total?: number;
+}
+
+interface AsyncSearchPickerProps<T> {
+  /** Ids for the listbox and its options are derived from this. */
+  id: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Rendered through `asChild`, so it must forward props and accept a ref. */
+  trigger: ReactNode;
+  fetchPage: (query: string, signal: AbortSignal) => Promise<AsyncSearchPage<T>>;
+  getKey: (item: T) => string;
+  renderItem: (item: T) => ReactNode;
+  isSelected?: (item: T) => boolean;
+  onSelect: (item: T) => void;
+  searchPlaceholder: string;
+  listLabel: string;
+  emptyMessage: ReactNode;
+  /** Seeds the search so a likely match is on screen without typing. */
+  suggestQuery?: string;
+  /** Anything the fetch depends on beyond the query. Changing it refetches. */
+  fetchKey?: string;
+  /** Required when the picker lives inside a Dialog — see the note below. */
+  modal?: boolean;
+  contentClassName?: string;
+  renderFooter?: (page: { shown: number; total: number }) => ReactNode;
+}
+
+const SEARCH_DEBOUNCE_MS = 180;
+
+/**
+ * Popover search over a remote list.
+ *
+ * Both asset pickers had grown their own copy of the same debounce, abort, and
+ * result-rendering logic, and only one of them had keyboard support. This is
+ * that shell, once: the search box keeps DOM focus and points at the highlighted
+ * row through `aria-activedescendant`, so arrow keys never walk a tab-stop per
+ * result and the options are a real listbox rather than a stack of buttons.
+ *
+ * Callers own the trigger, the row markup, and the fetch; everything about
+ * *finding* lives here.
+ */
+export function AsyncSearchPicker<T>({
+  id,
+  open,
+  onOpenChange,
+  trigger,
+  fetchPage,
+  getKey,
+  renderItem,
+  isSelected,
+  onSelect,
+  searchPlaceholder,
+  listLabel,
+  emptyMessage,
+  suggestQuery = "",
+  fetchKey = "",
+  modal = false,
+  contentClassName,
+  renderFooter,
+}: AsyncSearchPickerProps<T>) {
+  const [query, setQuery] = useState("");
+  const [items, setItems] = useState<T[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const listId = `${id}-listbox`;
+  const optionId = (index: number) => `${id}-option-${index}`;
+  const effectiveQuery = query || (open ? suggestQuery : "");
+
+  // `isSelected` is usually an inline arrow, so it must not gate the fetch.
+  const selectedRef = useRef(isSelected);
+  selectedRef.current = isSelected;
+  const fetchRef = useRef(fetchPage);
+  fetchRef.current = fetchPage;
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      setError("");
+      void fetchRef
+        .current(effectiveQuery.trim(), controller.signal)
+        .then((page) => {
+          if (controller.signal.aborted) return;
+          setItems(page.items);
+          setTotal(page.total ?? page.items.length);
+          // Land on the current selection when it survived the filter.
+          const selected = selectedRef.current;
+          const index = selected ? page.items.findIndex((item) => selected(item)) : -1;
+          setActiveIndex(index >= 0 ? index : 0);
+        })
+        .catch((reason: unknown) => {
+          if (controller.signal.aborted) return;
+          setItems([]);
+          setTotal(0);
+          setError(reason instanceof Error ? reason.message : String(reason));
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setLoading(false);
+        });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [effectiveQuery, fetchKey, open]);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  // Keep the keyboard-highlighted row inside the scroll viewport.
+  useEffect(() => {
+    if (!open) return;
+    listRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, open]);
+
+  const commit = (item: T) => {
+    onSelect(item);
+    onOpenChange(false);
+    setQuery("");
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!items.length) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % items.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index - 1 + items.length) % items.length);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setActiveIndex(items.length - 1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const item = items[activeIndex];
+      if (item) commit(item);
+    }
+  };
+
+  return (
+    // modal: when the picker opens inside a Dialog it portals outside that
+    // dialog's scroll lock, and without this Radix blocks wheel/touchmove over
+    // the result list. As the topmost modal layer it may scroll; nothing else moves.
+    <Popover open={open} onOpenChange={onOpenChange} modal={modal}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align="start" className={cn("p-0", contentClassName)}>
+        <div className="flex items-center gap-2 border-b px-2.5 py-2">
+          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleKeyDown}
+            role="combobox"
+            aria-expanded={open}
+            aria-controls={listId}
+            aria-autocomplete="list"
+            aria-activedescendant={items[activeIndex] ? optionId(activeIndex) : undefined}
+            placeholder={searchPlaceholder}
+            className="h-7 border-0 px-0 text-xs shadow-none focus-visible:ring-0"
+          />
+          {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" /> : null}
+        </div>
+        <div
+          ref={listRef}
+          id={listId}
+          role="listbox"
+          aria-label={listLabel}
+          className="max-h-64 overflow-y-auto"
+        >
+          {error ? (
+            <p className="px-3 py-4 text-center text-xs text-destructive">{error}</p>
+          ) : !loading && items.length === 0 ? (
+            <p className="px-3 py-4 text-center text-xs text-muted-foreground">{emptyMessage}</p>
+          ) : (
+            items.map((item, index) => (
+              <div
+                key={getKey(item)}
+                id={optionId(index)}
+                role="option"
+                aria-selected={index === activeIndex}
+                data-active={index === activeIndex}
+                // Options are divs, not buttons: focus stays in the search box so
+                // aria-activedescendant stays authoritative and Tab does not walk
+                // one stop per result. Pointer selection keeps the same focus.
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => commit(item)}
+                className={cn(
+                  "flex w-full cursor-pointer items-start gap-2 border-b border-border/60 px-2.5 py-2 text-left text-xs last:border-b-0",
+                  index === activeIndex && "bg-muted/60"
+                )}
+              >
+                {renderItem(item)}
+              </div>
+            ))
+          )}
+        </div>
+        {!error && renderFooter ? renderFooter({ shown: items.length, total }) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/workspace/library-asset-link-picker.tsx
+++ b/frontend/src/components/workspace/library-asset-link-picker.tsx
@@ -1,12 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, Link2, Loader2, Search, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link2, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { fetchJson } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { CatalogAssetSummary } from "@/types/catalog";
+import { AsyncSearchPicker } from "./async-search-picker";
 
 interface LibraryAssetLinkPickerProps {
   assetType: "symbol" | "footprint" | "3dmodel" | "spice";
@@ -28,6 +27,10 @@ const RESULT_LIMIT = 20;
  * Linking is a reference: the component points at the same asset row every other
  * component using that footprint points at, so importing a hundred 0603 resistors
  * does not create a hundred near-identical footprints.
+ *
+ * This searches registered asset *rows*. The workspace's stored-file picker
+ * searches *files* on disk, including ones no asset row points at yet - different
+ * sources, same search shell.
  */
 export function LibraryAssetLinkPicker({
   assetType,
@@ -38,47 +41,8 @@ export function LibraryAssetLinkPicker({
   onChange,
 }: LibraryAssetLinkPickerProps) {
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
   const [results, setResults] = useState<CatalogAssetSummary[]>([]);
-  const [loading, setLoading] = useState(false);
   const [linked, setLinked] = useState<CatalogAssetSummary | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const effectiveQuery = query || (open ? suggestQuery : "");
-
-  const search = useCallback(
-    async (term: string, signal: AbortSignal) => {
-      setLoading(true);
-      try {
-        const response = await fetchJson<{ items: CatalogAssetSummary[] }>(
-          `/api/catalog/assets/search?asset_type=${assetType}&limit=${RESULT_LIMIT}` +
-            `&q=${encodeURIComponent(term)}`,
-          { signal },
-          "Failed to search catalog assets"
-        );
-        if (!signal.aborted) setResults(response.items);
-      } catch {
-        if (!signal.aborted) setResults([]);
-      } finally {
-        if (!signal.aborted) setLoading(false);
-      }
-    },
-    [assetType]
-  );
-
-  useEffect(() => {
-    if (!open) return;
-    const controller = new AbortController();
-    const timer = window.setTimeout(() => void search(effectiveQuery, controller.signal), 180);
-    return () => {
-      controller.abort();
-      window.clearTimeout(timer);
-    };
-  }, [effectiveQuery, open, search]);
-
-  useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
 
   // Keep the label meaningful when a draft is restored and we only know the id.
   useEffect(() => {
@@ -97,13 +61,6 @@ export function LibraryAssetLinkPicker({
     return "Linked asset";
   }, [linked, placeholder, value]);
 
-  const select = (asset: CatalogAssetSummary) => {
-    setLinked(asset);
-    onChange(asset.id, asset);
-    setOpen(false);
-    setQuery("");
-  };
-
   const clear = (event: React.MouseEvent) => {
     event.stopPropagation();
     setLinked(null);
@@ -111,8 +68,14 @@ export function LibraryAssetLinkPicker({
   };
 
   return (
-    <Popover open={open} onOpenChange={disabled ? undefined : setOpen}>
-      <PopoverTrigger asChild>
+    <AsyncSearchPicker<CatalogAssetSummary>
+      id={`asset-link-${assetType}-${value || "none"}`}
+      open={open}
+      onOpenChange={disabled ? () => undefined : setOpen}
+      contentClassName="w-80"
+      fetchKey={assetType}
+      suggestQuery={suggestQuery}
+      trigger={
         <button
           type="button"
           disabled={disabled}
@@ -137,49 +100,46 @@ export function LibraryAssetLinkPicker({
             </span>
           ) : null}
         </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-80 p-0">
-        <div className="flex items-center gap-2 border-b px-2.5 py-2">
-          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <Input
-            ref={inputRef}
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder={suggestQuery ? `Search, e.g. ${suggestQuery}` : "Search catalog assets"}
-            className="h-7 border-0 px-0 text-xs shadow-none focus-visible:ring-0"
-          />
-          {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" /> : null}
-        </div>
-        <div className="max-h-64 overflow-y-auto">
-          {results.length === 0 && !loading ? (
-            <p className="px-3 py-4 text-center text-xs text-muted-foreground">
-              No matching {assetType} assets in the catalog yet.
-            </p>
-          ) : null}
-          {results.map((asset) => (
-            <button
-              key={asset.id}
-              type="button"
-              onClick={() => select(asset)}
-              className="flex w-full items-start gap-2 px-2.5 py-2 text-left hover:bg-muted/60"
-            >
-              <span className="mt-0.5 w-3.5 shrink-0">
-                {asset.id === value ? <Check className="h-3.5 w-3.5 text-primary" /> : null}
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-xs font-medium">
-                  {asset.target_name || asset.name}
-                </span>
-                <span className="block truncate text-[11px] text-muted-foreground">
-                  {asset.target_library || "—"}
-                  {" · used by "}
-                  {asset.usage_count} component{asset.usage_count === 1 ? "" : "s"}
-                </span>
-              </span>
-            </button>
-          ))}
-        </div>
-        {value ? (
+      }
+      fetchPage={(query, signal) =>
+        fetchJson<{ items: CatalogAssetSummary[] }>(
+          `/api/catalog/assets/search?asset_type=${assetType}&limit=${RESULT_LIMIT}` +
+            `&q=${encodeURIComponent(query)}`,
+          { signal },
+          "Failed to search catalog assets"
+        ).then((response) => {
+          setResults(response.items);
+          return { items: response.items };
+        })
+      }
+      getKey={(asset) => asset.id}
+      isSelected={(asset) => asset.id === value}
+      onSelect={(asset) => {
+        setLinked(asset);
+        onChange(asset.id, asset);
+      }}
+      searchPlaceholder={suggestQuery ? `Search, e.g. ${suggestQuery}` : "Search catalog assets"}
+      listLabel={`Catalog ${assetType} assets`}
+      emptyMessage={`No matching ${assetType} assets in the catalog yet.`}
+      renderItem={(asset) => (
+        <>
+          <span className="mt-0.5 w-3.5 shrink-0">
+            {asset.id === value ? <Link2 className="h-3.5 w-3.5 text-primary" /> : null}
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-xs font-medium">
+              {asset.target_name || asset.name}
+            </span>
+            <span className="block truncate text-[11px] text-muted-foreground">
+              {asset.target_library || "—"}
+              {" · used by "}
+              {asset.usage_count} component{asset.usage_count === 1 ? "" : "s"}
+            </span>
+          </span>
+        </>
+      )}
+      renderFooter={() =>
+        value ? (
           <div className="border-t p-1.5">
             <Button
               variant="ghost"
@@ -194,8 +154,8 @@ export function LibraryAssetLinkPicker({
               Import this row&apos;s own asset instead
             </Button>
           </div>
-        ) : null}
-      </PopoverContent>
-    </Popover>
+        ) : null
+      }
+    />
   );
 }

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -4,7 +4,9 @@ import {
   ArrowLeft,
   ArrowRight,
   Boxes,
+  Check,
   CheckCircle2,
+  ChevronDown,
   ChevronRight,
   CircleAlert,
   CircleDashed,
@@ -25,6 +27,7 @@ import {
   PackageCheck,
   RefreshCw,
   RotateCcw,
+  Search,
   SearchCheck,
   ShieldCheck,
   ShieldX,
@@ -48,7 +51,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { FileInput } from "@/components/ui/file-input";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
@@ -545,7 +550,6 @@ function AssetsPanel({
   canMutate,
   busyAction,
   onAttach,
-  onDetach,
   onDetachAsset,
   onDownload,
   onRegeneratePreviews,
@@ -556,7 +560,6 @@ function AssetsPanel({
   canMutate: boolean;
   busyAction: string;
   onAttach: (assetType: AssetType) => void;
-  onDetach: (assetType: AssetType) => void;
   onDetachAsset: (asset: CatalogAsset) => void;
   onDownload: (asset: CatalogAsset) => void;
   onRegeneratePreviews: () => void;
@@ -613,13 +616,13 @@ function AssetsPanel({
                       <div className="flex shrink-0 items-center gap-1">
                         {asset.required ? <Badge>Required</Badge> : <Badge variant="secondary">Optional</Badge>}
                         <Button size="icon-sm" variant="ghost" aria-label={`Download ${asset.name}`} title={downloadsAvailable ? "Download released asset" : "Downloads are available from the released revision"} disabled={!downloadsAvailable} onClick={() => onDownload(asset)}><Download className="h-3.5 w-3.5" /></Button>
-                        {canMutate && (type === "symbol" || type === "footprint") ? <Button size="icon-sm" variant="ghost" className="text-destructive" aria-label={`Detach ${asset.name}`} onClick={() => onDetachAsset(asset)}><XCircle className="h-3.5 w-3.5" /></Button> : null}
+                        {canMutate ? <Button size="icon-sm" variant="ghost" className="text-destructive" aria-label={`Detach ${asset.name}`} onClick={() => onDetachAsset(asset)}><XCircle className="h-3.5 w-3.5" /></Button> : null}
                       </div>
                     </div>
-                    <div className="grid gap-1 text-xs text-muted-foreground sm:grid-cols-2">
-                      <span>{asset.content_type || "Unknown content type"}</span>
+                    <div className="grid min-w-0 gap-1 text-xs text-muted-foreground sm:grid-cols-2">
+                      <span className="min-w-0 truncate">{asset.content_type || "Unknown content type"}</span>
                       <span>{formatBytes(asset.size_bytes)}</span>
-                      <span className="truncate font-mono sm:col-span-2" title={asset.sha256}>{asset.sha256 ? `SHA-256 ${asset.sha256}` : `Asset ${asset.id}`}</span>
+                      <span className="min-w-0 truncate font-mono sm:col-span-2" title={asset.sha256}>{asset.sha256 ? `SHA-256 ${asset.sha256}` : `Asset ${asset.id}`}</span>
                     </div>
                   </div>
                 ))}
@@ -627,11 +630,6 @@ function AssetsPanel({
             ) : (
               <EmptyState icon={CircleDashed} title={`No ${humanize(type)} asset`} detail={type === "symbol" || type === "footprint" ? "This required asset blocks place readiness." : "This optional asset has not been provided."} />
             )}
-            {canMutate && assets.length && (type === "3dmodel" || type === "spice") ? (
-              <div className="mt-3 border-t pt-3">
-                <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" disabled={Boolean(busyAction)} onClick={() => onDetach(type)}>Detach all {ASSET_LABELS[type].toLowerCase()} files</Button>
-              </div>
-            ) : null}
           </PanelCard>
         ))}
       </div>
@@ -897,16 +895,14 @@ function RevisionsPanel({
             const isCurrent = revision.id === currentRevisionId;
             return (
               <div key={revision.id} className={cn("border p-3", isActive && "border-primary bg-primary/5")}>
-                <div className="flex items-start justify-between gap-2">
-                  <div>
-                    <p className="text-sm font-medium">v{revision.version}</p>
-                    <p className="text-xs text-muted-foreground">{formatDate(revision.created_at)}</p>
-                  </div>
-                  <div className="flex gap-1">
+                <div className="flex min-w-0 items-center justify-between gap-2">
+                  <p className="truncate text-sm font-medium">v{revision.version}</p>
+                  <div className="flex shrink-0 gap-1">
                     {isCurrent ? <Badge>Current</Badge> : null}
                     <Badge variant="outline">{WORKFLOW_LABELS[revision.release_status]}</Badge>
                   </div>
                 </div>
+                <p className="mt-1 text-xs text-muted-foreground">{formatDate(revision.created_at)}</p>
                 <p className="mt-2 text-xs">{revision.change_summary || humanize(revision.change_kind)}</p>
                 <p className="mt-1 truncate text-xs text-muted-foreground">{revision.created_by || "Unknown actor"}</p>
                 <div className="mt-3 flex gap-2">
@@ -1466,6 +1462,190 @@ function MetadataEditDialog({
   );
 }
 
+const STORED_FILE_RESULT_LIMIT = 50;
+
+function StoredFilePicker({
+  id,
+  assetType,
+  value,
+  onChange,
+}: {
+  id: string;
+  assetType: AssetType;
+  value: string;
+  onChange: (path: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [files, setFiles] = useState<string[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  // Highlighted row for keyboard use. The search box keeps DOM focus and points
+  // at this row through aria-activedescendant, so ↑/↓ never leave the field.
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const listId = `${id}-listbox`;
+  const optionId = (index: number) => `${id}-option-${index}`;
+  // Read inside the fetch effect without making a re-selection refetch.
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      setError("");
+      void fetchJson<{ files: string[]; total?: number }>(
+        `/api/catalog/assets/browse?asset_type=${encodeURIComponent(assetType)}&limit=${STORED_FILE_RESULT_LIMIT}&q=${encodeURIComponent(query.trim())}`,
+        { signal: controller.signal },
+        "Stored assets could not be listed.",
+      )
+        .then((response) => {
+          if (!controller.signal.aborted) {
+            setFiles(response.files);
+            setTotal(response.total ?? response.files.length);
+            // Land on the already-linked file when it survived the filter.
+            const selected = response.files.indexOf(valueRef.current);
+            setActiveIndex(selected >= 0 ? selected : 0);
+          }
+        })
+        .catch((reason: unknown) => {
+          if (controller.signal.aborted) return;
+          setFiles([]);
+          setTotal(0);
+          setError(reason instanceof Error ? reason.message : String(reason));
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setLoading(false);
+        });
+    }, 180);
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [assetType, open, query]);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  // Keep the keyboard-highlighted row inside the scroll viewport.
+  useEffect(() => {
+    if (!open) return;
+    listRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, open]);
+
+  const commit = (path: string) => {
+    onChange(path);
+    setOpen(false);
+    setQuery("");
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!files.length) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % files.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index - 1 + files.length) % files.length);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setActiveIndex(files.length - 1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const path = files[activeIndex];
+      if (path) commit(path);
+    }
+  };
+
+  return (
+    // modal: the picker portals outside the dialog's scroll lock, so without it
+    // Radix blocks wheel/touchmove over the file list. As the topmost modal
+    // layer, scrolling inside the list is allowed and everything else stays put.
+    <Popover open={open} onOpenChange={setOpen} modal>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          id={id}
+          aria-expanded={open}
+          className="border-input dark:bg-input/30 dark:hover:bg-input/50 flex h-9 w-full min-w-0 items-center justify-between gap-1.5 border px-3 py-2 text-left text-xs leading-none transition-colors outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-1"
+        >
+          <span className={cn("min-w-0 truncate", value ? "text-foreground" : "text-muted-foreground")}>{value || "Select a stored file"}</span>
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+        <div className="flex items-center gap-2 border-b px-2.5 py-2">
+          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleKeyDown}
+            role="combobox"
+            aria-expanded={open}
+            aria-controls={listId}
+            aria-autocomplete="list"
+            aria-activedescendant={files[activeIndex] ? optionId(activeIndex) : undefined}
+            placeholder={`Search stored ${ASSET_LABELS[assetType].toLowerCase()} files`}
+            className="h-7 border-0 px-0 text-xs shadow-none focus-visible:ring-0"
+          />
+          {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" /> : null}
+        </div>
+        <div
+          ref={listRef}
+          id={listId}
+          role="listbox"
+          aria-label={`Stored ${ASSET_LABELS[assetType].toLowerCase()} files`}
+          className="max-h-64 overflow-y-auto"
+        >
+          {error ? (
+            <p className="px-3 py-4 text-center text-xs text-destructive">{error}</p>
+          ) : !loading && files.length === 0 ? (
+            <p className="px-3 py-4 text-center text-xs text-muted-foreground">
+              No stored {ASSET_LABELS[assetType].toLowerCase()} files match.
+            </p>
+          ) : (
+            files.map((path, index) => (
+              <div
+                key={path}
+                id={optionId(index)}
+                role="option"
+                aria-selected={index === activeIndex}
+                data-active={index === activeIndex}
+                // Options are divs, not buttons: focus stays in the search box
+                // so aria-activedescendant stays authoritative and Tab does not
+                // walk 50 rows. Pointer selection keeps the same focus.
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => commit(path)}
+                className={cn(
+                  "flex w-full cursor-pointer items-center gap-2 border-b border-border/60 px-2.5 py-2 text-left text-xs last:border-b-0",
+                  index === activeIndex && "bg-muted/60",
+                  path === value && "font-medium"
+                )}
+              >
+                <Check className={cn("h-3.5 w-3.5 shrink-0", path === value ? "text-primary" : "invisible")} />
+                <span className="min-w-0 flex-1 truncate">{path}</span>
+              </div>
+            ))
+          )}
+        </div>
+        {!error && total > files.length ? (
+          <p className="border-t px-2.5 py-1.5 text-[11px] text-muted-foreground">Showing {files.length} of {total} stored files — refine the search to narrow.</p>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function AssetAttachDialog({
   assetType,
   mode,
@@ -1474,11 +1654,9 @@ function AssetAttachDialog({
   targetName,
   counterpartAssets,
   counterpartAssetId,
-  links,
   selectedLink,
   selection,
   submitting,
-  linksLoading,
   onOpenChange,
   onModeChange,
   onFileChange,
@@ -1497,11 +1675,9 @@ function AssetAttachDialog({
   targetName: string;
   counterpartAssets: CatalogAsset[];
   counterpartAssetId: string;
-  links: string[];
   selectedLink: string;
   selection: AssetImportSelection | null;
   submitting: boolean;
-  linksLoading: boolean;
   onOpenChange: (open: boolean) => void;
   onModeChange: (mode: AssetAttachMode) => void;
   onFileChange: (file: File | null) => void;
@@ -1514,9 +1690,13 @@ function AssetAttachDialog({
   onLink: () => void;
 }) {
   const label = assetType ? ASSET_LABELS[assetType] : "asset";
+  const sourceTabs: Array<{ id: AssetAttachMode; label: string; icon: typeof Upload }> = [
+    { id: "upload", label: "Upload file", icon: Upload },
+    { id: "link", label: "Link existing", icon: Link2 },
+  ];
   return (
     <Dialog open={assetType !== null} onOpenChange={(next) => { if (!submitting) onOpenChange(next); }}>
-      <DialogContent className="sm:max-w-xl">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Add {label.toLowerCase()}</DialogTitle>
           <DialogDescription>Upload a file or link one already present in Prism storage. Attaching it creates a new immutable component revision.</DialogDescription>
@@ -1538,27 +1718,53 @@ function AssetAttachDialog({
           </div>
         ) : (
           <>
-            <div className="flex items-center gap-1 border bg-muted/20 p-1" role="group" aria-label="Asset source">
-              <Button size="sm" variant={mode === "upload" ? "secondary" : "ghost"} aria-pressed={mode === "upload"} onClick={() => onModeChange("upload")}><Upload className="h-3.5 w-3.5" /> Upload file</Button>
-              <Button size="sm" variant={mode === "link" ? "secondary" : "ghost"} aria-pressed={mode === "link"} onClick={() => onModeChange("link")}><Link2 className="h-3.5 w-3.5" /> Link existing</Button>
+            <div className="inline-flex items-center gap-1 border bg-muted/30 p-1" role="tablist" aria-label="Asset source">
+              {sourceTabs.map(({ id, label: tabLabel, icon: Icon }) => (
+                <button
+                  key={id}
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === id}
+                  disabled={submitting}
+                  className={cn(
+                    "inline-flex h-7 items-center gap-1.5 border border-transparent px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                    mode === id
+                      ? "border-border bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                  onClick={() => onModeChange(id)}
+                >
+                  <Icon className="h-3.5 w-3.5" />{tabLabel}
+                </button>
+              ))}
             </div>
             <div className="space-y-4">
               {mode === "upload" ? (
                 <div className="space-y-2">
                   <Label htmlFor="component-asset-file">{label} file</Label>
-                  <Input id="component-asset-file" type="file" accept={assetType ? ASSET_ACCEPT[assetType] : undefined} onChange={(event) => onFileChange(event.target.files?.[0] || null)} />
-                  {file ? <p className="text-xs text-muted-foreground">{file.name} · {formatBytes(file.size)}</p> : null}
+                  <FileInput
+                    id="component-asset-file"
+                    accept={assetType ? ASSET_ACCEPT[assetType] : undefined}
+                    value={file}
+                    onValueChange={onFileChange}
+                    disabled={submitting}
+                  />
+                  {file ? <p className="text-xs text-muted-foreground">{formatBytes(file.size)}</p> : null}
                 </div>
               ) : (
                 <div className="space-y-2">
                   <Label htmlFor="component-existing-asset">Existing file</Label>
-                  <Select value={selectedLink} onValueChange={onSelectedLinkChange} disabled={linksLoading || links.length === 0}>
-                    <SelectTrigger id="component-existing-asset"><SelectValue placeholder={linksLoading ? "Loading storage…" : links.length ? "Select a stored file" : "No compatible stored files"} /></SelectTrigger>
-                    <SelectContent>{links.map((path) => <SelectItem key={path} value={path}>{path}</SelectItem>)}</SelectContent>
-                  </Select>
+                  {assetType ? (
+                    <StoredFilePicker
+                      id="component-existing-asset"
+                      assetType={assetType}
+                      value={selectedLink}
+                      onChange={onSelectedLinkChange}
+                    />
+                  ) : null}
                 </div>
               )}
-              <div className="grid gap-4 sm:grid-cols-2">
+              <div className={cn("grid gap-4", mode === "link" && "sm:grid-cols-2")}>
                 <div className="space-y-2"><Label htmlFor="component-asset-library">Target library</Label><Input id="component-asset-library" value={targetLibrary} onChange={(event) => onTargetLibraryChange(event.target.value)} placeholder="Prism library" /></div>
                 {mode === "link" ? <div className="space-y-2"><Label htmlFor="component-asset-name">Target item name</Label><Input id="component-asset-name" value={targetName} onChange={(event) => onTargetNameChange(event.target.value)} placeholder="Auto-detect" /></div> : null}
               </div>
@@ -1566,7 +1772,7 @@ function AssetAttachDialog({
                 <div className="space-y-2">
                   <Label htmlFor="component-counterpart-asset">Pair with {assetType === "symbol" ? "footprint" : "symbol"}</Label>
                   <Select value={counterpartAssetId} onValueChange={onCounterpartAssetChange}>
-                    <SelectTrigger id="component-counterpart-asset"><SelectValue placeholder="Select the counterpart asset" /></SelectTrigger>
+                    <SelectTrigger id="component-counterpart-asset" className="w-full"><SelectValue placeholder="Select the counterpart asset" /></SelectTrigger>
                     <SelectContent>{counterpartAssets.map((asset) => <SelectItem key={asset.id} value={asset.id}>{asset.target_library ? `${asset.target_library}:` : ""}{asset.target_name}</SelectItem>)}</SelectContent>
                   </Select>
                   <p className="text-xs text-muted-foreground">The current default counterpart is preselected. You can edit the resulting pair in Representations.</p>
@@ -1639,11 +1845,8 @@ export function LibraryComponentWorkspace({
   const [attachTargetLibrary, setAttachTargetLibrary] = useState("");
   const [attachTargetName, setAttachTargetName] = useState("");
   const [attachCounterpartId, setAttachCounterpartId] = useState("");
-  const [availableLinks, setAvailableLinks] = useState<string[]>([]);
   const [selectedLink, setSelectedLink] = useState("");
-  const [linksLoading, setLinksLoading] = useState(false);
   const [importSelection, setImportSelection] = useState<AssetImportSelection | null>(null);
-  const [detachAssetType, setDetachAssetType] = useState<AssetType | null>(null);
   const [detachAsset, setDetachAsset] = useState<CatalogAsset | null>(null);
   const [busyAction, setBusyAction] = useState("");
 
@@ -2007,13 +2210,14 @@ export function LibraryComponentWorkspace({
     setAttachTargetLibrary("");
     setAttachTargetName("");
     setAttachCounterpartId("");
-    setAvailableLinks([]);
     setSelectedLink("");
     setImportSelection(null);
   };
 
-  const openAttachDialog = async (assetType: AssetType) => {
+  const openAttachDialog = (assetType: AssetType) => {
     if (!currentComponent || !canMutate) return;
+    // The dialog opens instantly in upload mode. Stored files are only listed
+    // when the user actually opens the "Link existing" picker.
     setAttachAssetType(assetType);
     setAttachMode("upload");
     setAttachFile(null);
@@ -2029,16 +2233,6 @@ export function LibraryComponentWorkspace({
     );
     setSelectedLink("");
     setImportSelection(null);
-    setLinksLoading(true);
-    try {
-      const response = await fetchJson<{ files: string[] }>(`/api/catalog/assets/browse?asset_type=${encodeURIComponent(assetType)}`);
-      setAvailableLinks(response.files);
-    } catch (reason) {
-      setAvailableLinks([]);
-      toast.error(reason instanceof Error ? reason.message : "Stored assets could not be listed.");
-    } finally {
-      setLinksLoading(false);
-    }
   };
 
   const handleAssetUpload = async () => {
@@ -2091,22 +2285,6 @@ export function LibraryComponentWorkspace({
       });
       toast.success(`${ASSET_LABELS[attachAssetType]} linked as a new revision.`);
       resetAttachDialog();
-      updateParams({ revision: null, compare: null });
-      setRefreshKey((value) => value + 1);
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : String(reason));
-    } finally {
-      setBusyAction("");
-    }
-  };
-
-  const handleAssetDetach = async () => {
-    if (!detachAssetType || !canMutate) return;
-    setBusyAction("detach");
-    try {
-      await fetchJson(`/api/catalog/components/${encodeURIComponent(componentId)}/assets/${encodeURIComponent(detachAssetType)}`, { method: "DELETE" });
-      toast.success(`${ASSET_LABELS[detachAssetType]} detached in a new revision.`);
-      setDetachAssetType(null);
       updateParams({ revision: null, compare: null });
       setRefreshKey((value) => value + 1);
     } catch (reason) {
@@ -2297,8 +2475,7 @@ export function LibraryComponentWorkspace({
               component={activeComponent}
               canMutate={canMutate}
               busyAction={busyAction}
-              onAttach={(assetType) => void openAttachDialog(assetType)}
-              onDetach={setDetachAssetType}
+              onAttach={openAttachDialog}
               onDetachAsset={setDetachAsset}
               onDownload={(asset) => void handleDownloadAsset(asset)}
               onRegeneratePreviews={() => void handleRegeneratePreviews()}
@@ -2399,11 +2576,9 @@ export function LibraryComponentWorkspace({
         targetName={attachTargetName}
         counterpartAssets={currentComponent.assets.filter((asset) => attachAssetType === "symbol" ? asset.asset_type === "footprint" : attachAssetType === "footprint" ? asset.asset_type === "symbol" : false)}
         counterpartAssetId={attachCounterpartId}
-        links={availableLinks}
         selectedLink={selectedLink}
         selection={importSelection}
         submitting={busyAction === "asset"}
-        linksLoading={linksLoading}
         onOpenChange={(open) => { if (!open) resetAttachDialog(); }}
         onModeChange={setAttachMode}
         onFileChange={setAttachFile}
@@ -2416,25 +2591,11 @@ export function LibraryComponentWorkspace({
         onLink={() => void handleAssetLink()}
       />
 
-      <Dialog open={detachAssetType !== null} onOpenChange={(open) => { if (!open && busyAction !== "detach") setDetachAssetType(null); }}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Detach {detachAssetType ? ASSET_LABELS[detachAssetType].toLowerCase() : "asset"}</DialogTitle>
-            <DialogDescription>This creates a new revision without the selected asset type. Canonical files and prior revisions remain intact.</DialogDescription>
-          </DialogHeader>
-          {detachAssetType === "3dmodel" || detachAssetType === "spice" ? <p className="text-sm text-muted-foreground">All attached {detachAssetType === "3dmodel" ? "3D model" : "SPICE model"} files will be detached from the new revision.</p> : null}
-          <DialogFooter>
-            <Button variant="outline" disabled={busyAction === "detach"} onClick={() => setDetachAssetType(null)}>Cancel</Button>
-            <Button variant="destructive" disabled={busyAction === "detach"} onClick={() => void handleAssetDetach()}>{busyAction === "detach" ? <Loader2 className="h-4 w-4 animate-spin" /> : <XCircle className="h-4 w-4" />} Detach asset</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       <Dialog open={detachAsset !== null} onOpenChange={(open) => { if (!open && busyAction !== "detach-id") setDetachAsset(null); }}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Detach {detachAsset?.name || "asset"}</DialogTitle>
-            <DialogDescription>The asset can only be detached when no representation references it. Prior revisions and canonical files remain intact.</DialogDescription>
+            <DialogDescription>This creates a new revision without this file. A symbol or footprint that a representation still references must be reassigned first. Prior revisions and canonical files remain intact.</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" disabled={busyAction === "detach-id"} onClick={() => setDetachAsset(null)}>Cancel</Button>

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -27,7 +27,6 @@ import {
   PackageCheck,
   RefreshCw,
   RotateCcw,
-  Search,
   SearchCheck,
   ShieldCheck,
   ShieldX,
@@ -53,8 +52,8 @@ import {
 import { Label } from "@/components/ui/label";
 import { FileInput } from "@/components/ui/file-input";
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { AsyncSearchPicker } from "./async-search-picker";
 import {
   Select,
   SelectContent,
@@ -1356,6 +1355,65 @@ function useEvidenceLoadState() {
   return { state, stateRef, update };
 }
 
+/**
+ * Load one tab's evidence once per component generation.
+ *
+ * Each tab used to carry its own copy of this. The parts that look incidental
+ * are not: the `idle` check is what stops a re-render re-requesting, `settled`
+ * distinguishes "aborted before it answered" (reset to idle so the next visit
+ * retries) from "answered" (leave the outcome alone), and the generation string
+ * ties a response to the component revision it was asked for.
+ */
+function useEvidenceResource<T>({
+  enabled,
+  generation,
+  retryKey,
+  load,
+  loadState,
+  onLoaded,
+}: {
+  enabled: boolean;
+  generation: string;
+  retryKey: number;
+  load: (signal: AbortSignal) => Promise<T>;
+  loadState: ReturnType<typeof useEvidenceLoadState>;
+  onLoaded: (value: T) => void;
+}) {
+  const { stateRef, update } = loadState;
+  const loadRef = useRef(load);
+  loadRef.current = load;
+  const onLoadedRef = useRef(onLoaded);
+  onLoadedRef.current = onLoaded;
+
+  useEffect(() => {
+    if (!enabled || stateRef.current.status !== "idle") return;
+    const controller = new AbortController();
+    let settled = false;
+    update({ status: "loading", error: "", generation });
+    void loadRef
+      .current(controller.signal)
+      .then((value) => {
+        settled = true;
+        if (controller.signal.aborted) return;
+        onLoadedRef.current(value);
+        update({ status: "loaded", error: "", generation });
+      })
+      .catch((reason: unknown) => {
+        settled = true;
+        if (controller.signal.aborted) return;
+        update({
+          status: "error",
+          error: reason instanceof Error ? reason.message : String(reason),
+          generation,
+        });
+      });
+    return () => {
+      controller.abort();
+      if (!settled) update(IDLE_EVIDENCE);
+    };
+  }, [enabled, generation, retryKey, stateRef, update]);
+}
+
 function combinedEvidenceState(states: EvidenceLoadState[]): EvidenceLoadState {
   const failed = states.find((state) => state.status === "error");
   if (failed) return failed;
@@ -1464,6 +1522,7 @@ function MetadataEditDialog({
 
 const STORED_FILE_RESULT_LIMIT = 50;
 
+/** Pick a file already sitting in Prism storage, including ones never registered as an asset. */
 function StoredFilePicker({
   id,
   assetType,
@@ -1476,101 +1535,18 @@ function StoredFilePicker({
   onChange: (path: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const [files, setFiles] = useState<string[]>([]);
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-  // Highlighted row for keyboard use. The search box keeps DOM focus and points
-  // at this row through aria-activedescendant, so ↑/↓ never leave the field.
-  const [activeIndex, setActiveIndex] = useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
-  const listId = `${id}-listbox`;
-  const optionId = (index: number) => `${id}-option-${index}`;
-  // Read inside the fetch effect without making a re-selection refetch.
-  const valueRef = useRef(value);
-  valueRef.current = value;
-
-  useEffect(() => {
-    if (!open) return;
-    const controller = new AbortController();
-    const timer = window.setTimeout(() => {
-      setLoading(true);
-      setError("");
-      void fetchJson<{ files: string[]; total?: number }>(
-        `/api/catalog/assets/browse?asset_type=${encodeURIComponent(assetType)}&limit=${STORED_FILE_RESULT_LIMIT}&q=${encodeURIComponent(query.trim())}`,
-        { signal: controller.signal },
-        "Stored assets could not be listed.",
-      )
-        .then((response) => {
-          if (!controller.signal.aborted) {
-            setFiles(response.files);
-            setTotal(response.total ?? response.files.length);
-            // Land on the already-linked file when it survived the filter.
-            const selected = response.files.indexOf(valueRef.current);
-            setActiveIndex(selected >= 0 ? selected : 0);
-          }
-        })
-        .catch((reason: unknown) => {
-          if (controller.signal.aborted) return;
-          setFiles([]);
-          setTotal(0);
-          setError(reason instanceof Error ? reason.message : String(reason));
-        })
-        .finally(() => {
-          if (!controller.signal.aborted) setLoading(false);
-        });
-    }, 180);
-    return () => {
-      controller.abort();
-      window.clearTimeout(timer);
-    };
-  }, [assetType, open, query]);
-
-  useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
-
-  // Keep the keyboard-highlighted row inside the scroll viewport.
-  useEffect(() => {
-    if (!open) return;
-    listRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex, open]);
-
-  const commit = (path: string) => {
-    onChange(path);
-    setOpen(false);
-    setQuery("");
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!files.length) return;
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setActiveIndex((index) => (index + 1) % files.length);
-    } else if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setActiveIndex((index) => (index - 1 + files.length) % files.length);
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      setActiveIndex(0);
-    } else if (event.key === "End") {
-      event.preventDefault();
-      setActiveIndex(files.length - 1);
-    } else if (event.key === "Enter") {
-      event.preventDefault();
-      const path = files[activeIndex];
-      if (path) commit(path);
-    }
-  };
+  const kind = ASSET_LABELS[assetType].toLowerCase();
 
   return (
-    // modal: the picker portals outside the dialog's scroll lock, so without it
-    // Radix blocks wheel/touchmove over the file list. As the topmost modal
-    // layer, scrolling inside the list is allowed and everything else stays put.
-    <Popover open={open} onOpenChange={setOpen} modal>
-      <PopoverTrigger asChild>
+    <AsyncSearchPicker<string>
+      id={id}
+      open={open}
+      onOpenChange={setOpen}
+      // Portalled out of the attach dialog, so it needs its own modal layer.
+      modal
+      contentClassName="w-[var(--radix-popover-trigger-width)]"
+      fetchKey={assetType}
+      trigger={
         <button
           type="button"
           id={id}
@@ -1580,69 +1556,32 @@ function StoredFilePicker({
           <span className={cn("min-w-0 truncate", value ? "text-foreground" : "text-muted-foreground")}>{value || "Select a stored file"}</span>
           <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
         </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
-        <div className="flex items-center gap-2 border-b px-2.5 py-2">
-          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <Input
-            ref={inputRef}
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            onKeyDown={handleKeyDown}
-            role="combobox"
-            aria-expanded={open}
-            aria-controls={listId}
-            aria-autocomplete="list"
-            aria-activedescendant={files[activeIndex] ? optionId(activeIndex) : undefined}
-            placeholder={`Search stored ${ASSET_LABELS[assetType].toLowerCase()} files`}
-            className="h-7 border-0 px-0 text-xs shadow-none focus-visible:ring-0"
-          />
-          {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" /> : null}
-        </div>
-        <div
-          ref={listRef}
-          id={listId}
-          role="listbox"
-          aria-label={`Stored ${ASSET_LABELS[assetType].toLowerCase()} files`}
-          className="max-h-64 overflow-y-auto"
-        >
-          {error ? (
-            <p className="px-3 py-4 text-center text-xs text-destructive">{error}</p>
-          ) : !loading && files.length === 0 ? (
-            <p className="px-3 py-4 text-center text-xs text-muted-foreground">
-              No stored {ASSET_LABELS[assetType].toLowerCase()} files match.
-            </p>
-          ) : (
-            files.map((path, index) => (
-              <div
-                key={path}
-                id={optionId(index)}
-                role="option"
-                aria-selected={index === activeIndex}
-                data-active={index === activeIndex}
-                // Options are divs, not buttons: focus stays in the search box
-                // so aria-activedescendant stays authoritative and Tab does not
-                // walk 50 rows. Pointer selection keeps the same focus.
-                onMouseDown={(event) => event.preventDefault()}
-                onMouseEnter={() => setActiveIndex(index)}
-                onClick={() => commit(path)}
-                className={cn(
-                  "flex w-full cursor-pointer items-center gap-2 border-b border-border/60 px-2.5 py-2 text-left text-xs last:border-b-0",
-                  index === activeIndex && "bg-muted/60",
-                  path === value && "font-medium"
-                )}
-              >
-                <Check className={cn("h-3.5 w-3.5 shrink-0", path === value ? "text-primary" : "invisible")} />
-                <span className="min-w-0 flex-1 truncate">{path}</span>
-              </div>
-            ))
-          )}
-        </div>
-        {!error && total > files.length ? (
-          <p className="border-t px-2.5 py-1.5 text-[11px] text-muted-foreground">Showing {files.length} of {total} stored files — refine the search to narrow.</p>
-        ) : null}
-      </PopoverContent>
-    </Popover>
+      }
+      fetchPage={(query, signal) =>
+        fetchJson<{ files: string[]; total?: number }>(
+          `/api/catalog/assets/browse?asset_type=${encodeURIComponent(assetType)}&limit=${STORED_FILE_RESULT_LIMIT}&q=${encodeURIComponent(query)}`,
+          { signal },
+          "Stored assets could not be listed.",
+        ).then((response) => ({ items: response.files, total: response.total }))
+      }
+      getKey={(path) => path}
+      isSelected={(path) => path === value}
+      onSelect={onChange}
+      searchPlaceholder={`Search stored ${kind} files`}
+      listLabel={`Stored ${kind} files`}
+      emptyMessage={`No stored ${kind} files match.`}
+      renderItem={(path) => (
+        <>
+          <Check className={cn("h-3.5 w-3.5 shrink-0", path === value ? "text-primary" : "invisible")} />
+          <span className="min-w-0 flex-1 truncate">{path}</span>
+        </>
+      )}
+      renderFooter={({ shown, total }) =>
+        total > shown ? (
+          <p className="border-t px-2.5 py-1.5 text-[11px] text-muted-foreground">Showing {shown} of {total} stored files — refine the search to narrow.</p>
+        ) : null
+      }
+    />
   );
 }
 
@@ -1826,11 +1765,18 @@ export function LibraryComponentWorkspace({
   const [historicalError, setHistoricalError] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
   const [evidenceRetryKey, setEvidenceRetryKey] = useState(0);
-  const { state: revisionsLoadState, stateRef: revisionsLoadRef, update: setRevisionsLoad } = useEvidenceLoadState();
-  const { state: reviewsLoadState, stateRef: reviewsLoadRef, update: setReviewsLoad } = useEvidenceLoadState();
-  const { state: releasesLoadState, stateRef: releasesLoadRef, update: setReleasesLoad } = useEvidenceLoadState();
-  const { state: usageLoadState, stateRef: usageLoadRef, update: setUsageLoad } = useEvidenceLoadState();
-  const { state: auditLoadState, stateRef: auditLoadRef, update: setAuditLoad } = useEvidenceLoadState();
+  // Kept whole so each can be handed to useEvidenceResource; the destructured
+  // aliases below are what the render and retry paths read.
+  const revisionsLoad = useEvidenceLoadState();
+  const reviewsLoad = useEvidenceLoadState();
+  const releasesLoad = useEvidenceLoadState();
+  const usageLoad = useEvidenceLoadState();
+  const auditLoad = useEvidenceLoadState();
+  const { state: revisionsLoadState, stateRef: revisionsLoadRef, update: setRevisionsLoad } = revisionsLoad;
+  const { state: reviewsLoadState, stateRef: reviewsLoadRef, update: setReviewsLoad } = reviewsLoad;
+  const { state: releasesLoadState, stateRef: releasesLoadRef, update: setReleasesLoad } = releasesLoad;
+  const { state: usageLoadState, stateRef: usageLoadRef, update: setUsageLoad } = usageLoad;
+  const { state: auditLoadState, stateRef: auditLoadRef, update: setAuditLoad } = auditLoad;
   const { state: diffLoadState, stateRef: diffLoadRef, update: setDiffLoad } = useEvidenceLoadState();
   const diffCacheRef = useRef(new Map<string, CatalogRevisionDiff>());
   const [transitionTarget, setTransitionTarget] = useState<WorkflowStage | null>(null);
@@ -1938,119 +1884,61 @@ export function LibraryComponentWorkspace({
     return () => controller.abort();
   }, [componentId, currentComponent, requestedRevisionId]);
 
-  useEffect(() => {
-    if (!componentReady || !needsRevisions || revisionsLoadRef.current.status !== "idle") return;
-    const controller = new AbortController();
-    let settled = false;
-    setRevisionsLoad({ status: "loading", error: "", generation: evidenceGeneration });
-    void fetchJson<{ items: CatalogRevisionSummary[] }>(`/api/catalog/components/${encodeURIComponent(componentId)}/revisions`, { signal: controller.signal })
-      .then((response) => {
-        settled = true;
-        if (controller.signal.aborted) return;
-        setRevisions(response.items);
-        setRevisionsLoad({ status: "loaded", error: "", generation: evidenceGeneration });
-      })
-      .catch((reason: unknown) => {
-        settled = true;
-        if (!controller.signal.aborted) setRevisionsLoad({ status: "error", error: reason instanceof Error ? reason.message : String(reason), generation: evidenceGeneration });
-      });
-    return () => {
-      controller.abort();
-      if (!settled) setRevisionsLoad(IDLE_EVIDENCE);
-    };
-  }, [componentId, componentReady, evidenceGeneration, evidenceRetryKey, needsRevisions, revisionsLoadRef, setRevisionsLoad]);
+  const componentPath = `/api/catalog/components/${encodeURIComponent(componentId)}`;
 
-  useEffect(() => {
-    if (!componentReady || !needsReviews || reviewsLoadRef.current.status !== "idle") return;
-    const controller = new AbortController();
-    let settled = false;
-    setReviewsLoad({ status: "loading", error: "", generation: evidenceGeneration });
-    void fetchJson<{ items: CatalogReviewDecision[] }>(`/api/catalog/components/${encodeURIComponent(componentId)}/reviews`, { signal: controller.signal })
-      .then((response) => {
-        settled = true;
-        if (controller.signal.aborted) return;
-        setReviews(response.items);
-        setReviewsLoad({ status: "loaded", error: "", generation: evidenceGeneration });
-      })
-      .catch((reason: unknown) => {
-        settled = true;
-        if (!controller.signal.aborted) setReviewsLoad({ status: "error", error: reason instanceof Error ? reason.message : String(reason), generation: evidenceGeneration });
-      });
-    return () => {
-      controller.abort();
-      if (!settled) setReviewsLoad(IDLE_EVIDENCE);
-    };
-  }, [componentId, componentReady, evidenceGeneration, evidenceRetryKey, needsReviews, reviewsLoadRef, setReviewsLoad]);
+  useEvidenceResource({
+    enabled: componentReady && needsRevisions,
+    generation: evidenceGeneration,
+    retryKey: evidenceRetryKey,
+    loadState: revisionsLoad,
+    load: (signal) => fetchJson<{ items: CatalogRevisionSummary[] }>(`${componentPath}/revisions`, { signal }),
+    onLoaded: (response) => setRevisions(response.items),
+  });
 
-  useEffect(() => {
-    if (!componentReady || !needsReleases || releasesLoadRef.current.status !== "idle") return;
-    const controller = new AbortController();
-    let settled = false;
-    setReleasesLoad({ status: "loading", error: "", generation: evidenceGeneration });
-    void fetchJson<{ items: CatalogReleaseRecord[] }>(`/api/catalog/components/${encodeURIComponent(componentId)}/releases`, { signal: controller.signal })
-      .then((response) => {
-        settled = true;
-        if (controller.signal.aborted) return;
-        setReleases(response.items);
-        setReleasesLoad({ status: "loaded", error: "", generation: evidenceGeneration });
-      })
-      .catch((reason: unknown) => {
-        settled = true;
-        if (!controller.signal.aborted) setReleasesLoad({ status: "error", error: reason instanceof Error ? reason.message : String(reason), generation: evidenceGeneration });
-      });
-    return () => {
-      controller.abort();
-      if (!settled) setReleasesLoad(IDLE_EVIDENCE);
-    };
-  }, [componentId, componentReady, evidenceGeneration, evidenceRetryKey, needsReleases, releasesLoadRef, setReleasesLoad]);
+  useEvidenceResource({
+    enabled: componentReady && needsReviews,
+    generation: evidenceGeneration,
+    retryKey: evidenceRetryKey,
+    loadState: reviewsLoad,
+    load: (signal) => fetchJson<{ items: CatalogReviewDecision[] }>(`${componentPath}/reviews`, { signal }),
+    onLoaded: (response) => setReviews(response.items),
+  });
 
-  useEffect(() => {
-    if (!componentReady || !needsUsage || usageLoadRef.current.status !== "idle") return;
-    const controller = new AbortController();
-    let settled = false;
-    setUsageLoad({ status: "loading", error: "", generation: evidenceGeneration });
-    void fetchJson<{ items: CatalogComponentUsage[] }>(`/api/catalog/components/${encodeURIComponent(componentId)}/usage`, { signal: controller.signal })
-      .then((response) => {
-        settled = true;
-        if (controller.signal.aborted) return;
-        setUsage(response.items);
-        setUsageLoad({ status: "loaded", error: "", generation: evidenceGeneration });
-      })
-      .catch((reason: unknown) => {
-        settled = true;
-        if (!controller.signal.aborted) setUsageLoad({ status: "error", error: reason instanceof Error ? reason.message : String(reason), generation: evidenceGeneration });
-      });
-    return () => {
-      controller.abort();
-      if (!settled) setUsageLoad(IDLE_EVIDENCE);
-    };
-  }, [componentId, componentReady, evidenceGeneration, evidenceRetryKey, needsUsage, setUsageLoad, usageLoadRef]);
+  useEvidenceResource({
+    enabled: componentReady && needsReleases,
+    generation: evidenceGeneration,
+    retryKey: evidenceRetryKey,
+    loadState: releasesLoad,
+    load: (signal) => fetchJson<{ items: CatalogReleaseRecord[] }>(`${componentPath}/releases`, { signal }),
+    onLoaded: (response) => setReleases(response.items),
+  });
 
-  useEffect(() => {
-    if (!componentReady || !needsAudit || auditLoadRef.current.status !== "idle") return;
-    const controller = new AbortController();
-    let settled = false;
-    setAuditLoad({ status: "loading", error: "", generation: evidenceGeneration });
-    void Promise.all([
-      fetchJson<{ items: CatalogAuditEvent[] }>(`/api/catalog/components/${encodeURIComponent(componentId)}/audit`, { signal: controller.signal }),
-      fetchJson<CatalogAuditVerification>(`/api/catalog/components/${encodeURIComponent(componentId)}/audit/verify`, { signal: controller.signal }),
-    ])
-      .then(([eventList, auditVerification]) => {
-        settled = true;
-        if (controller.signal.aborted) return;
-        setEvents(eventList.items);
-        setVerification(auditVerification);
-        setAuditLoad({ status: "loaded", error: "", generation: evidenceGeneration });
-      })
-      .catch((reason: unknown) => {
-        settled = true;
-        if (!controller.signal.aborted) setAuditLoad({ status: "error", error: reason instanceof Error ? reason.message : String(reason), generation: evidenceGeneration });
-      });
-    return () => {
-      controller.abort();
-      if (!settled) setAuditLoad(IDLE_EVIDENCE);
-    };
-  }, [auditLoadRef, componentId, componentReady, evidenceGeneration, evidenceRetryKey, needsAudit, setAuditLoad]);
+  useEvidenceResource({
+    enabled: componentReady && needsUsage,
+    generation: evidenceGeneration,
+    retryKey: evidenceRetryKey,
+    loadState: usageLoad,
+    load: (signal) => fetchJson<{ items: CatalogComponentUsage[] }>(`${componentPath}/usage`, { signal }),
+    onLoaded: (response) => setUsage(response.items),
+  });
+
+  useEvidenceResource({
+    enabled: componentReady && needsAudit,
+    generation: evidenceGeneration,
+    retryKey: evidenceRetryKey,
+    loadState: auditLoad,
+    // The chain and its verification are one piece of evidence: a verified
+    // chain shown against a half-loaded event list would be misleading.
+    load: (signal) =>
+      Promise.all([
+        fetchJson<{ items: CatalogAuditEvent[] }>(`${componentPath}/audit`, { signal }),
+        fetchJson<CatalogAuditVerification>(`${componentPath}/audit/verify`, { signal }),
+      ]),
+    onLoaded: ([eventList, auditVerification]) => {
+      setEvents(eventList.items);
+      setVerification(auditVerification);
+    },
+  });
 
   const diffPair = useMemo(() => {
     if (!activeComponent) return null;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -112,3 +112,26 @@
     background: hsl(var(--muted-foreground) / 0.5);
   }
 }
+
+@layer base {
+  :root {
+    /* Height claimed by full-width app chrome above the routes (today: the
+       session-expired banner). Zero unless the shell sets it. */
+    --app-chrome-offset: 0px;
+  }
+}
+
+@layer utilities {
+  /* Viewport-height helpers that stay correct while that chrome is showing.
+     Route layouts sized in raw 100vh would otherwise overflow by exactly the
+     banner height and push their own footers off-screen. */
+  .h-app-viewport {
+    height: calc(100vh - var(--app-chrome-offset));
+  }
+  .min-h-app-viewport {
+    min-height: calc(100vh - var(--app-chrome-offset));
+  }
+  .h-app-main {
+    height: calc(100vh - 4rem - var(--app-chrome-offset));
+  }
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -126,6 +126,17 @@ export function stashLoginNext(): void {
   if (next) window.sessionStorage.setItem(LOGIN_NEXT_KEY, next);
 }
 
+/**
+ * Remember exactly where the user was when a mid-session 401 hit, so the
+ * post-login redirect returns them to the same workspace, tab, and dialog.
+ */
+export function stashCurrentLocation(): void {
+  const next = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (next && !next.startsWith("/auth/callback")) {
+    window.sessionStorage.setItem(LOGIN_NEXT_KEY, next);
+  }
+}
+
 export function consumeStashedLoginNext(): string | null {
   const stored = window.sessionStorage.getItem(LOGIN_NEXT_KEY);
   if (stored) window.sessionStorage.removeItem(LOGIN_NEXT_KEY);

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -341,11 +341,11 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
     }, [currentCommit, projectId, selectedBranchRef]);
 
     if (loading) {
-        return <div className="flex items-center justify-center h-screen">Loading...</div>;
+        return <div className="flex items-center justify-center h-app-viewport">Loading...</div>;
     }
 
     if (!project) {
-        return <div className="flex items-center justify-center h-screen">Project not found</div>;
+        return <div className="flex items-center justify-center h-app-viewport">Project not found</div>;
     }
 
     const navItems = [
@@ -374,7 +374,7 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
     };
 
     return (
-        <div className="h-screen flex flex-col bg-background">
+        <div className="h-app-viewport flex flex-col bg-background">
             <header className="border-b px-4 md:px-6 py-4 flex items-center gap-4">
                 {/* Mobile Menu */}
                 <Sheet>

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -38,3 +38,16 @@ configure({ asyncUtilTimeout: 5_000 });
  * reason — there are no vitest globals here.
  */
 afterEach(cleanup);
+
+/**
+ * jsdom implements no layout, so it ships no `Element.scrollIntoView`.
+ *
+ * Any component that keeps a keyboard-highlighted row in view calls it and
+ * would otherwise throw during a passive effect — a failure in the component
+ * under test that says nothing about the component. Stubbed centrally rather
+ * than guarded at each call site, so production code is not shaped around a
+ * gap in the test environment.
+ */
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
## Why

Two things in the component workspace broke down once libraries got large or a session lapsed mid-edit:

- **Asset browsing didn't scale.** `/assets/browse` walked the entire symbol/footprint store on every dialog open and returned every path, which the UI dropped into a `Select`. Opening **Link existing** stalled, and the list was unusable at thousands of files.
- **A mid-session 401 threw away your work.** Any data endpoint returning 401 unmounted the app straight to the login screen.

## What changed

**Asset browsing is a server-side search.** `/assets/browse` now takes `q` and `limit` and returns `{files, total}`. The recursive walk is cached per asset type (30s TTL) so repeated dialog opens don't rescan the store. The picker is a debounced, abortable combobox: ↑/↓/Home/End/Enter over a real `role="listbox"`, options addressed by `aria-activedescendant` so focus stays in the search box, and a "showing N of M" footer when results are capped.

**The file picker is a proper control.** The old field styled the native `::file-selector-button`, which read as browser chrome rather than app chrome. New `FileInput` composes a real button segment, the filename, and a clear action. The native input stays in the DOM as `sr-only` instead of being replaced by a click-through button, so it remains focusable, Space/Enter still opens the OS dialog, and assistive tech still sees a file upload control. Clearing also resets the DOM value, otherwise re-picking the same file wouldn't fire `change`.

**Detach is uniform across asset kinds.** 3D and SPICE assets only had "Detach all … files", so removing one file out of several was impossible. They now get the same per-file cross as symbols and footprints, and the coarse per-type path is gone. `detach_asset_by_id` was already asset-type agnostic — its representation-reference guard only ever matches symbol/footprint — so no backend change was needed.

**Session expiry keeps your place.** A 401 from a data endpoint leaves the app mounted and shows a notice. Password re-auth completes in a dialog over the still-mounted app, so open dialogs and unsaved input survive. OIDC is a full-page redirect by nature, so that path says so plainly instead of promising the page is kept. The banner sits in normal flow and route layouts subtract its height via `--app-chrome-offset`, so it no longer covers the header it sits above.

Plus truncation fixes for content types, SHA-256 values, and revision headers that were overflowing their cards.

## Performance

Measured against a 20k-component catalog (17k assets, 44k `revision_assets`, 9,172 footprint files on disk):

| Path | Before | After |
|---|---|---|
| `/assets/search`, empty query (fires when the picker opens) | 498 ms | **8.8 ms** |
| `/assets/search`, typed term | 23–76 ms warm, 1296 ms cold | **15.7 ms** |
| Store walk blocking an unrelated asset type | up to 3.3 s | no longer blocks |

`search_assets` ordered by a computed `usage_count`, so the counts had to exist before `LIMIT` could apply — an aggregate over the whole `revision_assets` join for every asset of that type. The unfiltered listing now orders by the columns `idx_assets_kind` already covers and counts usage only for the page it returns. Typed searches keep usage ordering and gain trigram indexes, extending the existing `_ensure_postgres_search_indexes` mechanism rather than adding a new one.

The migration runs `ANALYZE assets` after creating those indexes: verified in a rolled-back transaction that until the table has statistics the planner ignores a brand-new index and keeps seq scanning (27 ms), and picks the bitmap scan once analyzed (0.9 ms). Without it every deploy would stay slow until autovacuum came around.

The stored-file browse walk held one lock shared across all four asset types, so a cold 3.3 s footprint walk delayed symbol browses that could have been answered from cache. Each type now has its own lock. Store writes also drop the cache, which closes the staleness window this PR previously documented — and a walk that started before a write no longer reinstates the listing it took.

## Consolidation

`LibraryAssetLinkPicker` and `StoredFilePicker` had grown separate copies of the same debounce, abort, and result-rendering logic, and only one had keyboard support. They now share `async-search-picker.tsx`, so the import picker gains ↑/↓, Home/End, Enter, and a real `role="listbox"` instead of one tab stop per result. The two data sources stay distinct: `/assets/search` returns registered asset *rows* (linking is a reference to a shared row), `/assets/browse` returns *files* on disk including ones no asset row points at yet.

The five per-tab evidence loaders in the component workspace differed only in URL and setter, and are now one `useEvidenceResource` hook — 272 lines out of that file.

## Testing

`tsc -b`, eslint, `vite build`, and the full frontend suite (417 tests / 52 files) pass. The backend suite passes too (955 tests, 84 skipped for want of `TEST_POSTGRES_URL`); the frontend suite is now 425 tests across 53 files.

New coverage is mutation-checked: removing the write invalidation, the walk-generation guard, the per-type locks, the arrow-key handling, the listbox role, the selection restore, the error surface, and the request abort each fail at least one test. Index behaviour was verified inside a rolled-back transaction, so nothing was created on the live database.

The live app has auth enabled with no dev or guest mode, so the new controls were verified by rendering them against the app's compiled CSS rather than by clicking through the real dialogs. **The re-auth dialog's happy path is unexercised and worth a manual pass.**

## Notes for review

- The browse cache staleness window flagged earlier in this PR is now closed: store writes invalidate the listing, and the TTL is only a backstop for changes made outside the process. One caveat — an import writing thousands of files clears the cache on each one, so a browse interleaved with a large import can re-walk. That is correct rather than cheap, and the per-type locks keep it off the other pickers.
- `DELETE /assets/{asset_type}` still exists on the backend but no longer has a frontend caller. Left in place in case something else consumes it.
- **Scope note:** the `search_assets` and picker-consolidation changes touch the import-remediation flow, which this PR did not originally cover. That picker's behaviour is unchanged apart from gaining keyboard support and surfacing search errors instead of silently showing an empty list.
- `/assets/browse` now has coverage (`backend/tests/test_catalog_asset_browse.py`, 11 tests): per-type extension scoping, case-insensitive matching across the whole relative path, `limit` capping the page after filtering while `total` keeps counting every match, the route's `limit`/`q` bounds, and error mapping. Verified by mutation — case-sensitive matching, an unstripped query, a `total` that counts the capped page, an endpoint that drops `total`, and a cache that never reuses its entry each fail at least one test.

