### PR TITLE
React Doctor Phase 2: clear all remaining error-severity findings

### DIFF
--- a/frontend/src/components/comment-card.tsx
+++ b/frontend/src/components/comment-card.tsx
@@ -114,8 +114,8 @@ export function CommentCard({
 
             {comment.replies.length > 0 && (
                 <div className="space-y-2 border-t bg-muted/30 px-3 py-2">
-                    {comment.replies.slice(-3).map((reply, index) => (
-                        <div key={`${reply.timestamp}-${index}`} className="text-xs">
+                    {comment.replies.slice(-3).map((reply) => (
+                        <div key={`${reply.timestamp}-${reply.author}-${reply.content}`} className="text-xs">
                             <span className="font-medium">{reply.author}</span>
                             <span className="text-muted-foreground"> · {reply.content}</span>
                         </div>

--- a/frontend/src/components/comment-panel.tsx
+++ b/frontend/src/components/comment-panel.tsx
@@ -273,8 +273,8 @@ function PanelCommentCard({
                                 {comment.replies.length} replies
                             </div>
                             {expanded &&
-                                comment.replies.map((reply, idx) => (
-                                    <div key={idx} className="relative border-l-2 border-muted pl-2 text-sm">
+                                comment.replies.map((reply) => (
+                                    <div key={`${reply.timestamp}-${reply.author}-${reply.content}`} className="relative border-l-2 border-muted pl-2 text-sm">
                                         <div className="mb-1 flex items-center justify-between">
                                             <span className="text-xs font-medium">{reply.author}</span>
                                             <span className="text-[10px] text-muted-foreground">

--- a/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
+++ b/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
@@ -765,6 +765,10 @@ export function ComparisonPresentationShell({
                 // Old/New reuses one retained viewport and swaps its prepared
                 // revision scene. Reapply the camera captured before the swap
                 // so switching revisions never performs an implicit zoom-fit.
+                // Imperative command to a live custom element, not data
+                // mutation: the element must not be cloned or replaced, and
+                // the camera change must not trigger a render.
+                // react-doctor-disable-next-line react-doctor/no-direct-state-mutation
                 primaryViewer.camera = retainedOldNewCamera;
             }
             setPreparation(session.preparation);
@@ -1108,6 +1112,9 @@ export function ComparisonPresentationShell({
         sessionPhase,
     ]);
 
+    // Every listener registered below is removed in the returned cleanup; the
+    // rule cannot match the removal loop across its multiline form.
+    // react-doctor-disable-next-line react-doctor/effect-needs-cleanup
     useEffect(() => {
         if (domain !== "pcb") {
             setPcbLayers([]);

--- a/frontend/src/components/design-comparison/comparison-result-loader.ts
+++ b/frontend/src/components/design-comparison/comparison-result-loader.ts
@@ -31,33 +31,35 @@ export async function hydrateDesignComparePayload(
     signal?: AbortSignal,
 ): Promise<DesignCompareResult> {
     if (!isBundle(payload)) return payload;
-    const responses = await Promise.all(
-        SIDECARS.map(async (name) => {
-            const descriptor = payload.sidecars[name];
-            if (!descriptor?.url) {
-                throw new Error(`Comparison result is missing its ${name} sidecar`);
-            }
-            const response = await fetchApi(descriptor.url, { signal });
-            if (!response.ok) {
-                throw new Error(
-                    await readApiError(
-                        response,
-                        `Failed to load comparison ${name} data`,
-                    ),
-                );
-            }
-            return [name, await response.json()] as const;
-        }),
-    );
-    const optional = await Promise.all(
-        OPTIONAL_SIDECARS.map(async (name) => {
-            const descriptor = payload.sidecars[name];
-            if (!descriptor?.url) return [name, undefined] as const;
-            const response = await fetchApi(descriptor.url, { signal });
-            if (!response.ok) return [name, undefined] as const;
-            return [name, await response.json()] as const;
-        }),
-    );
+    const [responses, optional] = await Promise.all([
+        Promise.all(
+            SIDECARS.map(async (name) => {
+                const descriptor = payload.sidecars[name];
+                if (!descriptor?.url) {
+                    throw new Error(`Comparison result is missing its ${name} sidecar`);
+                }
+                const response = await fetchApi(descriptor.url, { signal });
+                if (!response.ok) {
+                    throw new Error(
+                        await readApiError(
+                            response,
+                            `Failed to load comparison ${name} data`,
+                        ),
+                    );
+                }
+                return [name, await response.json()] as const;
+            }),
+        ),
+        Promise.all(
+            OPTIONAL_SIDECARS.map(async (name) => {
+                const descriptor = payload.sidecars[name];
+                if (!descriptor?.url) return [name, undefined] as const;
+                const response = await fetchApi(descriptor.url, { signal });
+                if (!response.ok) return [name, undefined] as const;
+                return [name, await response.json()] as const;
+            }),
+        ),
+    ]);
     const sidecars = Object.fromEntries([...responses, ...optional]) as Record<
         (typeof SIDECARS)[number] | (typeof OPTIONAL_SIDECARS)[number],
         unknown

--- a/frontend/src/components/design-comparison/use-design-compare-job.ts
+++ b/frontend/src/components/design-comparison/use-design-compare-job.ts
@@ -82,6 +82,9 @@ export function useDesignCompareJob(
         return () => controller.abort();
     }, [projectId, base, head]);
 
+    // The pending timeout is cleared in this effect's cleanup; the assignment
+    // happens inside the async poll loop, where the rule cannot see it.
+    // react-doctor-disable-next-line react-doctor/effect-needs-cleanup
     useEffect(() => {
         if (!jobId) return;
         const controller = new AbortController();

--- a/frontend/src/components/keyboard-shortcuts-dialog.tsx
+++ b/frontend/src/components/keyboard-shortcuts-dialog.tsx
@@ -50,8 +50,8 @@ export function KeyboardShortcutsDialog({
                     <div key={shortcut.description} className="flex items-start justify-between gap-3">
                       <dt className="text-sm text-foreground">{shortcut.description}</dt>
                       <dd className="flex shrink-0 items-center gap-1 pt-0.5">
-                        {keys.map((key, index) => (
-                          <KeyCap key={`${key}-${index}`}>{key}</KeyCap>
+                        {keys.map((key) => (
+                          <KeyCap key={`${shortcut.description}-${key}`}>{key}</KeyCap>
                         ))}
                       </dd>
                     </div>

--- a/frontend/src/components/release-studio/shared.tsx
+++ b/frontend/src/components/release-studio/shared.tsx
@@ -126,7 +126,9 @@ export function MemberViewer({
                 }
                 created = url;
                 if (kind === "text") {
-                    const body = await (await fetch(url)).text();
+                    const response = await fetch(url);
+                    if (!response.ok) throw new Error(`Preview unavailable (${response.status})`);
+                    const body = await response.text();
                     if (!revoked) setText(body);
                 } else {
                     setObjectUrl(url);

--- a/frontend/src/components/ui/field.tsx
+++ b/frontend/src/components/ui/field.tsx
@@ -188,8 +188,8 @@ function FieldError({
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
+          (error) =>
+            error?.message && <li key={error.message}>{error.message}</li>
         )}
       </ul>
     )

--- a/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
+++ b/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
@@ -359,8 +359,14 @@ export function LibraryBulkEditWorkspace({ user }: { user: User | null }) {
   const visibleRows = items.slice(firstVisibleRow, lastVisibleRow);
 
   const commitStaged = useCallback((next: StagedRows) => {
-    setStaged((current) => { undoStack.current.push(cloneStaged(current)); if (undoStack.current.length > 100) undoStack.current.shift(); redoStack.current = []; return next; });
-  }, []);
+    // History bookkeeping lives here, not inside a state updater: React may
+    // invoke an updater more than once, which would duplicate undo entries.
+    if (next === staged) return;
+    undoStack.current.push(cloneStaged(staged));
+    if (undoStack.current.length > 100) undoStack.current.shift();
+    redoStack.current = [];
+    setStaged(next);
+  }, [staged]);
   const undo = () => { const previous = undoStack.current.pop(); if (!previous) return; redoStack.current.push(cloneStaged(staged)); setStaged(previous); };
   const redo = () => { const next = redoStack.current.pop(); if (!next) return; undoStack.current.push(cloneStaged(staged)); setStaged(next); };
 

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -697,6 +697,14 @@ function OverlayDifference({
             event.currentTarget.releasePointerCapture(event.pointerId);
             draggingRef.current = false;
           }}
+          onPointerCancel={() => {
+            // Capture is already released by the browser on cancel; dragging
+            // must stop or the divider tracks a pointer that no longer exists.
+            draggingRef.current = false;
+          }}
+          onLostPointerCapture={() => {
+            draggingRef.current = false;
+          }}
           onKeyDown={(event) => {
             if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
               event.preventDefault();

--- a/frontend/src/components/workspace/library-import-remediation-dialog.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-dialog.tsx
@@ -113,7 +113,7 @@ export function LibraryImportRemediationDialog({ proposal, open, submitting, onO
             </div>
           </section>
 
-          {proposal.findings.length > 0 && <section><h3 className="text-sm font-semibold">Import findings</h3><div className="mt-2 space-y-2">{proposal.findings.map((finding, index) => <div key={`${finding.code}-${index}`} className="flex gap-2 border p-2.5 text-sm"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" /><span>{finding.message}</span></div>)}</div></section>}
+          {proposal.findings.length > 0 && <section><h3 className="text-sm font-semibold">Import findings</h3><div className="mt-2 space-y-2">{proposal.findings.map((finding) => <div key={`${finding.code}-${finding.message}`} className="flex gap-2 border p-2.5 text-sm"><AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" /><span>{finding.message}</span></div>)}</div></section>}
           <div className="space-y-1.5"><Label htmlFor="import-summary">Revision summary</Label><Input id="import-summary" value={changeSummary} onChange={(event) => setChangeSummary(event.target.value)} /></div>
         </div>}
 

--- a/frontend/src/components/workspace/library-import-remediation-grid.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-grid.tsx
@@ -17,6 +17,7 @@ import type {
   BulkAcceptResult, ImportProposalDraft, ProjectComponentImportProposal,
 } from "@/types/catalog";
 import { LibraryAssetLinkPicker } from "./library-asset-link-picker";
+import { useEditHistory } from "./use-edit-history";
 
 interface LibraryImportRemediationGridProps {
   sessionId: string;
@@ -215,11 +216,11 @@ export function LibraryImportRemediationGrid({
   canWrite,
   onRefresh,
 }: LibraryImportRemediationGridProps) {
-  const [edits, setEdits] = useState<RowEdits>({});
   // Every cell edit, fill-down, and link change pushes the previous state here so a
-  // mis-aimed fill-down across 300 rows is one keystroke to undo.
-  const [undoStack, setUndoStack] = useState<RowEdits[]>([]);
-  const [redoStack, setRedoStack] = useState<RowEdits[]>([]);
+  // mis-aimed fill-down across 300 rows is one keystroke to undo. The three
+  // pieces move through one pure reducer (useEditHistory) so history can never
+  // duplicate or desync.
+  const { edits, undoStack, redoStack, commitEdits, replaceEdits, resetHistory, undo, redo } = useEditHistory();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [accepting, setAccepting] = useState(false);
@@ -283,40 +284,6 @@ export function LibraryImportRemediationGrid({
   }, [groups]);
 
   /** Apply an edit through the history so it can be undone. */
-  const commitEdits = useCallback((update: (current: RowEdits) => RowEdits) => {
-    setEdits((current) => {
-      const next = update(current);
-      if (next === current) return current;
-      setUndoStack((stack) => [...stack.slice(-49), current]);
-      setRedoStack([]);
-      return next;
-    });
-  }, []);
-
-  const undo = useCallback(() => {
-    setUndoStack((stack) => {
-      if (stack.length === 0) return stack;
-      const previous = stack[stack.length - 1];
-      setEdits((current) => {
-        setRedoStack((redo) => [...redo, current]);
-        return previous;
-      });
-      return stack.slice(0, -1);
-    });
-  }, []);
-
-  const redo = useCallback(() => {
-    setRedoStack((stack) => {
-      if (stack.length === 0) return stack;
-      const next = stack[stack.length - 1];
-      setEdits((current) => {
-        setUndoStack((undoEntries) => [...undoEntries, current]);
-        return next;
-      });
-      return stack.slice(0, -1);
-    });
-  }, []);
-
   /** A grouped row stands for one component, so an edit applies to every member. */
   const setCell = useCallback(
     (group: ProposalGroup, field: EditableField, value: string) => {
@@ -396,9 +363,7 @@ export function LibraryImportRemediationGrid({
         { method: "PUT", body: JSON.stringify({ drafts: buildDrafts() }) },
         "Failed to save import edits"
       );
-      setEdits({});
-      setUndoStack([]);
-      setRedoStack([]);
+      resetHistory();
       // Saved edits are no longer pending, so a stale selection would leave the
       // "Import selected" count disagreeing with the checkboxes.
       setSelected(new Set());
@@ -409,7 +374,7 @@ export function LibraryImportRemediationGrid({
     } finally {
       setSaving(false);
     }
-  }, [buildDrafts, dirtyCount, onRefresh, sessionId]);
+  }, [buildDrafts, dirtyCount, onRefresh, resetHistory, sessionId]);
 
   const acceptRows = useCallback(
     async (rows: ProposalGroup[]) => {
@@ -439,7 +404,7 @@ export function LibraryImportRemediationGrid({
           "Failed to accept import rows"
         );
 
-        setEdits((current) => {
+        replaceEdits((current) => {
           const next = { ...current };
           for (const entry of result.results) {
             if (entry.status === "accepted") delete next[entry.proposal_id];
@@ -477,7 +442,7 @@ export function LibraryImportRemediationGrid({
         setAccepting(false);
       }
     },
-    [edits, onRefresh, sessionId]
+    [edits, onRefresh, replaceEdits, sessionId]
   );
 
   const exportCsv = useCallback(() => {
@@ -497,7 +462,7 @@ export function LibraryImportRemediationGrid({
         );
         if (!response.ok) throw new Error(await readApiError(response, "Failed to import CSV"));
         const result = (await response.json()) as { saved: number; skipped_unknown_rows: number };
-        setEdits({});
+        replaceEdits(() => ({}));
         await onRefresh();
         toast.success(
           `Applied ${result.saved} rows` +
@@ -510,7 +475,7 @@ export function LibraryImportRemediationGrid({
         if (fileInputRef.current) fileInputRef.current.value = "";
       }
     },
-    [onRefresh, sessionId]
+    [onRefresh, replaceEdits, sessionId]
   );
 
   // Undo, redo, and save stay live while a cell is focused — the whole point is

--- a/frontend/src/components/workspace/use-edit-history.test.ts
+++ b/frontend/src/components/workspace/use-edit-history.test.ts
@@ -1,0 +1,122 @@
+import { StrictMode } from "react";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+    editHistoryReducer,
+    emptyEditHistory,
+    useEditHistory,
+    type EditHistoryState,
+} from "./use-edit-history";
+import type { RowEdits } from "./library-import-remediation-grid";
+
+/**
+ * Characterization tests for the remediation-grid edit history. These pin the
+ * behavior contract the old nested-setState implementation provided before it
+ * was replaced with a pure reducer:
+ * - commit snapshots prior edits onto undo (capped at 50) and clears redo
+ * - undo/redo are symmetric no-ops on empty stacks
+ * - replaceEdits rewrites edits without touching history
+ * - reset wipes everything
+ */
+
+const setField = (value: string) => (current: RowEdits): RowEdits => ({
+    ...current,
+    R1: { metadata: { ...current.R1?.metadata, package_name: value } },
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+describe("editHistoryReducer", () => {
+    it("commit applies the update and pushes prior edits onto the undo stack", () => {
+        const base: EditHistoryState = { ...emptyEditHistory, edits: { R0: { metadata: {} } } };
+        const next = editHistoryReducer(base, { type: "commit", update: setField("v1") });
+
+        expect(Object.keys(next.edits)).toContain("R1");
+        expect(next.undoStack).toEqual([base.edits]);
+        expect(next.redoStack).toEqual([]);
+    });
+
+    it("a no-op commit returns the same state object", () => {
+        const base: EditHistoryState = { ...emptyEditHistory, edits: { R1: { metadata: {} } } };
+        const next = editHistoryReducer(base, { type: "commit", update: (current) => current });
+
+        expect(next).toBe(base);
+    });
+
+    it("undo and redo round-trip the exact previous snapshot", () => {
+        const first = editHistoryReducer(emptyEditHistory, { type: "commit", update: setField("v1") });
+        const second = editHistoryReducer(first, { type: "commit", update: setField("v2") });
+
+        const undone = editHistoryReducer(second, { type: "undo" });
+        expect(undone.edits).toBe(first.edits);
+        expect(undone.redoStack).toEqual([second.edits]);
+
+        const redone = editHistoryReducer(undone, { type: "redo" });
+        expect(redone.edits).toBe(second.edits);
+        // Redo pushes the undone edits back, so the stack matches the state
+        // before the undo rather than shrinking to `first.undoStack`.
+        expect(redone.undoStack).toEqual(second.undoStack);
+        expect(redone.redoStack).toEqual([]);
+    });
+
+    it("undo on an empty stack is a no-op", () => {
+        expect(editHistoryReducer(emptyEditHistory, { type: "undo" })).toBe(emptyEditHistory);
+        expect(editHistoryReducer(emptyEditHistory, { type: "redo" })).toBe(emptyEditHistory);
+    });
+
+    it("caps the undo stack at 50 entries", () => {
+        let current = emptyEditHistory;
+        for (let index = 0; index < 60; index += 1) {
+            current = editHistoryReducer(current, { type: "commit", update: setField(`v${index}`) });
+        }
+        expect(current.undoStack.length).toBe(50);
+    });
+
+    it("replaceEdits rewrites edits without touching history", () => {
+        const committed = editHistoryReducer(emptyEditHistory, { type: "commit", update: setField("v1") });
+        const pruned = editHistoryReducer(committed, {
+            type: "replace",
+            update: (current) => {
+                const next = { ...current };
+                delete next.R1;
+                return next;
+            },
+        });
+
+        expect(pruned.edits).toEqual({});
+        // History still holds the pre-prune snapshot, exactly as the original
+        // implementation did when accepted rows dropped out of the grid.
+        expect(pruned.undoStack).toEqual(committed.undoStack);
+        expect(pruned.redoStack).toEqual([]);
+    });
+
+    it("reset wipes edits and both stacks", () => {
+        const committed = editHistoryReducer(emptyEditHistory, { type: "commit", update: setField("v1") });
+        expect(editHistoryReducer(committed, { type: "reset" })).toBe(emptyEditHistory);
+    });
+});
+
+describe("useEditHistory under StrictMode", () => {
+    // The original implementation performed history bookkeeping inside state
+    // updater callbacks. StrictMode invokes updaters twice in development,
+    // which would push duplicate undo entries; the reducer makes that hazard
+    // unreachable by construction.
+    it("one commit produces exactly one undo entry", () => {
+        const { result } = renderHook(() => useEditHistory(), { wrapper: StrictMode });
+
+        act(() => result.current.commitEdits(setField("v1")));
+        act(() => result.current.commitEdits(setField("v2")));
+
+        expect(result.current.undoStack.length).toBe(2);
+        expect(result.current.edits.R1.metadata.package_name).toBe("v2");
+
+        act(() => result.current.undo());
+        expect(result.current.edits.R1.metadata.package_name).toBe("v1");
+
+        act(() => result.current.redo());
+        expect(result.current.edits.R1.metadata.package_name).toBe("v2");
+    });
+});

--- a/frontend/src/components/workspace/use-edit-history.ts
+++ b/frontend/src/components/workspace/use-edit-history.ts
@@ -1,0 +1,105 @@
+import { useCallback, useReducer } from "react";
+
+import type { RowEdits } from "./library-import-remediation-grid";
+
+/**
+ * Edit history for the import remediation grid: the pending edits plus the
+ * undo/redo stacks, moved through one pure reducer so a single dispatch
+ * transitions all three coherently. The previous implementation nested
+ * setState calls inside updater callbacks, which React may invoke more than
+ * once — duplicating history entries under StrictMode.
+ *
+ * Behavior contract (preserved from the original implementation):
+ * - commit pushes the prior edits onto the undo stack (capped at 50) and
+ *   clears the redo stack; a no-op commit changes nothing.
+ * - undo/redo swap the top of one stack with the current edits and are
+ *   no-ops on empty stacks.
+ * - replaceEdits rewrites the edits WITHOUT touching history (used when
+ *   accepted rows drop out of the pending set).
+ * - reset wipes edits and both stacks (used after saving drafts).
+ */
+
+export interface EditHistoryState {
+    edits: RowEdits;
+    undoStack: RowEdits[];
+    redoStack: RowEdits[];
+}
+
+export type EditHistoryAction =
+    | { type: "commit"; update: (current: RowEdits) => RowEdits }
+    | { type: "replace"; update: (current: RowEdits) => RowEdits }
+    | { type: "reset" }
+    | { type: "undo" }
+    | { type: "redo" };
+
+const EDIT_HISTORY_LIMIT = 50;
+
+export const emptyEditHistory: EditHistoryState = {
+    edits: {},
+    undoStack: [],
+    redoStack: [],
+};
+
+export function editHistoryReducer(
+    state: EditHistoryState,
+    action: EditHistoryAction,
+): EditHistoryState {
+    switch (action.type) {
+        case "commit": {
+            const next = action.update(state.edits);
+            if (next === state.edits) return state;
+            return {
+                edits: next,
+                undoStack: [
+                    ...state.undoStack.slice(-(EDIT_HISTORY_LIMIT - 1)),
+                    state.edits,
+                ],
+                redoStack: [],
+            };
+        }
+        case "replace": {
+            const next = action.update(state.edits);
+            return next === state.edits ? state : { ...state, edits: next };
+        }
+        case "reset":
+            return state === emptyEditHistory ? state : emptyEditHistory;
+        case "undo": {
+            const previous = state.undoStack[state.undoStack.length - 1];
+            if (!previous) return state;
+            return {
+                edits: previous,
+                undoStack: state.undoStack.slice(0, -1),
+                redoStack: [...state.redoStack, state.edits],
+            };
+        }
+        case "redo": {
+            const next = state.redoStack[state.redoStack.length - 1];
+            if (!next) return state;
+            return {
+                edits: next,
+                undoStack: [...state.undoStack, state.edits],
+                redoStack: state.redoStack.slice(0, -1),
+            };
+        }
+    }
+}
+
+export function useEditHistory() {
+    const [state, dispatch] = useReducer(editHistoryReducer, emptyEditHistory);
+
+    const commitEdits = useCallback(
+        (update: (current: RowEdits) => RowEdits) =>
+            dispatch({ type: "commit", update }),
+        [],
+    );
+    const replaceEdits = useCallback(
+        (update: (current: RowEdits) => RowEdits) =>
+            dispatch({ type: "replace", update }),
+        [],
+    );
+    const resetHistory = useCallback(() => dispatch({ type: "reset" }), []);
+    const undo = useCallback(() => dispatch({ type: "undo" }), []);
+    const redo = useCallback(() => dispatch({ type: "redo" }), []);
+
+    return { ...state, commitEdits, replaceEdits, resetHistory, undo, redo };
+}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -794,6 +794,14 @@ function WorkflowsPanel({ projectId, user, canRun }: { projectId: string, user: 
         }
     };
 
+    // Log lines arrive as whole-array snapshots from the job poller; position
+    // is their only stable identity, and the array is replaced (not appended)
+    // on every update, so index-based reconciliation is exact here.
+    const logRows = logs.map((log, i) => (
+        // react-doctor-disable-next-line react-doctor/no-array-index-as-key
+        <div key={i} className="break-all whitespace-pre-wrap">{log}</div>
+    ));
+
     return (
         <div className="max-w-5xl">
             <h2 className="text-2xl font-bold mb-6">Workflows</h2>
@@ -831,9 +839,7 @@ function WorkflowsPanel({ projectId, user, canRun }: { projectId: string, user: 
                         {status === 'failed' && <span className="text-destructive">Failed</span>}
                     </div>
                     <div className="space-y-1">
-                        {logs.map((log, i) => (
-                            <div key={i} className="break-all whitespace-pre-wrap">{log}</div>
-                        ))}
+                        {logRows}
                         {logs.length === 0 && <span className="text-zinc-600">Initializing...</span>}
                     </div>
                 </div>

--- a/frontend/src/panel/lib/kicad-bridge.ts
+++ b/frontend/src/panel/lib/kicad-bridge.ts
@@ -187,7 +187,7 @@ export async function sendRpcCommand(
     session_id: sessionId,
     message_id: ++messageCounter,
     command,
-    parameters: JSON.parse(JSON.stringify(parameters)),
+    parameters: structuredClone(parameters),
     data,
   };
   postToKiCad(JSON.stringify(envelope));


### PR DESCRIPTION
Stacks on #175 (Phase 0+1). Clears every remaining error-severity finding plus the cheap correctness batch — after this, the only errors left in a scoped scan are the wontfix'd latest-ref idioms (RD-01, re-graded P3).

## Fixes

| Finding | Change |
|---|---|
| Preview text parsed without status check (`shared.tsx:129`) | check `res.ok`, throw with status → failure lands in the existing catch path |
| Sequential sidecar fetches (`comparison-result-loader:52`) | required + optional sidecars now fetched in one `Promise.all` |
| `JSON.parse(JSON.stringify())` clone (`kicad-bridge:190`) | `structuredClone` — preserves Dates/Maps, no silent drops |
| Divider drags on forever when capture is interrupted (`library-component-workspace:685`) | `onPointerCancel` + `onLostPointerCapture` stop the drag |
| Array-index keys ×7 | stable identities from reply author+timestamp+content, finding code+message, deduped messages, shortcut description+key; job-log list suppressed at site (whole-array snapshots; position is the identity) |

## RD-02: impure state updaters ×13 → pure reducer

The remediation grid's undo/redo nested `setUndoStack`/`setRedoStack` calls **inside** `setEdits` updater callbacks. React may invoke updaters more than once, duplicating history entries under StrictMode. Extracted into `useEditHistory` — one reducer over `{edits, undoStack, redoStack}` with the exact behavior contract preserved:

- commit caps history at 50 and clears redo; no-op commits return the same object
- undo/redo symmetric no-ops on empty stacks
- accepted-row pruning rewrites edits *without* touching history (as before)
- draft-save wipes everything (as before)

Covered by 8 characterization tests, including a StrictMode render test proving one commit = exactly one undo entry.

`bulk-edit-workspace.commitStaged` had the same shape via ref writes inside an updater; bookkeeping moved into the handler body.

## Justified suppressions (3)

- PCB-layers effect (`presentation-shell`): add/remove listener loops are properly paired across multiline optional-chained forms the matcher can't see.
- Compare-job poll timer: `clearTimeout` sits in cleanup; the assignment happens inside the async poll loop where it's statically invisible. The `cancelled` guard precedes every reschedule.
- Presentation-shell camera write: imperative command to a live custom element held as state — cloning/replacing would be wrong, and it must not re-render.

## Verification

`tsc -b` clean · eslint clean · vitest **433/433** (8 new) · rescan: all eight targeted rules at zero (`no-array-index-as-key`, `effect-needs-cleanup`, both updater rules, `no-direct-state-mutation`, sequential-await, pointer-cancel, status-check).

Note: raw totals on this branch (~375) read high because it predates #175's config exclusion and fixes; against the post-#175 baseline of 297 this PR removes ~35 findings.