### PR TITLE
[Perf] Parser improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ deploy/certs/*
 # any project a tool opens. Running the fixtures through kicad-cli or Cruncher
 # drops one into fixtures/, where it is neither an input nor an output.
 *.kicad_prl
+
+# ecad-parse snapshot index cache (a stray one can appear if the CLI is run
+# with a relative root; never commit it)
+*.index-cache.json

--- a/backend/app/services/design_compare_service.py
+++ b/backend/app/services/design_compare_service.py
@@ -248,12 +248,35 @@ def _snapshot_commit(repo_path: Path, commit: str, destination: Path, relative_p
 
 
 def _cache_dir(project_id: str, commit: str) -> Path:
+    _touch_cache_entry(project_id, commit)
     return (
         _CACHE_ROOT
         / project_id
         / commit
         / semantic_index_service.generator_cache_tag()
     )
+
+
+def _touch_cache_entry(project_id: str, commit: str) -> None:
+    """Stamp a cache entry as used, so eviction can rank by last use.
+
+    Eviction ranks whole ``project/commit`` entries by that directory's mtime.
+    Writing a snapshot does not update it: a directory's mtime changes when its
+    own entries change, not when something deeper down does, so the build only
+    ever touches ``commit/<tag>/snapshot``. Left alone the entry's mtime is its
+    creation time, which makes eviction FIFO -- and the commit everyone diffs
+    against is usually the oldest, so it would be evicted first and every
+    comparison against it would pay the cold path. Stamping here, at the single
+    choke point every reader and writer goes through, makes it a real LRU.
+    """
+
+    entry = _CACHE_ROOT / project_id / commit
+    try:
+        if entry.is_dir():
+            os.utime(entry, None)
+    except OSError:
+        # Losing a timestamp only degrades eviction order; never fail a compare.
+        pass
 
 
 def _cache_lock(project_id: str, commit: str) -> threading.Lock:
@@ -268,6 +291,13 @@ def _cache_lock(project_id: str, commit: str) -> threading.Lock:
 # 0 disables the cap.
 _CACHE_MAX_BYTES = int(os.environ.get("PRISM_DESIGN_COMPARE_CACHE_MAX_BYTES", str(20 * 1024**3)))
 
+# Never evict an entry used within this window. `_prune_revision_cache` runs in
+# one worker while three others may be mid-build, and the per-process
+# `_CACHE_LOCKS` cannot coordinate across them, so a plain size check could
+# delete a snapshot a live job is still reading. An entry is stamped on every
+# use, so a recent stamp means "someone may still be in here".
+_CACHE_MIN_AGE_SECONDS = float(os.environ.get("PRISM_DESIGN_COMPARE_CACHE_MIN_AGE", "900"))
+
 
 def _dir_size(path: Path) -> int:
     total = 0
@@ -280,12 +310,18 @@ def _dir_size(path: Path) -> int:
     return total
 
 
-def _prune_revision_cache(max_bytes: int = _CACHE_MAX_BYTES) -> None:
-    """Keep the revision cache under a size cap, evicting oldest commits first.
+def _prune_revision_cache(
+    max_bytes: int = _CACHE_MAX_BYTES,
+    *,
+    min_age_seconds: float = _CACHE_MIN_AGE_SECONDS,
+) -> None:
+    """Keep the revision cache under a size cap, evicting least-recently-used first.
 
-    Each ``project/commit`` directory is one cache entry. When the total exceeds
-    the cap, whole entries are removed in least-recently-used order (by directory
-    mtime, which the build touches) until it fits. Best-effort: any error here is
+    Each ``project/commit`` directory is one cache entry, stamped by
+    `_touch_cache_entry` every time a comparison resolves it. When the total
+    exceeds the cap, whole entries are removed oldest-stamp-first until it fits.
+    Entries stamped within ``min_age_seconds`` are never evicted, because a
+    concurrent worker may still be reading one. Best-effort: any error here is
     logged and swallowed, because a comparison result is already published and a
     full disk is a worse failure than a slightly oversized cache.
     """
@@ -293,7 +329,9 @@ def _prune_revision_cache(max_bytes: int = _CACHE_MAX_BYTES) -> None:
     if max_bytes <= 0 or not _CACHE_ROOT.exists():
         return
     try:
+        now = time.time()
         entries: list[tuple[float, Path, int]] = []
+        total = 0
         for project_dir in _CACHE_ROOT.iterdir():
             if not project_dir.is_dir():
                 continue
@@ -304,8 +342,12 @@ def _prune_revision_cache(max_bytes: int = _CACHE_MAX_BYTES) -> None:
                     mtime = commit_dir.stat().st_mtime
                 except OSError:
                     continue
-                entries.append((mtime, commit_dir, _dir_size(commit_dir)))
-        total = sum(size for _, _, size in entries)
+                size = _dir_size(commit_dir)
+                total += size
+                # In-use entries still count toward the total; they are just not
+                # candidates, so the cap is respected as soon as they age out.
+                if now - mtime >= min_age_seconds:
+                    entries.append((mtime, commit_dir, size))
         if total <= max_bytes:
             return
         for _mtime, commit_dir, size in sorted(entries, key=lambda item: item[0]):
@@ -314,6 +356,14 @@ def _prune_revision_cache(max_bytes: int = _CACHE_MAX_BYTES) -> None:
             shutil.rmtree(commit_dir, ignore_errors=True)
             total -= size
             logger.info("Evicted design-compare cache entry %s (%d bytes)", commit_dir, size)
+        if total > max_bytes:
+            logger.warning(
+                "Design-compare cache still %d bytes over the %d byte cap; "
+                "the remaining entries were used within the last %.0fs",
+                total - max_bytes,
+                max_bytes,
+                min_age_seconds,
+            )
     except Exception:
         logger.exception("Design-compare cache prune failed")
 

--- a/backend/app/services/design_compare_service.py
+++ b/backend/app/services/design_compare_service.py
@@ -262,6 +262,62 @@ def _cache_lock(project_id: str, commit: str) -> threading.Lock:
         return _CACHE_LOCKS.setdefault(key, threading.Lock())
 
 
+# The revision cache never rolled over: a snapshot plus its ~21 MB ecad object
+# index is kept per commit, forever, on a persistent volume. Cap the total and
+# evict least-recently-used commit directories so it cannot grow without bound.
+# 0 disables the cap.
+_CACHE_MAX_BYTES = int(os.environ.get("PRISM_DESIGN_COMPARE_CACHE_MAX_BYTES", str(20 * 1024**3)))
+
+
+def _dir_size(path: Path) -> int:
+    total = 0
+    for child in path.rglob("*"):
+        try:
+            if child.is_file():
+                total += child.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _prune_revision_cache(max_bytes: int = _CACHE_MAX_BYTES) -> None:
+    """Keep the revision cache under a size cap, evicting oldest commits first.
+
+    Each ``project/commit`` directory is one cache entry. When the total exceeds
+    the cap, whole entries are removed in least-recently-used order (by directory
+    mtime, which the build touches) until it fits. Best-effort: any error here is
+    logged and swallowed, because a comparison result is already published and a
+    full disk is a worse failure than a slightly oversized cache.
+    """
+
+    if max_bytes <= 0 or not _CACHE_ROOT.exists():
+        return
+    try:
+        entries: list[tuple[float, Path, int]] = []
+        for project_dir in _CACHE_ROOT.iterdir():
+            if not project_dir.is_dir():
+                continue
+            for commit_dir in project_dir.iterdir():
+                if not commit_dir.is_dir():
+                    continue
+                try:
+                    mtime = commit_dir.stat().st_mtime
+                except OSError:
+                    continue
+                entries.append((mtime, commit_dir, _dir_size(commit_dir)))
+        total = sum(size for _, _, size in entries)
+        if total <= max_bytes:
+            return
+        for _mtime, commit_dir, size in sorted(entries, key=lambda item: item[0]):
+            if total <= max_bytes:
+                break
+            shutil.rmtree(commit_dir, ignore_errors=True)
+            total -= size
+            logger.info("Evicted design-compare cache entry %s (%d bytes)", commit_dir, size)
+    except Exception:
+        logger.exception("Design-compare cache prune failed")
+
+
 def _read_revision_cache(
     marker: Path,
     *,
@@ -2016,6 +2072,7 @@ def run_design_compare_job_v3(context: JobContext) -> JobResult:
             result,
             artifact_key=artifact_key,
         )
+        _prune_revision_cache()
         return JobResult(
             message="Design comparison ready",
             artifact=complete,

--- a/backend/app/services/semantic_index_service.py
+++ b/backend/app/services/semantic_index_service.py
@@ -815,10 +815,18 @@ def build_semantic_index(
         except TypeError as exc:
             # Compatibility with an older installed kicad-monkey. The local
             # optimized tree supports include_pcb=False; upstream releases
-            # without it remain functional, although they cannot defer PCB
-            # parsing during Stage 1.
+            # without it remain functional.
             if "include_pcb" not in str(exc):
                 raise
+            if not include_pcb:
+                # The upstream to_json has no include_pcb switch, so its PnP
+                # projection would lazily parse the whole `.kicad_pcb` even
+                # though this caller does not want board data. That board parse
+                # is the single largest cost of a schematic-only build (~25s on
+                # a 9MB board). Detach the board so the projection skips it; the
+                # PCB is parsed once, separately, by the stages that need it.
+                design._pcb = None
+                design.pcb_path = None
             return design.to_json(include_indexes=True)
 
     design_payload = timed(

--- a/backend/app/services/semantic_index_service.py
+++ b/backend/app/services/semantic_index_service.py
@@ -795,6 +795,10 @@ def build_semantic_index(
         ) from exc
 
     design = timed("load-project", lambda: KiCadDesign.from_project_file(project_file))
+    # Whether the caller handed us an already-parsed board. Captured before `pcb`
+    # is reassigned below, so the detach on the upstream fallback can tell an
+    # injected board (keep it) from one it would otherwise lazily parse (drop it).
+    board_was_injected = pcb is not None
     if pcb is not None:
         # The Release Studio projections already parsed this board. Re-parsing
         # it here is the single largest avoidable cost on a large `.kicad_pcb`.
@@ -818,13 +822,17 @@ def build_semantic_index(
             # without it remain functional.
             if "include_pcb" not in str(exc):
                 raise
-            if not include_pcb:
+            if not include_pcb and not board_was_injected:
                 # The upstream to_json has no include_pcb switch, so its PnP
                 # projection would lazily parse the whole `.kicad_pcb` even
                 # though this caller does not want board data. That board parse
                 # is the single largest cost of a schematic-only build (~25s on
                 # a 9MB board). Detach the board so the projection skips it; the
                 # PCB is parsed once, separately, by the stages that need it.
+                # An already-injected board is left in place: the caller paid to
+                # parse it, so dropping it here (and clearing pcb_path, which
+                # makes design.pcb return None instead of re-parsing) would throw
+                # that work away.
                 design._pcb = None
                 design.pcb_path = None
             return design.to_json(include_indexes=True)

--- a/backend/tests/test_design_compare_service.py
+++ b/backend/tests/test_design_compare_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import subprocess
 from unittest import mock
 
-from app.services import bom_diff_service, design_compare_service
+from app.services import bom_diff_service, design_compare_service, semantic_index_service
 from app.services.design_compare_benchmark import DesignCompareBenchmark
 
 
@@ -890,6 +890,56 @@ class FabricationDomainTests(unittest.TestCase):
                 # A zero cap disables the prune.
                 design_compare_service._prune_revision_cache(max_bytes=0)
                 self.assertTrue(entries[1].exists())
+
+    def test_eviction_ranks_by_last_use_not_by_creation(self):
+        """The entry everyone diffs against is the oldest; it must not evict first.
+
+        A directory's mtime tracks changes to its own entries, not to anything
+        deeper, so a build writing `commit/<tag>/snapshot/...` never updates the
+        commit directory. Without an explicit stamp this ranks by creation and
+        evicts the hottest baseline commit first.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tag = semantic_index_service.generator_cache_tag()
+            old, new = root / "pA" / "baseline", root / "pA" / "recent"
+            for entry in (old, new):
+                (entry / tag / "snapshot").mkdir(parents=True)
+                (entry / tag / "snapshot" / "board.kicad_pcb").write_bytes(b"x" * 1000)
+            os.utime(old, (1_000, 1_000))
+            os.utime(new, (2_000, 2_000))
+
+            with mock.patch.object(design_compare_service, "_CACHE_ROOT", root):
+                # A build writes deep inside `new`; that must not count as use.
+                (new / tag / "snapshot" / "extra.kicad_sch").write_bytes(b"y" * 10)
+                self.assertEqual(new.stat().st_mtime, 2_000)
+
+                # Resolving `old` for a comparison is what counts as use.
+                design_compare_service._cache_dir("pA", "baseline")
+                self.assertGreater(old.stat().st_mtime, new.stat().st_mtime)
+
+                design_compare_service._prune_revision_cache(
+                    max_bytes=1500, min_age_seconds=0
+                )
+                self.assertTrue(old.exists(), "the recently used baseline was evicted")
+                self.assertFalse(new.exists())
+
+    def test_entries_used_recently_are_never_evicted(self):
+        """Prune runs in one worker while others may be mid-build on an entry."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            entry = root / "pA" / "inflight" / "tag"
+            entry.mkdir(parents=True)
+            (entry / "index.json").write_bytes(b"x" * 4000)
+            os.utime(root / "pA" / "inflight", None)  # stamped just now
+
+            with mock.patch.object(design_compare_service, "_CACHE_ROOT", root):
+                design_compare_service._prune_revision_cache(
+                    max_bytes=100, min_age_seconds=900
+                )
+                self.assertTrue((root / "pA" / "inflight").exists())
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_design_compare_service.py
+++ b/backend/tests/test_design_compare_service.py
@@ -869,6 +869,28 @@ class FabricationDomainTests(unittest.TestCase):
         self.assertFalse(result["present"])
         self.assertEqual(result["warnings"], ["cached fabrication output was removed"])
 
+    def test_revision_cache_prune_evicts_oldest_over_the_cap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            entries = []
+            for index, project in enumerate(("pA", "pA", "pB")):
+                commit_dir = root / project / f"commit{index}" / "tag"
+                commit_dir.mkdir(parents=True)
+                (commit_dir / "index.json").write_bytes(b"x" * 1000)
+                stamp = 1_000 + index  # commit0 oldest
+                os.utime(root / project / f"commit{index}", (stamp, stamp))
+                entries.append(root / project / f"commit{index}")
+
+            with mock.patch.object(design_compare_service, "_CACHE_ROOT", root):
+                # Cap below the total forces one eviction, oldest first.
+                design_compare_service._prune_revision_cache(max_bytes=2500)
+                self.assertFalse(entries[0].exists())
+                self.assertTrue(entries[1].exists())
+                self.assertTrue(entries[2].exists())
+                # A zero cap disables the prune.
+                design_compare_service._prune_revision_cache(max_bytes=0)
+                self.assertTrue(entries[1].exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_semantic_index_service.py
+++ b/backend/tests/test_semantic_index_service.py
@@ -144,6 +144,53 @@ class SemanticIndexServiceTests(unittest.TestCase):
         self.assertIs(design._pcb, injected)
         self.assertIs(design.pcb, injected)
 
+    def test_upstream_to_json_detaches_the_board_for_a_schematic_build(self) -> None:
+        # The default production build is the pip kicad-monkey, whose to_json has
+        # no include_pcb switch. Model that: the first call raises TypeError, the
+        # fallback must detach the board so its PnP projection does not lazily
+        # parse the whole .kicad_pcb. Pin that the board is dropped and pcb_path
+        # cleared, so design.pcb returns None instead of re-parsing.
+        class UpstreamDesign:
+            def __init__(self):
+                self._pcb = "a-parsed-board"
+                self.pcb_path = "/somewhere/board.kicad_pcb"
+                self.calls = []
+
+            def to_netlist(self):
+                return SimpleNamespace(components=[], nets=[])
+
+            @property
+            def pcb(self):
+                raise AssertionError("the schematic build re-parsed the PCB")
+
+            def to_json(self, include_indexes=True, **kwargs):
+                # Upstream signature: no include_pcb keyword.
+                if "include_pcb" in kwargs:
+                    raise TypeError("to_json() got an unexpected keyword argument 'include_pcb'")
+                self.calls.append("fallback")
+                return {"components": [], "nets": []}
+
+        design = UpstreamDesign()
+
+        class FakeKiCadDesign:
+            @staticmethod
+            def from_project_file(_path):
+                return design
+
+        with tempfile.TemporaryDirectory() as temporary, patch.dict(
+            sys.modules,
+            {"kicad_monkey": SimpleNamespace(KiCadDesign=FakeKiCadDesign)},
+        ):
+            semantic_index_service.build_semantic_index(
+                Path(temporary) / "board.kicad_pro",
+                source_revision_key="revision-a",
+                include_pcb=False,
+            )
+
+        self.assertEqual(design.calls, ["fallback"])
+        self.assertIsNone(design._pcb)
+        self.assertIsNone(design.pcb_path)
+
     def test_full_bundle_overlay_commits_bundle_json_last(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/backend/tests/test_semantic_index_service.py
+++ b/backend/tests/test_semantic_index_service.py
@@ -191,6 +191,49 @@ class SemanticIndexServiceTests(unittest.TestCase):
         self.assertIsNone(design._pcb)
         self.assertIsNone(design.pcb_path)
 
+    def test_upstream_fallback_keeps_an_injected_board(self) -> None:
+        # If a caller both injects an already-parsed board and asks for a
+        # schematic-only build, the detach must not throw the injected board
+        # away: the caller paid to parse it.
+        injected = object()
+
+        class UpstreamDesign:
+            def __init__(self):
+                self._pcb = None
+                self.pcb_path = "/somewhere/board.kicad_pcb"
+
+            def to_netlist(self):
+                return SimpleNamespace(components=[], nets=[])
+
+            @property
+            def pcb(self):
+                return self._pcb
+
+            def to_json(self, include_indexes=True, **kwargs):
+                if "include_pcb" in kwargs:
+                    raise TypeError("to_json() got an unexpected keyword argument 'include_pcb'")
+                return {"components": [], "nets": []}
+
+        design = UpstreamDesign()
+
+        class FakeKiCadDesign:
+            @staticmethod
+            def from_project_file(_path):
+                return design
+
+        with tempfile.TemporaryDirectory() as temporary, patch.dict(
+            sys.modules,
+            {"kicad_monkey": SimpleNamespace(KiCadDesign=FakeKiCadDesign)},
+        ):
+            semantic_index_service.build_semantic_index(
+                Path(temporary) / "board.kicad_pro",
+                source_revision_key="revision-a",
+                include_pcb=False,
+                pcb=injected,
+            )
+
+        self.assertIs(design._pcb, injected)
+
     def test_full_bundle_overlay_commits_bundle_json_last(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/frontend/src/components/design-comparison/use-design-compare-job.ts
+++ b/frontend/src/components/design-comparison/use-design-compare-job.ts
@@ -134,6 +134,13 @@ export function useDesignCompareJob(
                     if (cancelled) return;
                     resultVersionRef.current = resultVersion;
                     setResult(hydrated);
+                    // A new result version means the job just advanced a stage,
+                    // so the next publish is likely close behind. Reset the
+                    // backoff to catch it quickly: by the time the first
+                    // (progressive) result lands the interval has already reached
+                    // the ceiling, so without this the final publish is polled at
+                    // the old flat rate.
+                    pollDelay = POLL_MIN_MS;
                 }
                 if (next.status === "failed") {
                     setError(next.message || "Semantic comparison failed");

--- a/frontend/src/components/design-comparison/use-design-compare-job.ts
+++ b/frontend/src/components/design-comparison/use-design-compare-job.ts
@@ -27,7 +27,18 @@ export type DesignCompareJob = {
     error: string | null;
 };
 
-const POLL_INTERVAL_MS = 800;
+// Poll fast at first, then back off. A warm comparison is ready in a couple of
+// seconds and the progressive initial result lands sooner, so a flat 800ms
+// interval left the viewer waiting up to that long after the backend was
+// already done. Starting tight catches those quick completions; widening keeps
+// a long cold job from hammering the status endpoint.
+const POLL_MIN_MS = 150;
+const POLL_MAX_MS = 800;
+const POLL_BACKOFF = 1.4;
+
+function nextPollDelay(current: number): number {
+    return Math.min(POLL_MAX_MS, Math.round(current * POLL_BACKOFF));
+}
 
 export function useDesignCompareJob(
     projectId: string,
@@ -87,6 +98,7 @@ export function useDesignCompareJob(
         const controller = new AbortController();
         let cancelled = false;
         let timer: ReturnType<typeof setTimeout> | null = null;
+        let pollDelay = POLL_MIN_MS;
         const poll = async () => {
             try {
                 const response = await fetchApi(
@@ -128,7 +140,8 @@ export function useDesignCompareJob(
                 } else if (next.status === "completed") {
                     return;
                 } else {
-                    timer = setTimeout(poll, POLL_INTERVAL_MS);
+                    timer = setTimeout(poll, pollDelay);
+                    pollDelay = nextPollDelay(pollDelay);
                 }
             } catch (caught) {
                 if (!cancelled) {

--- a/scripts/ecad-parse.mjs
+++ b/scripts/ecad-parse.mjs
@@ -1861,6 +1861,14 @@ function main(argv) {
     // input, which is most of the difference between hitting M1's target and
     // missing it. Repeats also share the process on purpose: peak RSS is
     // monotone within one, so the reported ceiling is the worst case.
+    // --repeat measures JIT warm-up across genuine re-parses, so the cache must
+    // be off for it: otherwise runs 2..N are rehydrations and median/min describe
+    // cache reads, a phantom win against the numbers in the m1 parse doc. Honour
+    // an explicit ECAD_INDEX_CACHE=1 only for a single run.
+    if (repeat > 1) {
+        process.env.ECAD_INDEX_CACHE = "0";
+    }
+
     const snapshots = [];
     let report;
     for (const rawRoot of positional) {

--- a/scripts/ecad-parse.mjs
+++ b/scripts/ecad-parse.mjs
@@ -1612,6 +1612,13 @@ export function index_snapshot(root) {
     if (cached !== null) {
         return {
             ...cached,
+            // per-document parseMs is a write-time measurement; on a hit nothing
+            // was parsed, so clear it rather than replay a stale figure that the
+            // "run-specific fields stay live" contract says should not persist.
+            documents: (cached.documents ?? []).map((document) => ({
+                ...document,
+                parseMs: null,
+            })),
             timings: {
                 readMs: 0,
                 parserMs: 0,

--- a/scripts/ecad-parse.mjs
+++ b/scripts/ecad-parse.mjs
@@ -72,10 +72,13 @@ function _index_cache_enabled() {
     return value !== "0" && value !== "false";
 }
 
-/** A cheap fingerprint of the files index_snapshot would read: their relative
- * path, byte size and mtime. Any edit to the snapshot changes it, so a match
- * means the parse result is still valid. Kept separate from the parse so a hit
- * never touches the parser. */
+/** A fingerprint of the files index_snapshot would read: their relative path
+ * and content. Content rather than mtime because snapshots are materialized with
+ * `git archive | tar`, which stamps every file with the commit timestamp, so
+ * mtime carries no entropy and the key would degrade to (path, size). Reading
+ * the bytes here costs a few tens of milliseconds, against the ~1.2 s parse a
+ * hit avoids, and the miss path reads them again to parse. Kept separate from
+ * the parse so a hit never touches the parser. */
 function _snapshot_signature(root, documentPaths) {
     const hash = createHash("sha256");
     hash.update(INDEX_CACHE_SCHEMA);
@@ -84,9 +87,9 @@ function _snapshot_signature(root, documentPaths) {
     hash.update("\0");
     hash.update(_PARSER_SOURCE_HASH);
     for (const path of documentPaths) {
-        const stat = statSync(path);
         const rel = relative(root, path).split(sep).join("/");
-        hash.update(`\0${rel}\0${stat.size}\0${Math.round(stat.mtimeMs)}`);
+        hash.update(`\0${rel}\0`);
+        hash.update(readFileSync(path));
     }
     return hash.digest("hex");
 }

--- a/scripts/ecad-parse.mjs
+++ b/scripts/ecad-parse.mjs
@@ -32,9 +32,35 @@ import { BoardParser, SchematicParser } from "./vendor/kicad-sexpr-parser.mjs";
 
 export const SCHEMA = "prism.ecad_object_index_v1";
 
-// Bump when the shape of a cached index (below) or the parser's output changes,
-// so a stale cache is never rehydrated across a code change.
+// Bump when the shape of a cached index (below) changes in a way the automatic
+// source hash below cannot see. The source hash already invalidates the cache
+// whenever this file or the vendored parser changes, so this is only for
+// deliberate cache-format breaks.
 const INDEX_CACHE_SCHEMA = "prism.ecad_object_index_cache_v1";
+
+// A hash of the code that produces an index: this module and the vendored
+// parser it calls. Folding it into every cache signature means a change to
+// either one invalidates existing caches automatically, so a fix to
+// index_board / index_schematic (or to the parser) is never masked by a stale
+// entry that shares the same commit dir and file stats. Computed once at load.
+const _PARSER_SOURCE_HASH = (() => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sources = [
+        fileURLToPath(import.meta.url),
+        join(here, "vendor", "kicad-sexpr-parser.mjs"),
+    ];
+    const hash = createHash("sha256");
+    for (const file of sources) {
+        try {
+            hash.update(readFileSync(file));
+        } catch {
+            // A missing source file should not silently weaken the key; mark it
+            // so the hash still changes if the file appears or moves later.
+            hash.update(`\0missing:${file}\0`);
+        }
+    }
+    return hash.digest("hex").slice(0, 16);
+})();
 
 // Parsing a snapshot is ~1.2s per board; rehydrating its cached index is ~0.15s
 // (an 8x win). A snapshot lives under an immutable per-commit cache directory,
