### PR TITLE
React Doctor audit: tooling, baseline, and the measured bug fixes

### DIFF
--- a/docs/REACT_DOCTOR_FINDINGS.md
+++ b/docs/REACT_DOCTOR_FINDINGS.md
@@ -1,0 +1,906 @@
+# React Doctor findings — KiCAD-Prism frontend
+
+React Doctor v0.9.12, full scan of `frontend/`, run 2026-08-22. This document is the findings breakdown only; the remediation plan is separate.
+
+## How it was run
+
+```bash
+react-doctor ./frontend -y --no-telemetry --verbose
+```
+
+(run from a local install of `react-doctor@0.9.12`, not `npx` — see the environment note below)
+
+- **Scope:** `frontend/` — the only React project in the repo. `kicad-prism-viewer/` is a plain-JS esbuild package and was not scanned.
+- **Files analyzed:** 239 of 239 scanned. Lint, dead-code, and supply-chain checks all completed (`skippedChecks: []`).
+- **Exclusions:** `frontend/doctor.config.ts` ignores everything under `public/` **except `public/ecad-viewer.js`**, which is maintained code vendored from our ecad-viewer fork:
+
+  ```ts
+  ignore: { files: ["public/!(ecad-viewer.js)", "public/*/**"] }
+  ```
+
+  Verified against the report: the only `public/` path with a finding is `public/ecad-viewer.js` (see RD-20).
+
+> **Environment note.** A plain `npx react-doctor` run silently skips linting on this machine — the npx cache is missing the `@oxlint/binding-darwin-arm64` native binding, and the failure only shows up as `skippedChecks: ["lint"]` inside the JSON report. That run reported 7 findings instead of 303. Install `react-doctor` as a real dependency (or clear the npx cache) before trusting a run, and check `skippedChecks` in the JSON output.
+
+## Summary
+
+| | Count |
+| --- | --- |
+| Errors | 22 |
+| Warnings | 281 |
+| **Total findings** | **303** |
+| Affected files | 84 |
+| Distinct rules fired | 51 |
+| Fixable issues below | 33 |
+
+By category:
+
+| Category | Findings |
+| --- | --- |
+| Bugs | 139 |
+| Performance | 77 |
+| Maintainability | 58 |
+| Accessibility | 21 |
+| Security | 8 |
+
+### Where the findings live
+
+Five files carry 107 of the 303 findings (35%). They are the same files that show up in RD-02, RD-04, RD-25, and RD-33 — fixing them structurally clears findings across several issues at once.
+
+| File | Findings |
+| --- | --- |
+| `src/components/visualizer.tsx` | 25 |
+| `src/components/workspace/library-bulk-edit-workspace.tsx` | 24 |
+| `src/components/workspace/library-component-workspace.tsx` | 23 |
+| `src/components/workspace/library-import-remediation-grid.tsx` | 19 |
+| `src/components/design-comparison/comparison-presentation-shell.tsx` | 16 |
+| `src/components/import-dialog.tsx` | 9 |
+| `src/components/release-studio/ReleaseStudioPanel.tsx` | 9 |
+| `src/pages/ProjectDetailPage.tsx` | 8 |
+| `src/components/comment-form.tsx` | 7 |
+| `src/components/command-palette.tsx` | 6 |
+| `src/components/comment-panel.tsx` | 6 |
+| `src/components/design-comparison/design-comparison-workspace.tsx` | 6 |
+
+## Re-grading after verification (2026-08-22)
+
+The priorities below grade by rule severity. An empirical verification pass (code reads
+plus a StrictMode probe replicating the flagged updater pattern) re-graded the high-priority
+rows; this table supersedes the per-issue priorities above.
+
+| ID | Was | Now |
+| --- | --- | --- |
+| RD-01 | P0 | **P3** — every site is the deliberate latest-ref idiom; not breaking today. Revisit when migrating to React 19 `useEffectEvent`. |
+| RD-02 | P0 | **P2-latent** — probe under StrictMode 18.3.1 ran the updater once (`updaterRuns=1, undoDepth=1`); no reproduction of corruption. Still worth the cheap mechanical hardening, but it is not an active defect. |
+| RD-06 | 11 exposed | All sites read: only `assets-portal:140`, `documentation-browser:124`, and `auth-callback-page:13` lacked guards; the other 8 had AbortController/flag guards the rule cannot see. Fixed in Phase 1. |
+| RD-07 | 2 sites | 1 — `settings-dialog:243` is a false positive (reset already sits in `finally`; the rule tripped on the abort guard). The remaining site is fixed in Phase 1. |
+| RD-19 | P2/M | Mostly false positive — `sameOriginNextPath` already validates origin (`auth.ts:117`). Document-and-close pending one confirmation of what `?next` drives. |
+| RD-20 | P2/S | False positive for our usage — the flagged helper generates element ids, not auth material. Fix upstream in the ecad-viewer fork or suppress scoped to this file. |
+| RD-25 | 20 sites | Only `library-bulk-edit-workspace.tsx:477` plausibly matters at scale (CSV batch rows). The rest run over metadata arrays numbering in tens — won't-fix absent profile evidence. |
+| RD-28 | P4/S | False positive — both functions return the URL to the caller (ownership transfer); revoking at the creation site would blank previews. The consumer (`shared.tsx`) owns revocation correctly. The rule cannot see across module boundaries. |
+
+Post-Phase-1 live count: **297** findings with `skippedChecks: []` (from the 303 baseline).
+Residuals in remediated files are owned by Phases 2–4 of `.scratch/react-doctor-remediation/plan.md`.
+
+## Issues
+
+Priorities: **P0** correctness errors · **P1** bugs and React anti-patterns · **P2** security · **P3** accessibility · **P4** performance · **P5** maintainability. Effort is a rough per-issue estimate: **S** under an hour, **M** a few hours, **L** a day or more.
+
+| ID | Pri | Issue | Findings | Files | Effort |
+| --- | --- | --- | --- | --- | --- |
+| [RD-01](#rd-01) | P0 | Refs mutated during render | 14 | 9 | M |
+| [RD-02](#rd-02) | P0 | Side effects inside state updater functions | 13 | 2 | M |
+| [RD-03](#rd-03) | P0 | Effects that subscribe or start timers without cleanup | 2 | 2 | S |
+| [RD-04](#rd-04) | P1 | State adjusted in an effect when a prop changes | 60 | 18 | L |
+| [RD-05](#rd-05) | P1 | All state reset in an effect on a prop change | 6 | 6 | S |
+| [RD-06](#rd-06) | P1 | State written after `await` in an effect without a cancellation guard | 11 | 8 | M |
+| [RD-07](#rd-07) | P1 | Loading flags reset outside `finally` | 2 | 2 | S |
+| [RD-08](#rd-08) | P1 | Unchecked `fetch` response body | 1 | 1 | S |
+| [RD-09](#rd-09) | P1 | Array index used as a React `key` | 7 | 7 | S |
+| [RD-10](#rd-10) | P1 | State mutated in place | 1 | 1 | S |
+| [RD-11](#rd-11) | P1 | Props copied or mirrored into state | 3 | 3 | S |
+| [RD-12](#rd-12) | P1 | Child components pushing data up through effects | 10 | 5 | M |
+| [RD-13](#rd-13) | P1 | Data fetching directly inside `useEffect` | 3 | 3 | M |
+| [RD-14](#rd-14) | P1 | Pointer capture with no cancellation path | 1 | 1 | S |
+| [RD-15](#rd-15) | P1 | Related `useState` calls that should be one reducer | 4 | 4 | M |
+| [RD-16](#rd-16) | P1 | Independent awaits run sequentially | 1 | 1 | S |
+| [RD-17](#rd-17) | P2 | `window.open` without `noopener` | 3 | 2 | S |
+| [RD-18](#rd-18) | P2 | `<iframe>` without a `sandbox` attribute | 3 | 2 | S |
+| [RD-19](#rd-19) | P2 | Privileged action pre-filled from the URL | 1 | 1 | M |
+| [RD-20](#rd-20) | P2 | Weak randomness in a security-shaped context (vendored `ecad-viewer.js`) | 1 | 1 | S |
+| [RD-21](#rd-21) | P3 | Interactive controls without accessible labels | 9 | 7 | S |
+| [RD-22](#rd-22) | P3 | Click handlers unreachable by keyboard | 9 | 4 | M |
+| [RD-23](#rd-23) | P3 | `autoFocus` and hand-rolled modals | 3 | 3 | S |
+| [RD-24](#rd-24) | P4 | Array chains that iterate the same list twice | 35 | 21 | M |
+| [RD-25](#rd-25) | P4 | Linear lookups inside loops | 20 | 6 | M |
+| [RD-26](#rd-26) | P4 | Values rebuilt every render that should be hoisted | 19 | 14 | M |
+| [RD-27](#rd-27) | P4 | State that only handlers read should be a ref | 5 | 4 | S |
+| [RD-28](#rd-28) | P4 | Object URLs never revoked | 2 | 1 | S |
+| [RD-29](#rd-29) | P4 | `transition-all` on animated elements | 4 | 3 | S |
+| [RD-30](#rd-30) | P4 | `JSON.parse(JSON.stringify(x))` deep clone | 1 | 1 | S |
+| [RD-31](#rd-31) | P5 | Dead code: unused files, exports, and dependencies | 14 | 13 | S |
+| [RD-32](#rd-32) | P5 | Non-component exports in component files | 17 | 14 | M |
+| [RD-33](#rd-33) | P5 | Components over 300 lines | 18 | 18 | L |
+
+### RD-01
+
+**Refs mutated during render** — P0 · error · 14 findings in 9 files · effort M
+
+Rules: `react-doctor/no-ref-current-in-render`
+
+**Why it matters.** Render must be pure. React 18 StrictMode double-invokes render and React can discard render work, so a write to `ref.current` during render can leak state from a render that never commits — or be applied twice. This is the largest cluster of hard errors in the scan.
+
+**Fix.** Move each `ref.current = ...` write into an event handler, a `useEffect`, or a null-guarded lazy-init (`if (ref.current === null) ref.current = ...`), which stays supported. `ReleaseStudioPanel.tsx` has four sites and should be done first.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L297
+- `src/components/ecad-viewer-controls.tsx` — L76
+- `src/components/release-studio/ReleaseStudioPanel.tsx` — L97, L130, L134, L146
+- `src/components/ui/hold-to-confirm-button.tsx` — L60
+- `src/components/viewer-overlay-rail.tsx` — L108
+- `src/components/webgpu-3d-tab.tsx` — L122
+- `src/components/workspace/async-search-picker.tsx` — L88, L90
+- `src/components/workspace/library-component-workspace.tsx` — L1384, L1386
+- `src/hooks/use-hotkeys.ts` — L39
+
+</details>
+
+### RD-02
+
+**Side effects inside state updater functions** — P0 · error/warning · 13 findings in 2 files · effort M
+
+Rules: `react-doctor/no-impure-state-updater`, `react-doctor/no-side-effect-in-state-updater-function`
+
+**Why it matters.** React may invoke a `setState(prev => ...)` callback more than once. Any toast, persistence, ref write, or captured-stack mutation inside it can run twice or observe inconsistent external state. Concentrated almost entirely in the library import remediation grid.
+
+**Fix.** Make every updater callback pure and return only the next state. Compute the next state first, then perform the side effect in the event handler that queued the update. `library-import-remediation-grid.tsx` accounts for 11 of the 13 sites — fixing that one file clears most of this issue.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/no-impure-state-updater` (6)
+
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L362
+- `src/components/workspace/library-import-remediation-grid.tsx` — L287, L297, L300, L309, L312
+
+`react-doctor/no-side-effect-in-state-updater-function` (7)
+
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L362
+- `src/components/workspace/library-import-remediation-grid.tsx` — L290, L291, L300, L301, L312, L313
+
+</details>
+
+### RD-03
+
+**Effects that subscribe or start timers without cleanup** — P0 · error · 2 findings in 2 files · effort S
+
+Rules: `react-doctor/effect-needs-cleanup`
+
+**Why it matters.** An `addEventListener` (or timer/observer/socket) created in `useEffect` without a returned cleanup leaks after unmount and keeps firing against a dead component.
+
+**Fix.** Return a cleanup function that undoes every allocation the effect makes: `return () => target.removeEventListener(name, handler)`.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L1111
+- `src/components/design-comparison/use-design-compare-job.ts` — L85
+
+</details>
+
+### RD-04
+
+**State adjusted in an effect when a prop changes** — P1 · warning · 60 findings in 18 files · effort L
+
+Rules: `react-doctor/no-adjust-state-on-prop-change`
+
+**Why it matters.** The single biggest cluster: 60 findings, but React Doctor collapses them into 9 fix groups (one per file) — one restructuring per component clears the whole file. Each effect writes state in response to a prop change, so users see the stale value for a frame before the effect catches up.
+
+**Fix.** Derive the value during render, or reset the component with a `key` prop, or update the related state in the event handler that changes the prop. Do not add a "previous prop" state variable — that keeps the duplication. Sequence by group size: `visualizer.tsx` (16), `library-component-workspace.tsx` (13), `comparison-presentation-shell.tsx` (5), `command-palette.tsx` (4), then the 3-and-under files.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/command-palette.tsx` — L121, L122, L123, L288
+- `src/components/comment-form.tsx` — L72, L75, L76
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L519, L523, L524, L528, L1043
+- `src/components/design-comparison/design-comparison-workspace.tsx` — L519, L520
+- `src/components/design-comparison/differences-pane.tsx` — L383
+- `src/components/design-comparison/fabrication-panel.tsx` — L311
+- `src/components/design-search-field.tsx` — L119
+- `src/components/history-viewer.tsx` — L597, L598, L599
+- `src/components/visualizer.tsx` — L657, L658, L661, L663, L664, L665, L666, L668 (+8 more)
+- `src/components/workspace.tsx` — L187, L191, L196
+- `src/components/workspace/create-folder-dialog.tsx` — L27
+- `src/components/workspace/library-asset-link-picker.tsx` — L50
+- `src/components/workspace/library-component-workspace.tsx` — L1821, L1822, L1823, L1824, L1825, L1826, L1827, L1829 (+5 more)
+- `src/components/workspace/library-folder-discovery-dialog.tsx` — L38
+- `src/components/workspace/library-import-remediation-dialog.tsx` — L56
+- `src/components/workspace/library-import-remediation-grid.tsx` — L278
+- `src/components/workspace/move-project-dialog.tsx` — L93, L101
+- `src/panel/screens/PartDetailScreen.tsx` — L519
+
+</details>
+
+### RD-05
+
+**All state reset in an effect on a prop change** — P1 · warning · 6 findings in 6 files · effort S
+
+Rules: `react-doctor/no-reset-all-state-on-prop-change`
+
+**Why it matters.** Same class as RD-04 but with a much cheaper fix: the effect clears every state value when a prop changes, so stale state is visible for one render.
+
+**Fix.** Pass the prop as `key` on the component so React remounts it and resets state for you, and delete the effect.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/comment-form.tsx` — L70
+- `src/components/release-studio/steps/ObserveBuildStep.tsx` — L223
+- `src/components/workspace/create-folder-dialog.tsx` — L25
+- `src/components/workspace/library-component-workspace.tsx` — L763
+- `src/components/workspace/library-preview-inspector.tsx` — L99
+- `src/panel/screens/PartDetailScreen.tsx` — L518
+
+</details>
+
+### RD-06
+
+**State written after `await` in an effect without a cancellation guard** — P1 · warning · 11 findings in 8 files · effort M
+
+Rules: `react-doctor/no-set-state-after-await-in-effect`
+
+**Why it matters.** When the effect re-runs before the previous async call settles, the two responses can resolve out of order and the older one wins — a classic stale-data race in viewer/project screens that switch targets quickly.
+
+**Fix.** Add an `ignore`/`cancelled` flag captured per effect run and checked before every setter, or return a cleanup that aborts the request (`AbortController`).
+
+<details><summary>Affected sites</summary>
+
+- `src/components/assets-portal.tsx` — L140
+- `src/components/auth-callback-page.tsx` — L13
+- `src/components/design-comparison/revision-sources.ts` — L65
+- `src/components/design-comparison/use-comparison-comments.ts` — L18
+- `src/components/design-comparison/use-design-compare-job.ts` — L44
+- `src/components/documentation-browser.tsx` — L124
+- `src/components/visualizer.tsx` — L436, L544, L619
+- `src/pages/ProjectDetailPage.tsx` — L223, L259
+
+</details>
+
+### RD-07
+
+**Loading flags reset outside `finally`** — P1 · warning · 2 findings in 2 files · effort S
+
+Rules: `react-doctor/no-loading-flag-reset-outside-finally`
+
+**Why it matters.** The reset only runs on the success path, so a rejected request leaves a spinner spinning or a button disabled forever.
+
+**Fix.** Move the reset into a `finally` block (or mirror it in every `catch`).
+
+<details><summary>Affected sites</summary>
+
+- `src/components/design-comparison/comparison-discussion-rail.tsx` — L103
+- `src/components/settings-dialog.tsx` — L243
+
+</details>
+
+### RD-08
+
+**Unchecked `fetch` response body** — P1 · warning · 1 finding in 1 file · effort S
+
+Rules: `react-doctor/no-fetch-response-used-without-status-check`
+
+**Why it matters.** `fetch` resolves on 4xx/5xx, so reading the body without checking `response.ok` parses an error payload as if it were success.
+
+**Fix.** Check `response.ok` / `response.status` before `.json()`/`.text()`/`.blob()`, or handle the API error payload deliberately.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/release-studio/shared.tsx` — L129
+
+</details>
+
+### RD-09
+
+**Array index used as a React `key`** — P1 · warning · 7 findings in 7 files · effort S
+
+Rules: `react-doctor/no-array-index-as-key`
+
+**Why it matters.** When a list reorders or filters, index keys make React reuse the wrong DOM node — in comment threads and remediation dialogs this means users can see and submit the wrong row.
+
+**Fix.** Key by a stable id from the item (`item.id`, `item.slug`). Where the data genuinely has no id, derive a stable composite key.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/comment-card.tsx` — L118
+- `src/components/comment-panel.tsx` — L277
+- `src/components/design-comparison/comparison-discussion-rail.tsx` — L180
+- `src/components/keyboard-shortcuts-dialog.tsx` — L54
+- `src/components/ui/field.tsx` — L192
+- `src/components/workspace/library-import-remediation-dialog.tsx` — L116
+- `src/pages/ProjectDetailPage.tsx` — L835
+
+</details>
+
+### RD-10
+
+**State mutated in place** — P1 · warning · 1 finding in 1 file · effort S
+
+Rules: `react-doctor/no-direct-state-mutation`
+
+**Why it matters.** React compares by identity, so an in-place mutation can be skipped entirely and the update lost.
+
+**Fix.** Call the setter with a new value (`setItems([...items, x])`, `items.toSorted(...)`, etc.).
+
+<details><summary>Affected sites</summary>
+
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L768
+
+</details>
+
+### RD-11
+
+**Props copied or mirrored into state** — P1 · warning · 3 findings in 3 files · effort S
+
+Rules: `react-doctor/no-derived-useState`, `react-doctor/no-mirror-prop-effect`
+
+**Why it matters.** `useState(prop)` copies the prop once, so later prop changes leave a stale value on screen; the effect-mirroring variant shows the old value on first render.
+
+**Fix.** Read the prop directly during render, or compute the value inline. Delete both the `useState` and the syncing `useEffect`.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/no-derived-useState` (2)
+
+- `src/components/session-expired-banner.tsx` — L53
+- `src/components/workspace/library-component-workspace.tsx` — L429
+
+`react-doctor/no-mirror-prop-effect` (1)
+
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L83
+
+</details>
+
+### RD-12
+
+**Child components pushing data up through effects** — P1 · warning · 10 findings in 5 files · effort M
+
+Rules: `react-doctor/no-pass-data-to-parent`, `react-doctor/no-pass-live-state-to-parent`, `react-doctor/no-prop-callback-in-effect`, `react-doctor/no-effect-chain`
+
+**Why it matters.** Each of these costs an extra render pass per interaction and makes the data flow hard to follow. `use-comparison-url-state.ts` alone has 5 sites, so the comparison URL-state hook is the natural unit of work.
+
+**Fix.** Lift the state to the parent (or return it from the hook) instead of handing it back through a prop callback in an effect; for shared state across siblings, use a Provider. Collapse effect chains by computing during render and writing related state in the originating event handler.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/no-pass-data-to-parent` (5)
+
+- `src/components/design-comparison/use-comparison-url-state.ts` — L62, L63, L68, L71, L74
+
+`react-doctor/no-pass-live-state-to-parent` (2)
+
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L267
+- `src/components/release-studio/ReleaseStudioPanel.tsx` — L269
+
+`react-doctor/no-prop-callback-in-effect` (2)
+
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L267
+- `src/components/ecad-viewer-controls.tsx` — L142
+
+`react-doctor/no-effect-chain` (1)
+
+- `src/components/workspace.tsx` — L186
+
+</details>
+
+### RD-13
+
+**Data fetching directly inside `useEffect`** — P1 · warning · 3 findings in 3 files · effort M
+
+Rules: `react-doctor/no-fetch-in-effect`
+
+**Why it matters.** Raw `fetch` in an effect can race, double-fire under StrictMode, and leak. Related to RD-06 but the fix is structural rather than a guard flag.
+
+**Fix.** Route these through the existing data-fetching layer (or add one) so cancellation, dedupe, and error handling live in one place.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/assets-portal.tsx` — L140
+- `src/components/documentation-browser.tsx` — L124
+- `src/components/release-studio/shared.tsx` — L113
+
+</details>
+
+### RD-14
+
+**Pointer capture with no cancellation path** — P1 · warning · 1 finding in 1 file · effort S
+
+Rules: `react-doctor/pointer-capture-needs-cancel-handler`
+
+**Why it matters.** The drag cleans up only on pointer-up, so an interruption (scroll, app switch, orientation change) leaves the drag stuck active.
+
+**Fix.** Handle `onPointerCancel` / `onLostPointerCapture` with the same cleanup as pointer-up.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/workspace/library-component-workspace.tsx` — L685
+
+</details>
+
+### RD-15
+
+**Related `useState` calls that should be one reducer** — P1 · warning · 4 findings in 4 files · effort M
+
+Rules: `react-doctor/prefer-useReducer`
+
+**Why it matters.** Advisory, not a defect: four components update 5+ separate state values in one place, which is where inconsistent intermediate states come from.
+
+**Fix.** Group state that always changes together into `useReducer` so one action describes the whole transition. Worth doing opportunistically while fixing RD-04 in the same files.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/path-config-dialog.tsx` — L91
+- `src/components/release-studio/ReleaseStudioPanel.tsx` — L80
+- `src/components/visualizer.tsx` — L289
+- `src/components/workspace/library-component-workspace.tsx` — L1744
+
+</details>
+
+### RD-16
+
+**Independent awaits run sequentially** — P1 · warning · 1 finding in 1 file · effort S
+
+Rules: `react-doctor/server-sequential-independent-await`
+
+**Why it matters.** The second `await` does not use the first result, so the load takes twice as long as it needs to.
+
+**Fix.** Wrap the two calls in `Promise.all([...])`.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/design-comparison/comparison-result-loader.ts` — L52
+
+</details>
+
+### RD-17
+
+**`window.open` without `noopener`** — P2 · warning · 3 findings in 2 files · effort S
+
+Rules: `react-doctor/window-open-without-noopener`
+
+**Why it matters.** The opened page can redirect the parent tab through `window.opener` (reverse tabnabbing). These are asset/doc links, which can point at user-supplied URLs.
+
+**Fix.** Pass `'noopener'` in the third features argument, plus `'noreferrer'` where the destination should not receive the referrer.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/assets-portal.tsx` — L169, L175
+- `src/components/documentation-browser.tsx` — L159
+
+</details>
+
+### RD-18
+
+**`<iframe>` without a `sandbox` attribute** — P2 · warning · 3 findings in 2 files · effort S
+
+Rules: `react-doctor/iframe-missing-sandbox`
+
+**Why it matters.** An unsandboxed iframe gives the embedded page full access to the host origin. These frames render build/manufacturing output and viewer content.
+
+**Fix.** Add `sandbox=""` and re-add only the capabilities each frame actually needs (`allow-scripts allow-same-origin` is the combination to avoid together).
+
+<details><summary>Affected sites</summary>
+
+- `src/components/release-studio/shared.tsx` — L71, L180
+- `src/components/visualizer.tsx` — L1404
+
+</details>
+
+### RD-19
+
+**Privileged action pre-filled from the URL** — P2 · warning · 1 finding in 1 file · effort M
+
+Rules: `react-doctor/url-prefilled-privileged-action`
+
+**Why it matters.** `src/lib/auth.ts` reads sensitive action state from the URL, which lets an attacker-crafted link pre-fill an invite, role, redirect, or share flow.
+
+**Fix.** Validate URL-sourced auth parameters server-side and require explicit user confirmation before acting on them. Confirm what the parameter actually drives before changing behaviour.
+
+<details><summary>Affected sites</summary>
+
+- `src/lib/auth.ts` — L113
+
+</details>
+
+### RD-20
+
+**Weak randomness in a security-shaped context (vendored `ecad-viewer.js`)** — P2 · warning · 1 finding in 1 file · effort S
+
+Rules: `react-doctor/insecure-crypto-risk`
+
+**Why it matters.** The only remaining finding under `public/`, and the reason that file is kept in scope: it lives in the bundle built from our ecad-viewer fork, so it is fixable upstream rather than here.
+
+**Fix.** Checked against the bundle: the site is a `generateUUID()` helper built from `Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)`. It generates element ids, not auth material, so this is a **false positive** for our usage. Two options — suppress it via `ignore.overrides` scoped to `public/ecad-viewer.js`, or switch the upstream helper in the ecad-viewer fork to `crypto.randomUUID()` and rebuild the bundle. Either way, never hand-edit `public/ecad-viewer.js`; it is generated output.
+
+<details><summary>Affected sites</summary>
+
+- `public/ecad-viewer.js` — L1416
+
+</details>
+
+### RD-21
+
+**Interactive controls without accessible labels** — P3 · warning · 9 findings in 7 files · effort S
+
+Rules: `react-doctor/control-has-associated-label`, `react-doctor/no-placeholder-only-field`
+
+**Why it matters.** Icon-only buttons and placeholder-only fields give screen reader users nothing to go on; placeholders also vanish as soon as the user types.
+
+**Fix.** Add visible text, `aria-label`, or `aria-labelledby` to each control, and a real associated `<label>` to each field (keep the placeholder as a format hint).
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/control-has-associated-label` (6)
+
+- `src/components/assets-portal.tsx` — L59
+- `src/components/documentation-browser.tsx` — L40
+- `src/components/settings-dialog.tsx` — L748, L784
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L122, L134
+
+`react-doctor/no-placeholder-only-field` (3)
+
+- `src/components/comment-card.tsx` — L128
+- `src/components/comment-form.tsx` — L236
+- `src/components/comment-panel.tsx` — L292
+
+</details>
+
+### RD-22
+
+**Click handlers unreachable by keyboard** — P3 · warning · 9 findings in 4 files · effort M
+
+Rules: `react-doctor/click-events-have-key-events`, `react-doctor/no-static-element-interactions`, `react-doctor/html-no-nested-interactive`
+
+**Why it matters.** `onClick` on a `<div>`/`<span>` with no role and no key handler is invisible to keyboard and screen reader users. The nested-interactive case also breaks focus order.
+
+**Fix.** Prefer a real `<button>`/`<a>`. Where the layout forbids it, add `role`, `tabIndex={0}`, and a matching key handler; move nested focusable elements out of their interactive ancestor.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/click-events-have-key-events` (4)
+
+- `src/components/comment-panel.tsx` — L171, L264
+- `src/components/sidebar-tree.tsx` — L27
+- `src/components/workspace/library-asset-link-picker.tsx` — L92
+
+`react-doctor/no-static-element-interactions` (4)
+
+- `src/components/comment-panel.tsx` — L171, L264
+- `src/components/sidebar-tree.tsx` — L27
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L97
+
+`react-doctor/html-no-nested-interactive` (1)
+
+- `src/components/workspace/library-asset-link-picker.tsx` — L92
+
+</details>
+
+### RD-23
+
+**`autoFocus` and hand-rolled modals** — P3 · warning · 3 findings in 3 files · effort S
+
+Rules: `react-doctor/no-autofocus`, `react-doctor/prefer-html-dialog`
+
+**Why it matters.** `autoFocus` yanks focus on mount and disorients assistive-tech users; a `role="dialog"` wrapper re-implements semantics the native `<dialog>` gives for free.
+
+**Fix.** Drop `autoFocus` (or move focus deliberately after an explicit user action) and migrate the custom modal to `<dialog>` + `showModal()`.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/no-autofocus` (2)
+
+- `src/components/command-palette.tsx` — L337
+- `src/components/comment-form.tsx` — L238
+
+`react-doctor/prefer-html-dialog` (1)
+
+- `src/components/comment-card.tsx` — L74
+
+</details>
+
+### RD-24
+
+**Array chains that iterate the same list twice** — P4 · warning · 35 findings in 21 files · effort M
+
+Rules: `react-doctor/js-combine-iterations`, `react-doctor/js-flatmap-filter`
+
+**Why it matters.** 35 findings, mostly in the design-comparison pipeline and the library workspaces — the code paths that run over the largest lists (BOM rows, diff sets, import candidates).
+
+**Fix.** Collapse `.filter().map()` into a single `for...of`/`.reduce()` pass, and `.map().filter(Boolean)` into `.flatMap()`. Prioritise the comparison modules, where list sizes scale with design size.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/js-combine-iterations` (30)
+
+- `src/components/design-comparison/comparison-change-facts.ts` — L213
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L497, L840, L1069, L1180, L1196
+- `src/components/design-comparison/comparison-property-model.ts` — L165, L445
+- `src/components/design-comparison/comparison-review-noise.ts` — L145, L153
+- `src/components/design-comparison/comparison-review-policy.ts` — L431
+- `src/components/design-comparison/comparison-review-queue.ts` — L113
+- `src/components/design-comparison/comparison-selection-bridge.ts` — L30
+- `src/components/design-comparison/design-comparison-workspace.tsx` — L271
+- `src/components/design-comparison/differences-pane.tsx` — L414
+- `src/components/design-comparison/revision-sources.ts` — L89, L177
+- `src/components/import-dialog.tsx` — L491
+- `src/components/release-studio/steps/ManufacturingStep.tsx` — L228
+- `src/components/selection-inspector.tsx` — L467
+- `src/components/visualizer.tsx` — L591
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L298, L477, L503
+- `src/components/workspace/library-catalog-workspace.tsx` — L473
+- `src/components/workspace/library-folder-discovery-dialog.tsx` — L26
+- `src/components/workspace/library-import-center.tsx` — L274
+- `src/components/workspace/library-import-remediation-grid.tsx` — L422, L455
+- `src/pages/ProjectDetailPage.tsx` — L473
+
+`react-doctor/js-flatmap-filter` (5)
+
+- `src/components/design-comparison/comparison-review-policy.ts` — L431
+- `src/components/design-comparison/comparison-review-queue.ts` — L186
+- `src/lib/design-search.ts` — L143, L233, L240
+
+</details>
+
+### RD-25
+
+**Linear lookups inside loops** — P4 · warning · 20 findings in 6 files · effort M
+
+Rules: `react-doctor/js-set-map-lookups`, `react-doctor/js-index-maps`
+
+**Why it matters.** `array.includes()` / `array.find()` inside a loop makes the work quadratic. 14 of the 20 sites are in `library-bulk-edit-workspace.tsx`, which is exactly the screen users point at large libraries.
+
+**Fix.** Build a `Set` or `Map` once before the loop and look up against it. `library-bulk-edit-workspace.tsx` is a single focused change that clears most of this issue.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/js-set-map-lookups` (19)
+
+- `src/components/engineering-bom-table.tsx` — L150
+- `src/components/import-dialog.tsx` — L493, L687
+- `src/components/release-studio/steps/ManufacturingStep.tsx` — L147
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L227, L300, L301, L341, L342, L348, L477, L516 (+1 more)
+- `src/components/workspace/library-import-center.tsx` — L265
+
+`react-doctor/js-index-maps` (1)
+
+- `src/components/design-comparison/comparison-property-panel.tsx` — L153
+
+</details>
+
+### RD-26
+
+**Values rebuilt every render that should be hoisted** — P4 · warning · 19 findings in 14 files · effort M
+
+Rules: `react-doctor/js-hoist-intl`, `react-doctor/prefer-module-scope-pure-function`, `react-doctor/prefer-module-scope-static-value`, `react-doctor/rerender-lazy-state-init`, `react-doctor/rerender-lazy-ref-init`, `react-doctor/rerender-memo-with-default-value`
+
+**Why it matters.** `Intl` formatters, pure helpers, static arrays, and eager `useState`/`useRef` initialisers all get rebuilt on every render and hand memoized children brand-new identities, defeating memoization downstream.
+
+**Fix.** Move pure helpers and static values to module scope, hoist `Intl.*` formatters (or `useMemo` them), pass initialisers as functions (`useState(() => find())`), and replace inline `[]`/`{}` default props with module-level constants.
+
+<details><summary>Affected sites</summary>
+
+`react-doctor/js-hoist-intl` (4)
+
+- `src/components/workspace/library-catalog-workspace.tsx` — L133
+- `src/components/workspace/library-component-workspace.tsx` — L216
+- `src/components/workspace/library-release-queue.tsx` — L59
+- `src/panel/screens/PartDetailScreen.tsx` — L676
+
+`react-doctor/prefer-module-scope-pure-function` (5)
+
+- `src/components/import-dialog.tsx` — L439
+- `src/components/login-page.tsx` — L165
+- `src/components/project-card.tsx` — L61
+- `src/components/workspace.tsx` — L93
+- `src/pages/ProjectDetailPage.tsx` — L117
+
+`react-doctor/prefer-module-scope-static-value` (4)
+
+- `src/components/workspace/library-component-workspace.tsx` — L1469, L1632
+- `src/components/workspace/library-import-center.tsx` — L120
+- `src/pages/ProjectDetailPage.tsx` — L351
+
+`react-doctor/rerender-lazy-state-init` (2)
+
+- `src/components/release-studio/steps/ObserveBuildStep.tsx` — L44, L50
+
+`react-doctor/rerender-lazy-ref-init` (2)
+
+- `src/components/visualizer.tsx` — L185
+- `src/components/webgpu-3d-tab.tsx` — L121
+
+`react-doctor/rerender-memo-with-default-value` (2)
+
+- `src/components/comment-form.tsx` — L61
+- `src/components/release-studio/steps/ObserveBuildStep.tsx` — L20
+
+</details>
+
+### RD-27
+
+**State that only handlers read should be a ref** — P4 · warning · 5 findings in 4 files · effort S
+
+Rules: `react-doctor/rerender-state-only-in-handlers`
+
+**Why it matters.** Each update re-renders the component for a value that is never rendered.
+
+**Fix.** Swap `useState` for `useRef` where the value is only written and read in handlers.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/import-dialog.tsx` — L136
+- `src/components/login-page.tsx` — L55
+- `src/components/release-studio/ReleaseStudioPanel.tsx` — L121, L147
+- `src/components/visualizer.tsx` — L365
+
+</details>
+
+### RD-28
+
+**Object URLs never revoked** — P4 · warning · 2 findings in 1 file · effort S
+
+Rules: `react-doctor/no-create-object-url-without-revoke`
+
+**Why it matters.** `URL.createObjectURL` pins the Blob for the document lifetime. In release-studio download paths that means every artifact the user downloads stays in memory until reload.
+
+**Fix.** Keep the URL and call `URL.revokeObjectURL(url)` after the download completes or in effect cleanup.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/release-studio/api.ts` — L46, L243
+
+</details>
+
+### RD-29
+
+**`transition-all` on animated elements** — P4 · warning · 4 findings in 3 files · effort S
+
+Rules: `react-doctor/no-transition-all`
+
+**Why it matters.** It animates every changing property, including layout-triggering ones and instant ones like focus rings, which is where the jank comes from.
+
+**Fix.** Name the properties: `transition-colors`, `transition-opacity`, `transition-transform`.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/design-comparison/design-comparison-workspace.tsx` — L996
+- `src/components/import-dialog.tsx` — L594, L785
+- `src/pages/ProjectDetailPage.tsx` — L855
+
+</details>
+
+### RD-30
+
+**`JSON.parse(JSON.stringify(x))` deep clone** — P4 · warning · 1 finding in 1 file · effort S
+
+Rules: `react-doctor/no-json-parse-stringify-clone`
+
+**Why it matters.** Slow on large objects, and it silently drops `undefined`, functions, `Date`/`Map`/`Set`, and cycles — a real correctness risk in the KiCad bridge payloads.
+
+**Fix.** Use `structuredClone(value)`.
+
+<details><summary>Affected sites</summary>
+
+- `src/panel/lib/kicad-bridge.ts` — L190
+
+</details>
+
+### RD-31
+
+**Dead code: unused files, exports, and dependencies** — P5 · warning · 14 findings in 13 files · effort S
+
+Rules: `deslop/unused-file`, `deslop/unused-export`, `deslop/unused-dependency`
+
+**Why it matters.** 14 findings that are pure subtraction. Note that four of the six unused files are shadcn-style `src/components/ui/*` primitives — those are scaffolding, so decide once whether the repo keeps unused primitives on purpose.
+
+**Fix.** Delete `src/components/example.tsx` and `src/components/sidebar-tree.tsx` outright; decide a policy for the unused `ui/` primitives; drop the `export` keyword on the six unused exports; remove the two unused dependencies (`jwt-decode`, `tw-animate-css`) from `package.json` after confirming nothing loads them dynamically — `tw-animate-css` in particular may be referenced from CSS rather than JS.
+
+<details><summary>Affected sites</summary>
+
+`deslop/unused-file` (6)
+
+- `src/components/example.tsx` — L0
+- `src/components/sidebar-tree.tsx` — L0
+- `src/components/ui/alert-dialog.tsx` — L0
+- `src/components/ui/combobox.tsx` — L0
+- `src/components/ui/field.tsx` — L0
+- `src/components/ui/input-group.tsx` — L0
+
+`deslop/unused-export` (6)
+
+- `src/components/design-comparison/comparison-review-report.ts` — L57
+- `src/components/design-comparison/comparison-selection-bridge.ts` — L51
+- `src/components/release-studio/flow.ts` — L30
+- `src/lib/diff-grouping.ts` — L191
+- `src/lib/prism-selection.ts` — L188
+- `src/panel/lib/kicad-bridge.ts` — L146
+
+`deslop/unused-dependency` (2)
+
+- `package.json` — L0
+
+</details>
+
+### RD-32
+
+**Non-component exports in component files** — P5 · warning · 17 findings in 14 files · effort M
+
+Rules: `react-doctor/only-export-components`
+
+**Why it matters.** Fast Refresh cannot preserve component state when a module also exports non-components, so every edit to these files full-reloads the app. It is a developer-experience cost, not a user-facing bug.
+
+**Fix.** Move helpers, constants, and variants into sibling modules (`*.constants.ts`, `*.utils.ts`) and re-export from there. Do the `ui/` primitives (`badge`, `button`, `tabs`) as one batch since they follow the same shadcn variant pattern.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/command-palette.tsx` — L71
+- `src/components/comment-severity-badge.tsx` — L13
+- `src/components/design-comparison/bom-panel.tsx` — L38
+- `src/components/design-comparison/change-status.tsx` — L27
+- `src/components/design-comparison/design-comparison-workspace.tsx` — L93
+- `src/components/engineering-bom-table.tsx` — L13
+- `src/components/import-dialog.tsx` — L41
+- `src/components/release-studio/shared.tsx` — L19
+- `src/components/ui/badge.tsx` — L48
+- `src/components/ui/button.tsx` — L66
+- `src/components/ui/permission-hint.tsx` — L33
+- `src/components/ui/tabs.tsx` — L95
+- `src/components/viewer-overlay-rail.tsx` — L26
+- `src/components/workspace/library-import-remediation-grid.tsx` — L125, L140, L178, L186
+
+</details>
+
+### RD-33
+
+**Components over 300 lines** — P5 · warning · 18 findings in 18 files · effort L
+
+Rules: `react-doctor/no-giant-component`
+
+**Why it matters.** 18 components exceed the threshold, topping out at `library-component-workspace.tsx` (~2.5k lines). This is the structural reason so many other findings cluster in the same handful of files.
+
+**Fix.** Do not treat this as its own task. Split each file as a byproduct of the RD-02/RD-04 work in that same file, and re-scan afterwards to see which of the 18 actually remain.
+
+<details><summary>Affected sites</summary>
+
+- `src/components/design-comparison/comparison-presentation-shell.tsx` — L227
+- `src/components/design-comparison/design-comparison-workspace.tsx` — L107
+- `src/components/design-comparison/fabrication-panel.tsx` — L259
+- `src/components/history-viewer.tsx` — L474
+- `src/components/import-dialog.tsx` — L127
+- `src/components/path-config-dialog.tsx` — L91
+- `src/components/release-studio/ReleaseStudioPanel.tsx` — L75
+- `src/components/settings-dialog.tsx` — L213
+- `src/components/visualizer.tsx` — L289
+- `src/components/webgpu-3d-tab.tsx` — L107
+- `src/components/workspace.tsx` — L56
+- `src/components/workspace/library-bulk-edit-workspace.tsx` — L242
+- `src/components/workspace/library-catalog-workspace.tsx` — L279
+- `src/components/workspace/library-component-workspace.tsx` — L1734
+- `src/components/workspace/library-import-center.tsx` — L93
+- `src/components/workspace/library-import-remediation-grid.tsx` — L212
+- `src/pages/ProjectDetailPage.tsx` — L95
+- `src/panel/screens/PartDetailScreen.tsx` — L82
+
+</details>
+
+## Not turned into issues
+
+- Nothing was suppressed or downgraded during this scan beyond the `public/` exclusion above.
+- React Doctor tags 27 of the 51 fired rules as `test-noise`, meaning they are commonly noisy in test files. No test-file findings appear in this report — every site is production source.
+- The score API and share URL were disabled (`--no-telemetry`), so this report has no React Doctor score attached.
+
+## Reproducing
+
+```bash
+cd frontend && npm i -D react-doctor
+npx react-doctor . -y --no-telemetry --verbose
+```
+
+For a machine-readable report: add `--json --json-out report.json`, then check `projects[0].skippedChecks` is empty before reading the diagnostics.

--- a/frontend/doctor.config.ts
+++ b/frontend/doctor.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "react-doctor/api";
+
+export default defineConfig({
+  ignore: {
+    // Exclude everything under public/ except ecad-viewer.js, which is
+    // maintained code vendored from our ecad-viewer fork.
+    files: ["public/!(ecad-viewer.js)", "public/*/**"],
+  },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
         "jsdom": "^26.1.0",
+        "react-doctor": "^0.9.12",
         "typescript": "~5.7.3",
         "typescript-eslint": "^8.24.1",
         "vite": "^6.2.0",
@@ -94,6 +95,59 @@
         "nup": "bin/nup.mjs"
       }
     },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins/node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -114,6 +168,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -337,18 +398,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -377,12 +438,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -549,13 +610,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -896,6 +957,40 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1608,6 +1703,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
@@ -1835,6 +1937,28 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
@@ -1930,6 +2054,1054 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
+      "integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
+      "integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
+      "integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
+      "integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
+      "integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
+      "integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
+      "integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
+      "integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
+      "integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
+      "integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
+      "integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
+      "integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
+      "integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
+      "integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
+      "integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
+      "integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
+      "integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
+      "integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
+      "integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
+      "integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
+      "integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
+      "integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
+      "integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
+      "integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
+      "integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
+      "integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
+      "integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
+      "integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
+      "integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
+      "integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
+      "integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
+      "integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
+      "integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
+      "integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
+      "integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3750,6 +4922,136 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
     },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.70.0.tgz",
+      "integrity": "sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node-core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.70.0.tgz",
+      "integrity": "sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.70.0.tgz",
+      "integrity": "sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@shaderfrog/glsl-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@shaderfrog/glsl-parser/-/glsl-parser-7.0.1.tgz",
+      "integrity": "sha512-8mpfsoPeRhesY3pOrzNZBL8uG6N5GVX1EHLBYbd4gzKs+c7vaEIqpTNK5VrffU33qQN4cwpP2v3u4aPPBU32sw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@simonwep/pickr": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@simonwep/pickr/-/pickr-1.9.0.tgz",
@@ -3874,6 +5176,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3951,6 +5264,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4504,6 +5824,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agent-install": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/agent-install/-/agent-install-0.0.5.tgz",
+      "integrity": "sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "commander": "^14.0.0",
+        "jsonc-parser": "^3.3.1",
+        "picocolors": "^1.1.1",
+        "prompts": "^2.4.2",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "agent-install": "bin/agent-install.mjs"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4681,6 +6019,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/autoprefixer": {
@@ -5068,6 +6427,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -5247,6 +6613,87 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/conf": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
+      "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "atomically": "^2.0.3",
+        "debounce-fn": "^6.0.0",
+        "dot-prop": "^10.0.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.7.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/conf/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/conf/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -5419,6 +6866,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/debounce-fn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5554,6 +7017,70 @@
         "node": ">=6"
       }
     },
+    "node_modules/deslop-js": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/deslop-js/-/deslop-js-0.9.12.tgz",
+      "integrity": "sha512-Ku6Zngzmu4EISb58WUkRKZytfgWjJ18Cic7lb4wl+/BF0tHWRvpBOLlA0FP35r82mV45Y72AK3RPC1Nw0GLbIw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@oxc-project/types": "^0.143.0",
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.2.5",
+        "oxc-parser": "^0.143.0",
+        "oxc-resolver": "^11.24.2",
+        "typescript": ">=5.0.4 <6"
+      }
+    },
+    "node_modules/deslop-js/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/deslop-js/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/deslop-js/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -5601,6 +7128,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dot-prop": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.2.0.tgz",
+      "integrity": "sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -5954,9 +7497,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6825,6 +8368,23 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "license": "MIT"
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/hono": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.1.tgz",
@@ -6964,6 +8524,28 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -7279,6 +8861,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -7436,6 +9028,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -7488,6 +9087,267 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -7637,6 +9497,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/markdown-table": {
@@ -7974,6 +9846,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/micromark": {
@@ -8642,6 +10524,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9017,6 +10906,187 @@
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "license": "MIT"
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
+      "integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.143.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.143.0",
+        "@oxc-parser/binding-android-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-x64": "0.143.0",
+        "@oxc-parser/binding-freebsd-x64": "0.143.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.143.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.143.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.143.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
+      "integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.77.0",
+        "@oxlint/binding-android-arm64": "1.77.0",
+        "@oxlint/binding-darwin-arm64": "1.77.0",
+        "@oxlint/binding-darwin-x64": "1.77.0",
+        "@oxlint/binding-freebsd-x64": "1.77.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.77.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.77.0",
+        "@oxlint/binding-linux-arm64-musl": "1.77.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.77.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.77.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-gnu": "1.77.0",
+        "@oxlint/binding-linux-x64-musl": "1.77.0",
+        "@oxlint/binding-openharmony-arm64": "1.77.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.77.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.77.0",
+        "@oxlint/binding-win32-x64-msvc": "1.77.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=7.0.2001",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/oxlint-plugin-react-doctor/-/oxlint-plugin-react-doctor-0.9.12.tgz",
+      "integrity": "sha512-BplcCUU/tGByFGgY1YIax6evUmjk0K8zOGGrdPs3A3dqamrzjUvVuJdYpM1Ftyt/B5fFx6+VwRrWi3YZbIz4VQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@shaderfrog/glsl-parser": "^7.0.1",
+        "@typescript-eslint/types": "^8.59.3",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "lightningcss": "^1.33.0",
+        "oxc-parser": "^0.143.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0"
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor/node_modules/@typescript-eslint/types": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor/node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/oxlint-plugin-react-doctor/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -9693,6 +11763,60 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-doctor": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/react-doctor/-/react-doctor-0.9.12.tgz",
+      "integrity": "sha512-H7RNg13RYKwpQvi3+O3IkSj8pAD1pGTxSetxu7aOwXX3wmF+BydCLDiWxkPT9Pq7bIMHjuJ0taSZLsxEjlNjcA==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@astrojs/compiler": "^4.0.0",
+        "@sentry/node": "^10.54.0",
+        "agent-install": "0.0.5",
+        "conf": "^15.1.0",
+        "confbox": "^0.2.4",
+        "deslop-js": "0.9.12",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "jiti": "^2.7.0",
+        "magicast": "^0.5.3",
+        "oxc-resolver": "^11.24.2",
+        "oxlint": ">=1.77.0 <1.78.0",
+        "oxlint-plugin-react-doctor": "0.9.12",
+        "prompts": "^2.4.2",
+        "typescript": ">=5.0.4 <6",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0",
+        "yaml": "^2.9.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "bin": {
+        "react-doctor": "bin/react-doctor.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0"
+      }
+    },
+    "node_modules/react-doctor/node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -10061,6 +12185,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -10265,6 +12403,13 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -10708,6 +12853,23 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
       "dev": true,
       "license": "MIT"
     },
@@ -11196,6 +13358,19 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -11656,6 +13831,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -11748,6 +13978,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -11922,6 +14159,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -12027,6 +14280,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/zod": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
@@ -12043,6 +14303,19 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zwitch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "build:panel": "vite build --config vite.config.panel.ts",
     "lint": "eslint .",
     "test": "vitest run",
+    "scan": "react-doctor . --no-telemetry",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -53,6 +54,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
     "jsdom": "^26.1.0",
+    "react-doctor": "^0.9.12",
     "typescript": "~5.7.3",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0",

--- a/frontend/src/components/assets-portal.tsx
+++ b/frontend/src/components/assets-portal.tsx
@@ -137,14 +137,22 @@ export function AssetsPortal({ projectId, commit }: AssetsPortalProps) {
         return `${url}${url.includes("?") ? "&" : "?"}commit=${encodeURIComponent(commit)}`;
     }, [commit]);
 
+    // Fetches carry the AbortController signal and every setter is guarded by
+    // `signal.aborted`; the rule cannot see those guards from outside.
+    // react-doctor-disable-next-line react-doctor/no-set-state-after-await-in-effect
     useEffect(() => {
+        const controller = new AbortController();
+        const { signal } = controller;
+
         const fetchFiles = async () => {
             setLoading(true);
             try {
                 const [designRes, mfgRes] = await Promise.all([
-                    fetch(appendCommit(`/api/projects/${projectId}/files?type=design`)),
-                    fetch(appendCommit(`/api/projects/${projectId}/files?type=manufacturing`))
+                    fetch(appendCommit(`/api/projects/${projectId}/files?type=design`), { signal }),
+                    fetch(appendCommit(`/api/projects/${projectId}/files?type=manufacturing`), { signal })
                 ]);
+
+                if (signal.aborted) return;
 
                 if (designRes.ok) {
                     const data = await designRes.json();
@@ -155,13 +163,18 @@ export function AssetsPortal({ projectId, commit }: AssetsPortalProps) {
                     setMfgFiles(data);
                 }
             } catch (err) {
+                if (err instanceof DOMException && err.name === "AbortError") return;
                 console.error("Failed to fetch files", err);
             } finally {
-                setLoading(false);
+                // The abort guard is required: an unconditional reset would let
+                // the stale, aborted effect clear the replacement effect's spinner.
+                // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
+                if (!signal.aborted) setLoading(false);
             }
         };
 
-        fetchFiles();
+        void fetchFiles();
+        return () => controller.abort();
     }, [projectId, appendCommit]);
 
     const handleDownload = (path: string, type: string) => {

--- a/frontend/src/components/auth-callback-page.test.tsx
+++ b/frontend/src/components/auth-callback-page.test.tsx
@@ -1,0 +1,91 @@
+import { StrictMode } from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthCallbackPage } from "./auth-callback-page";
+import { consumeStashedLoginNext, exchangeOidcAuthCode } from "@/lib/auth";
+import type { User } from "@/types/auth";
+
+vi.mock("@/lib/auth", () => ({
+    consumeStashedLoginNext: vi.fn(),
+    exchangeOidcAuthCode: vi.fn(),
+}));
+
+const mockedExchange = vi.mocked(exchangeOidcAuthCode);
+const mockedConsume = vi.mocked(consumeStashedLoginNext);
+
+/**
+ * The OIDC authorization code is single-use, so exchanging it a second time
+ * fails and shows "Authentication failed" after a successful login. These
+ * tests pin the one-exchange guarantee against both re-run triggers:
+ * StrictMode's dev-only double effect invocation, and App handing down a
+ * fresh `onLoginSuccess` identity on every parent render.
+ */
+
+const user: User = { name: "Ada Lovelace", email: "ada@example.com", role: "admin" };
+
+function mount(onLoginSuccess: (user: User) => void = () => {}) {
+    return render(
+        <StrictMode>
+            <AuthCallbackPage onLoginSuccess={onLoginSuccess} />
+        </StrictMode>,
+    );
+}
+
+function settle() {
+    // Let any stray second effect run surface before asserting the count.
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+    window.history.replaceState(null, "", "/login/callback?code=abc123&state=s3cret");
+    mockedExchange.mockReset();
+    mockedConsume.mockReset();
+    mockedConsume.mockReturnValue(null);
+});
+
+afterEach(() => {
+    cleanup();
+    window.history.replaceState(null, "", "/");
+});
+
+describe("AuthCallbackPage", () => {
+    it("exchanges the authorization code exactly once across StrictMode's double effect invocation", async () => {
+        mockedExchange.mockResolvedValue(user);
+
+        mount();
+
+        await waitFor(() => expect(mockedExchange).toHaveBeenCalledTimes(1));
+        await settle();
+        expect(mockedExchange).toHaveBeenCalledTimes(1);
+        expect(mockedExchange).toHaveBeenCalledWith("abc123", "s3cret");
+    });
+
+    it("does not re-exchange when the parent re-renders with a fresh callback identity", async () => {
+        mockedExchange.mockResolvedValue(user);
+        const onLoginSuccess = vi.fn();
+
+        const view = mount(onLoginSuccess);
+        await waitFor(() => expect(mockedExchange).toHaveBeenCalledTimes(1));
+
+        view.rerender(
+            <StrictMode>
+                <AuthCallbackPage onLoginSuccess={() => {}} />
+            </StrictMode>,
+        );
+        await settle();
+
+        expect(mockedExchange).toHaveBeenCalledTimes(1);
+        expect(onLoginSuccess).toHaveBeenCalledWith(user);
+    });
+
+    it("reports an exchange failure instead of retrying against a dead code", async () => {
+        mockedExchange.mockRejectedValue(new Error("code already used"));
+
+        mount();
+
+        await waitFor(() => expect(screen.getByText("code already used")).toBeTruthy());
+        await settle();
+        expect(mockedExchange).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/components/auth-callback-page.tsx
+++ b/frontend/src/components/auth-callback-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { consumeStashedLoginNext, exchangeOidcAuthCode } from "@/lib/auth";
 import type { User } from "@/types/auth";
@@ -9,8 +9,20 @@ interface AuthCallbackPageProps {
 
 export function AuthCallbackPage({ onLoginSuccess }: AuthCallbackPageProps) {
   const [error, setError] = useState<string | null>(null);
+  // The authorization code is single-use: guard against the effect re-running
+  // because App re-rendered and handed us a new `onLoginSuccess` identity, and
+  // against StrictMode's dev-only double effect invocation.
+  const startedRef = useRef(false);
 
+  // The once-only guard below is the cancellation strategy: a per-run cancelled
+  // flag would be flipped by StrictMode's cleanup while this single exchange is
+  // still in flight, silently dropping the login in dev. Late setState after
+  // unmount is a no-op in React 18.
+  // react-doctor-disable-next-line react-doctor/no-set-state-after-await-in-effect
   useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
     const run = async () => {
       const urlParams = new URLSearchParams(window.location.search);
       const code = urlParams.get("code");
@@ -43,6 +55,11 @@ export function AuthCallbackPage({ onLoginSuccess }: AuthCallbackPageProps) {
         window.history.replaceState(null, "", "/");
         onLoginSuccess(user);
       } catch (err) {
+        // Deliberately unguarded: `startedRef` makes this effect run at most
+        // once per mount, and a cancellation flag would break StrictMode dev
+        // (cleanup would cancel the only real exchange). Late setState after
+        // unmount is a no-op in React 18.
+        // react-doctor-disable-next-line react-doctor/no-set-state-after-await-in-effect
         setError(err instanceof Error ? err.message : "Authentication failed");
       }
     };

--- a/frontend/src/components/design-comparison/comparison-discussion-rail.test.tsx
+++ b/frontend/src/components/design-comparison/comparison-discussion-rail.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ComparisonDiscussionRail } from "./comparison-discussion-rail";
+import { fetchApi, readApiError } from "@/lib/api";
+import type { Comment } from "@/types/comments";
+
+vi.mock("@/lib/api", () => ({
+    fetchApi: vi.fn(),
+    readApiError: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(fetchApi);
+const mockedReadError = vi.mocked(readApiError);
+
+/**
+ * A rejected request used to leave the reply button disabled until remount:
+ * `addReply` set `busy` and never cleared it when `fetchApi` threw. These
+ * tests pin that every path out of the handler re-enables the composer.
+ */
+
+const comment: Comment = {
+    id: "c1",
+    author: "Kim",
+    timestamp: "2026-08-22T00:00:00Z",
+    status: "OPEN",
+    context: "PCB",
+    location: { x: 0, y: 0, layer: "F.Cu" },
+    content: "Tracer looks wrong near J4",
+    replies: [],
+    commentClass: "general",
+    severity: "info",
+    mentions: [],
+};
+
+const baseProps = {
+    projectId: "p1",
+    base: "aaa",
+    compare: "bbb",
+    domain: "PCB" as const,
+    anchor: null,
+    comments: [comment],
+    canComment: true,
+    onCommentsChange: () => {},
+    onClose: () => {},
+};
+
+function openReplyComposer() {
+    // Two buttons answer to "Reply" across the rail's lifetime, but only one
+    // at a time: the opener swaps for the submit button once replying.
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    const textarea = screen.getByPlaceholderText("Reply…");
+    fireEvent.change(textarea, { target: { value: "Looks good to me" } });
+    return screen.getByRole("button", { name: "Reply" });
+}
+
+beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedReadError.mockReset();
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("ComparisonDiscussionRail addReply", () => {
+    it("re-enables the reply button after a network rejection", async () => {
+        mockedFetch.mockRejectedValue(new Error("network down"));
+
+        render(<ComparisonDiscussionRail {...baseProps} />);
+        const submit = openReplyComposer();
+        expect(submit).not.toBeDisabled();
+
+        fireEvent.click(submit);
+        await waitFor(() => expect(screen.getByRole("button", { name: "Reply" })).not.toBeDisabled());
+        expect(screen.getByText("network down")).toBeTruthy();
+    });
+
+    it("re-enables the reply button after an API error response", async () => {
+        mockedFetch.mockResolvedValue(new Response(null, { status: 500 }));
+        mockedReadError.mockResolvedValue("Server exploded");
+
+        render(<ComparisonDiscussionRail {...baseProps} />);
+        const submit = openReplyComposer();
+        fireEvent.click(submit);
+
+        await waitFor(() => expect(screen.getByRole("button", { name: "Reply" })).not.toBeDisabled());
+        expect(mockedReadError).toHaveBeenCalled();
+    });
+
+    it("still delivers the reply on the happy path", async () => {
+        const onCommentsChange = vi.fn();
+        mockedFetch.mockResolvedValue(new Response(JSON.stringify({ comment: { ...comment, id: "r1" } }), { status: 200 }));
+
+        render(<ComparisonDiscussionRail {...baseProps} onCommentsChange={onCommentsChange} />);
+        const submit = openReplyComposer();
+        fireEvent.click(submit);
+
+        await waitFor(() => expect(onCommentsChange).toHaveBeenCalledTimes(1));
+        expect(mockedFetch).toHaveBeenCalledWith("/api/projects/p1/comments/c1/replies", {
+            method: "POST",
+            body: JSON.stringify({ content: "Looks good to me" }),
+        });
+        // Composer reset signals completion.
+        expect(screen.queryByPlaceholderText("Reply…")).toBeNull();
+    });
+});

--- a/frontend/src/components/design-comparison/comparison-discussion-rail.tsx
+++ b/frontend/src/components/design-comparison/comparison-discussion-rail.tsx
@@ -74,42 +74,49 @@ export function ComparisonDiscussionRail({
     };
 
     const resolveThread = async (comment: Comment) => {
-        const response = await fetchApi(`/api/projects/${projectId}/comments/${comment.id}`, {
-            method: "PATCH",
-            body: JSON.stringify({
-                status: comment.status === "RESOLVED" ? "OPEN" : "RESOLVED",
-            }),
-        });
-        if (!response.ok) {
-            setError(await readApiError(response, "Failed to update discussion"));
-            return;
+        try {
+            const response = await fetchApi(`/api/projects/${projectId}/comments/${comment.id}`, {
+                method: "PATCH",
+                body: JSON.stringify({
+                    status: comment.status === "RESOLVED" ? "OPEN" : "RESOLVED",
+                }),
+            });
+            if (!response.ok) {
+                setError(await readApiError(response, "Failed to update discussion"));
+                return;
+            }
+            const updated = (await response.json()) as Comment;
+            onCommentsChange(comments.map((item) => item.id === updated.id ? updated : item));
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : "Failed to update discussion");
         }
-        const updated = (await response.json()) as Comment;
-        onCommentsChange(comments.map((item) => item.id === updated.id ? updated : item));
     };
 
     const addReply = async (comment: Comment) => {
         if (!reply.trim()) return;
         setBusy(true);
-        const response = await fetchApi(
-            `/api/projects/${projectId}/comments/${comment.id}/replies`,
-            {
-                method: "POST",
-                body: JSON.stringify({ content: reply.trim() }),
-            },
-        );
-        if (!response.ok) {
-            setError(await readApiError(response, "Failed to add reply"));
+        try {
+            const response = await fetchApi(
+                `/api/projects/${projectId}/comments/${comment.id}/replies`,
+                {
+                    method: "POST",
+                    body: JSON.stringify({ content: reply.trim() }),
+                },
+            );
+            if (!response.ok) {
+                throw new Error(await readApiError(response, "Failed to add reply"));
+            }
+            const payload = (await response.json()) as { comment: Comment };
+            onCommentsChange(
+                comments.map((item) => item.id === payload.comment.id ? payload.comment : item),
+            );
+            setReply("");
+            setReplyingTo(null);
+        } catch (caught) {
+            setError(caught instanceof Error ? caught.message : "Failed to add reply");
+        } finally {
             setBusy(false);
-            return;
         }
-        const payload = (await response.json()) as { comment: Comment };
-        onCommentsChange(
-            comments.map((item) => item.id === payload.comment.id ? payload.comment : item),
-        );
-        setReply("");
-        setReplyingTo(null);
-        setBusy(false);
     };
 
     return (

--- a/frontend/src/components/documentation-browser.tsx
+++ b/frontend/src/components/documentation-browser.tsx
@@ -121,24 +121,35 @@ export function DocumentationBrowser({ projectId, commit }: DocumentationBrowser
         return `${url}${url.includes("?") ? "&" : "?"}commit=${encodeURIComponent(commit)}`;
     }, [commit]);
 
+    // Fetch carries the AbortController signal and setters are guarded by
+    // `signal.aborted`; the rule cannot see those guards from outside.
+    // react-doctor-disable-next-line react-doctor/no-set-state-after-await-in-effect
     useEffect(() => {
+        const controller = new AbortController();
+        const { signal } = controller;
+
         const fetchFiles = async () => {
             setLoading(true);
             setViewingDoc(null);
             try {
-                const response = await fetch(appendCommit(`/api/projects/${projectId}/docs`));
+                const response = await fetch(appendCommit(`/api/projects/${projectId}/docs`), { signal });
                 if (response.ok) {
                     const data = await response.json();
-                    setFiles(data);
+                    if (!signal.aborted) setFiles(data);
                 }
             } catch (err) {
+                if (err instanceof DOMException && err.name === "AbortError") return;
                 console.error("Failed to fetch docs", err);
             } finally {
-                setLoading(false);
+                // The abort guard is required: an unconditional reset would let
+                // the stale, aborted effect clear the replacement effect's spinner.
+                // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
+                if (!signal.aborted) setLoading(false);
             }
         };
 
-        fetchFiles();
+        void fetchFiles();
+        return () => controller.abort();
     }, [projectId, appendCommit]);
 
     const handleView = async (path: string, name: string) => {


### PR DESCRIPTION
Carries Phase 0 (tooling + baseline) and Phase 1 (measured bugs) of the react-doctor remediation. The full findings breakdown lives in `docs/REACT_DOCTOR_FINDINGS.md` (committed, with a post-verification re-grading table); this body is the working record.

## Context

`react-doctor@0.9.12` scanned `frontend/`: **303 findings** across 239 files. Before acting on rule severities, every high-priority claim was verified by reading code or running probes — several P0s turned out to be deliberate idioms or false positives, and three genuinely broken behaviors surfaced. This PR fixes only what was measured to be broken.

## What changed

**Phase 0 — tooling**
- `react-doctor` as a devDependency + npm `scan` script. A bare `npx react-doctor` run silently skips linting on some machines (missing oxlint native binding, reported only as `skippedChecks` inside JSON) — always assert it's empty.
- `frontend/doctor.config.ts`: ignores vendored `public/` bundles except `ecad-viewer.js`, which is maintained fork code and stays in review.
- Baseline: 303 findings / 239 files / `skippedChecks: []`.

**Phase 1 — the measured bugs**

| Bug | Fix |
|---|---|
| **Stuck reply button** — `comparison-discussion-rail.tsx:91`: `addReply` set `busy`, then awaited with no try/catch; any network rejection left the button disabled until remount | try/catch/**finally**, matching `createThread`'s in-file pattern; `resolveThread` also reported failures instead of raising unhandled rejections |
| **Double OAuth exchange** — `auth-callback-page.tsx`: effect deps `[onLoginSuccess]` get a new identity on every App render (`App.tsx:165`, plain function), so any App re-render while on the callback route re-exchanged a single-use authorization code → "Authentication failed" after successful login. StrictMode's dev double-invocation did the same | `startedRef` once-per-mount guard |
| **Wrong commit's files** — `assets-portal.tsx:140` and `documentation-browser.tsx:124` re-fetched on `[projectId, commit]` with no cancellation; rapid switches let the older response land last | AbortController + aborted-guards on every setter, mirroring the existing `settings-dialog` pattern |

Six regression tests pin these. Each test was **verified to fail against the pre-fix code** (via stash round-trip) before being trusted — e.g. StrictMode really did double-invoke the exchange, and the reply button really did stay disabled for the full timeout on rejection.

## Verification

- `tsc -b` clean · eslint clean · **vitest 431/431 green** (was 425)
- Rescan: **303 → 297**, `skippedChecks: []`
- Delta accounting: both `no-fetch-in-effect` findings resolved by the guards; RD-07's real site resolved; the rest of the diff is line-shifts of untouched findings owned by Phases 2–4

## Deliberate suppressions (3 inline, each with justification at the site)

- `auth-callback-page`: the rule wants a per-run cancelled flag, but that would **break StrictMode dev login** — cleanup would cancel the only real exchange while the second mount early-returns on the guard. Late setState after unmount is a no-op in React 18.
- `assets-portal` / `documentation-browser`: the abort-guard inside `finally` is load-bearing — an unconditional reset would let the stale aborted effect clear the replacement effect's spinner. The rule flags this shape even when correct (same misfire as `settings-dialog:243`).

## Known false positives recorded (not fixed here)

RD-20 (weak crypto = element-id UUIDs), RD-28 (object URLs: ownership transfers to caller; revoking at creation would blank previews — consumer already revokes correctly), RD-19 (origin already validated), settings-dialog loading-flag FP. Full table in `docs/REACT_DOCTOR_FINDINGS.md` § Re-grading.

## Next phases (separate PRs)

2: cheap correctness batch (index-keys, status checks, pointer-cancel…) · 3: security quick wins · 4: accessibility sweep · 5: prop-sync restructures sequenced by rendering-test coverage, not finding count.