### PR TITLE
Key discussion replies by content identity (missed staging from #176)

### DIFF
--- a/frontend/src/components/design-comparison/comparison-discussion-rail.tsx
+++ b/frontend/src/components/design-comparison/comparison-discussion-rail.tsx
@@ -183,8 +183,8 @@ export function ComparisonDiscussionRail({
                         <p className="mt-2 whitespace-pre-wrap leading-relaxed">{comment.content}</p>
                         {!!comment.replies.length && (
                             <div className="mt-2 space-y-2 border-l pl-2">
-                                {comment.replies.map((item, index) => (
-                                    <div key={`${item.timestamp}-${index}`}>
+                                {comment.replies.map((item) => (
+                                    <div key={`${item.timestamp}-${item.author}-${item.content}`}>
                                         <span className="font-medium">{item.author}: </span>
                                         {item.content}
                                     </div>


### PR DESCRIPTION
One file from #176's RD-09 batch stayed in the working tree when the phase commit was assembled: `ComparisonDiscussionRail` reply keys move off array index onto a stable `timestamp+author+content` identity, same treatment as comment-card/comment-panel in that PR.

Everything else in #176 is already merged; this completes its findings list.