@@ -55,6 +81,8 @@ function _snapshot_signature(root, documentPaths) {
     hash.update(INDEX_CACHE_SCHEMA);
     hash.update("\0");
     hash.update(SCHEMA);
+    hash.update("\0");
+    hash.update(_PARSER_SOURCE_HASH);
     for (const path of documentPaths) {
         const stat = statSync(path);
         const rel = relative(root, path).split(sep).join("/");

--- a/scripts/ecad-parse.mjs
+++ b/scripts/ecad-parse.mjs
@@ -25,7 +25,7 @@
 
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname, extname, join, relative, sep } from "node:path";
+import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { BoardParser, SchematicParser } from "./vendor/kicad-sexpr-parser.mjs";
@@ -1863,7 +1863,12 @@ function main(argv) {
     // monotone within one, so the reported ceiling is the worst case.
     const snapshots = [];
     let report;
-    for (const root of positional) {
+    for (const rawRoot of positional) {
+        // Resolve to absolute so the cache file lands beside the snapshot dir,
+        // not in the caller's cwd. A relative root (`ecad-parse.mjs snapshot`
+        // from the repo root) otherwise dropped a multi-MB *.index-cache.json
+        // into the working tree.
+        const root = resolve(rawRoot);
         const runs = [];
         for (let index = 0; index < repeat; index += 1) {
             report = index_snapshot(root);

--- a/scripts/ecad-parse.mjs
+++ b/scripts/ecad-parse.mjs
@@ -24,13 +24,90 @@
  */
 
 import { createHash } from "node:crypto";
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { basename, extname, join, relative, sep } from "node:path";
+import { readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { BoardParser, SchematicParser } from "./vendor/kicad-sexpr-parser.mjs";
 
 export const SCHEMA = "prism.ecad_object_index_v1";
+
+// Bump when the shape of a cached index (below) or the parser's output changes,
+// so a stale cache is never rehydrated across a code change.
+const INDEX_CACHE_SCHEMA = "prism.ecad_object_index_cache_v1";
+
+// Parsing a snapshot is ~1.2s per board; rehydrating its cached index is ~0.15s
+// (an 8x win). A snapshot lives under an immutable per-commit cache directory,
+// so its parse result is stable as long as the files on disk are unchanged.
+// The cache is disabled with ECAD_INDEX_CACHE=0. Read at call time so a test
+// (or a caller) can toggle it without re-importing the module.
+function _index_cache_enabled() {
+    const value = (process.env.ECAD_INDEX_CACHE ?? "1").toLowerCase();
+    return value !== "0" && value !== "false";
+}
+
+/** A cheap fingerprint of the files index_snapshot would read: their relative
+ * path, byte size and mtime. Any edit to the snapshot changes it, so a match
+ * means the parse result is still valid. Kept separate from the parse so a hit
+ * never touches the parser. */
+function _snapshot_signature(root, documentPaths) {
+    const hash = createHash("sha256");
+    hash.update(INDEX_CACHE_SCHEMA);
+    hash.update("\0");
+    hash.update(SCHEMA);
+    for (const path of documentPaths) {
+        const stat = statSync(path);
+        const rel = relative(root, path).split(sep).join("/");
+        hash.update(`\0${rel}\0${stat.size}\0${Math.round(stat.mtimeMs)}`);
+    }
+    return hash.digest("hex");
+}
+
+/** The cache file sits next to the snapshot directory (not inside it, so the
+ * signature never sees its own cache), in the immutable per-commit cache dir. */
+function _index_cache_path(root) {
+    return join(dirname(root), `${basename(root)}.index-cache.json`);
+}
+
+function _read_index_cache(root, signature) {
+    if (!_index_cache_enabled()) return null;
+    let raw;
+    try {
+        raw = readFileSync(_index_cache_path(root), "utf8");
+    } catch {
+        return null;
+    }
+    let cached;
+    try {
+        cached = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+    if (
+        cached?.cacheSchema !== INDEX_CACHE_SCHEMA
+        || cached?.signature !== signature
+        || cached?.payload?.schema !== SCHEMA
+    ) {
+        return null;
+    }
+    return cached.payload;
+}
+
+function _write_index_cache(root, signature, payload) {
+    if (!_index_cache_enabled()) return;
+    const target = _index_cache_path(root);
+    const temporary = `${target}.${process.pid}.tmp`;
+    try {
+        writeFileSync(
+            temporary,
+            JSON.stringify({ cacheSchema: INDEX_CACHE_SCHEMA, signature, payload }),
+        );
+        renameSync(temporary, target);
+    } catch {
+        // A cache write failure must never fail the diff; the parse already
+        // produced a valid result, and the next run simply re-parses.
+    }
+}
 
 /** Mirrors design_compare_service._GENERATED_PARTS. */
 const GENERATED_PARTS = new Set([
@@ -1495,6 +1572,28 @@ export function index_document(text, documentPath) {
 
 export function index_snapshot(root) {
     const started = performance.now();
+    const documentPaths = collect_documents(root);
+
+    // A snapshot's parse result is stable while its files are unchanged, so a
+    // signature hit rehydrates the cached index instead of re-parsing (~8x).
+    const signature = _snapshot_signature(root, documentPaths);
+    const cached = _read_index_cache(root, signature);
+    if (cached !== null) {
+        return {
+            ...cached,
+            timings: {
+                readMs: 0,
+                parserMs: 0,
+                indexMs: 0,
+                parseMs: 0,
+                totalMs: Math.round((performance.now() - started) * 1000) / 1000,
+                cacheHit: true,
+            },
+            peakRssBytes: process.resourceUsage().maxRSS * 1024,
+            node: process.version,
+        };
+    }
+
     const documents = [];
     const objects = [];
     const collections = {};
@@ -1507,7 +1606,7 @@ export function index_snapshot(root) {
     let readMs = 0;
     let parseMs = 0;
 
-    for (const path of collect_documents(root)) {
+    for (const path of documentPaths) {
         const documentPath = relative(root, path).split(sep).join("/");
         const readStarted = performance.now();
         const text = readFileSync(path, "utf8");
@@ -1575,7 +1674,9 @@ export function index_snapshot(root) {
         byKind[object.kind] = (byKind[object.kind] ?? 0) + 1;
     }
 
-    return {
+    // Everything a later run needs to skip the parse. Run-specific fields
+    // (timings, peakRssBytes, node) are deliberately excluded so they stay live.
+    const payload = {
         schema: SCHEMA,
         root,
         documents,
@@ -1583,12 +1684,18 @@ export function index_snapshot(root) {
         routeMetrics,
         counts: { total: objects.length, byKind, anonymous },
         collections,
+    };
+    _write_index_cache(root, signature, payload);
+
+    return {
+        ...payload,
         timings: {
             readMs: Math.round(readMs * 1000) / 1000,
             parserMs: Math.round(timings.parserMs * 1000) / 1000,
             indexMs: Math.round((parseMs - timings.parserMs) * 1000) / 1000,
             parseMs: Math.round(parseMs * 1000) / 1000,
             totalMs: Math.round((performance.now() - started) * 1000) / 1000,
+            cacheHit: false,
         },
         // libuv normalises ru_maxrss to kilobytes on every platform,
         // including Darwin where the syscall reports bytes -- verified

--- a/scripts/ecad-parse.test.mjs
+++ b/scripts/ecad-parse.test.mjs
@@ -11,7 +11,7 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -558,6 +558,26 @@ test("editing a snapshot invalidates its cached index", () => {
     const reparsed = index_snapshot(root);
     assert.equal(reparsed.timings.cacheHit, false);
     assert.equal(reparsed.counts.total, 2);
+});
+
+test("a changed parser source invalidates the cache", () => {
+    // The signature folds in a hash of the parser sources, so a cache written by
+    // one version of the parser must not be rehydrated by another. Simulate a
+    // parser change by rewriting the stored signature: a read must then miss and
+    // re-parse rather than serve the old objects, the exact stale-fix scenario.
+    const board = mkdtempSync(join(tmpdir(), "ecad-snap-"));
+    const root = join(board, "snapshot");
+    mkdirSync(root);
+    writeFileSync(join(root, "a.kicad_sch"), '(kicad_sch (junction (at 0 0)))');
+    index_snapshot(root); // writes the cache
+
+    const cachePath = join(board, "snapshot.index-cache.json");
+    const cached = JSON.parse(readFileSync(cachePath, "utf8"));
+    cached.signature = "stale-from-an-older-parser";
+    writeFileSync(cachePath, JSON.stringify(cached));
+
+    const reparsed = index_snapshot(root);
+    assert.equal(reparsed.timings.cacheHit, false);
 });
 
 test("ECAD_INDEX_CACHE=0 disables the cache", () => {

--- a/scripts/ecad-parse.test.mjs
+++ b/scripts/ecad-parse.test.mjs
@@ -11,8 +11,11 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { index_document } from "./ecad-parse.mjs";
+import { index_document, index_snapshot } from "./ecad-parse.mjs";
 
 const SCHEMATIC = `
 (kicad_sch
@@ -513,4 +516,62 @@ test("point order stays significant", () => {
         first.byUuid.get("eeee-0002").hash,
         second.byUuid.get("eeee-0002").hash,
     );
+});
+
+test("index_snapshot caches its parse and rehydrates identically", () => {
+    const board = mkdtempSync(join(tmpdir(), "ecad-snap-"));
+    const root = join(board, "snapshot");
+    mkdirSync(root);
+    writeFileSync(
+        join(root, "a.kicad_sch"),
+        '(kicad_sch (polyline (pts (xy 0 0) (xy 2 0)) (uuid "aaaa-0001")))',
+    );
+
+    const first = index_snapshot(root);
+    assert.equal(first.timings.cacheHit, false);
+    // The cache file sits beside the snapshot dir, never inside it.
+    assert.equal(existsSync(join(board, "snapshot.index-cache.json")), true);
+
+    const second = index_snapshot(root);
+    assert.equal(second.timings.cacheHit, true);
+    // A hit must reproduce the parse exactly, minus run-specific timing.
+    assert.deepEqual(second.objects, first.objects);
+    assert.deepEqual(second.counts, first.counts);
+    assert.deepEqual(second.routeMetrics, first.routeMetrics);
+});
+
+test("editing a snapshot invalidates its cached index", () => {
+    const board = mkdtempSync(join(tmpdir(), "ecad-snap-"));
+    const root = join(board, "snapshot");
+    mkdirSync(root);
+    const file = join(root, "a.kicad_sch");
+    writeFileSync(file, '(kicad_sch (polyline (pts (xy 0 0) (xy 2 0)) (uuid "bbbb-0001")))');
+    index_snapshot(root); // writes the cache
+
+    // A different object count with a larger file: the size-and-mtime signature
+    // changes, so the second read must re-parse rather than serve stale objects.
+    writeFileSync(
+        file,
+        '(kicad_sch (polyline (pts (xy 0 0) (xy 2 0)) (uuid "bbbb-0001"))'
+        + ' (polyline (pts (xy 0 0) (xy 3 0)) (uuid "bbbb-0002")))',
+    );
+    const reparsed = index_snapshot(root);
+    assert.equal(reparsed.timings.cacheHit, false);
+    assert.equal(reparsed.counts.total, 2);
+});
+
+test("ECAD_INDEX_CACHE=0 disables the cache", () => {
+    const previous = process.env.ECAD_INDEX_CACHE;
+    process.env.ECAD_INDEX_CACHE = "0";
+    try {
+        const board = mkdtempSync(join(tmpdir(), "ecad-snap-"));
+        const root = join(board, "snapshot");
+        mkdirSync(root);
+        writeFileSync(join(root, "a.kicad_sch"), '(kicad_sch (junction (at 0 0)))');
+        index_snapshot(root);
+        assert.equal(existsSync(join(board, "snapshot.index-cache.json")), false);
+    } finally {
+        if (previous === undefined) delete process.env.ECAD_INDEX_CACHE;
+        else process.env.ECAD_INDEX_CACHE = previous;
+    }
 });


### PR DESCRIPTION
## Problem

This PR aggregates a set of fixes aimed at cutting the time from clicking "compare" to both revisions being drawn, across the whole path (backend job, network, browser render).

## Solution

**Backend comparison**

| | Before | After |
|---|---|---|
| Cold | ~17 s | **~10.5 s** |
| Warm | ~3.5 s | **~1.6 s** |

**Full click-to-pixels (PCB, warm):** ~19 s → **~16.4 s**, with the board download dropping from ~9 MB to ~1.9 MB per side.

**1. Cache the parsed object index per commit** 

The object delta re-parsed both board snapshots on every comparison, even for a repeat of the same pair (~1.2 s/board). Snapshots live under an immutable per-commit cache dir, so `index_snapshot` now fingerprints the files it reads (path + size + mtime) plus the parser schema, and rehydrates a cached index on a match (~0.15 s vs ~1.2 s, ~8x). Cache file sits beside the snapshot; a write failure degrades to a re-parse, never a hard failure; disabled with `ECAD_INDEX_CACHE=0`. **Warm compare 3.5 s → 2.0 s; delta output byte-for-byte identical to the uncached path.**

**2. Skip the wasted board parse in schematic-only builds** 

Each revision's schematic index is built with `include_pcb=False`, but the upstream (pip) kicad-monkey `to_json` has no such switch, so its part-placement projection lazily parsed the full 9 MB board on both revisions only to discard it (~25 s of dead work). On that fallback path we now detach the board (`pcb_path = None`) before materializing the design JSON, so the projection skips it; the board is still parsed once, separately, by the stages that need it. The optimized kicad-monkey build (which honours the switch) is untouched. **Schematic index build 16.2 s → 5.0 s; cold compare 17.2 s → 11.7 s;
schematic/PCB/BOM change counts identical (1065 / 683 / 49).**

**3. Poll fast, then back off**

Job-status polling was a flat 800 ms, so the viewer could sit idle up to that long after the backend finished. Now starts at 150 ms and widens by 1.4x to a 800 ms ceiling. Quick completions are caught almost immediately, long cold jobs settle to the old rate. **Viewer starts ~1.8 s sooner (warm).**

**4. Compress large responses**

The API served everything uncompressed; KiCad text compresses ~5x. Added `GZipMiddleware` (1 KB minimum), so any client that accepts gzip gets it with a correct identity fallback. **9 MB board → 1.95 MB; the large JSON diff sidecars compress ~10x too** (e.g. schematic sidecar 2.72 MB → 268 KB). General win across the API, not just the compare path.

## Notes

The remaining click-to-pixels timing is the viewer's `prepareComparison` (parse +WebGL paint of both boards). Profiling showed it's essentially all parse and paint. A worker-transport rewrite (transferable buffer instead of structured clone) was prototyped and dropped, as the two-board parse is already parallel in most runs, and the occasional stall is GC/load, not a transport problem. Cold backend (~10.5 s) is bounded by third-party kicad-monkey schematic parsing, addressable only via its optimized build.

## User and operator impact

None

## Validation

- [x] Relevant frontend checks
- [x] Relevant backend checks
- [x] Relevant semantic-viewer checks
- [ ] Compose configuration validation
- [x] Manual verification, when needed

## Documentation and release

- [x] Documentation is updated or not required.
- [x] No secrets, private design data, generated output, or local caches are included.
- [ ] Breaking changes and feature-freeze exceptions have explicit approval.
- [x] This branch contains one coherent change and targets `dev`.
