### PR TITLE
Fix legacy board testpoint drawings

### DIFF
--- a/backend/app/release_studio/documents/__init__.py
+++ b/backend/app/release_studio/documents/__init__.py
@@ -57,6 +57,8 @@ def renderer_resource_digest() -> str:
 #: reproducibility claim the key exists to make. The golden-digest tests in
 #: `test_release_studio_documents.py` fail on any rendering change, so the bump
 #: cannot be skipped silently.
+#: d22 -- testpoint drawings render a Monkey-derived TP-only staging board and
+#: promote legacy fp_text references for released Cruncher compatibility.
 #: d21 -- Cruncher views honor the checked-in board-outline canvas policy via
 #: Monkey's public bounding boxes, keeping SVG and PDF placement identical.
 #: d20 -- bordered schedule cells inset from the grid on both sides so
@@ -104,7 +106,7 @@ def renderer_resource_digest() -> str:
 #: d7 -- the default frame/title block is emitted by Monkey's public KiCad
 #: worksheet API and visible technical text uses Monkey's pinned NewStroke
 #: geometry. A deterministic hidden PDF text layer preserves search/copy.
-RENDERER_VERSION = "release-studio-documents/d21"
+RENDERER_VERSION = "release-studio-documents/d22"
 
 __all__ = [
     "ASSEMBLY_SIDES",

--- a/backend/app/release_studio/documents/artwork.py
+++ b/backend/app/release_studio/documents/artwork.py
@@ -22,7 +22,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from app.release_studio.documents.layout import Artwork, Rect
 
@@ -261,8 +261,9 @@ def _coordinate_pairs(svg_text: str, limit: int = 64) -> list[tuple[float, float
 #: input closure, and the closure digest would then depend on the build.
 PCB_SVG_CONFIG = Path(__file__).with_name("pcb-svg.config.json")
 
-#: The testpoint views, which need a per-board component map (see its own
-#: ``_prism`` note for why it cannot share the assembly configuration).
+#: Testpoint-only views. They use a derived staging board so Cruncher receives
+#: only TP footprints; see the config's ``_prism`` note for the compatibility
+#: contract with legacy KiCad boards.
 PCB_SVG_TESTPOINT_CONFIG = Path(__file__).with_name("pcb-svg.testpoints.config.json")
 
 #: Cruncher view name per assembly side.
@@ -277,10 +278,10 @@ TESTPOINT_VIEWS: dict[str, str] = {
     "bottom": "testpoint_bottom_view",
 }
 
-#: Every view kind Prism's checked-in Cruncher configuration declares.
+#: Views safe to render directly from the source board. Testpoints are
+#: deliberately absent: they must pass through :func:`_stage_testpoint_board`.
 VIEW_KINDS: dict[str, dict[str, str]] = {
     "assembly": ASSEMBLY_VIEWS,
-    "testpoint": TESTPOINT_VIEWS,
 }
 
 #: What Cruncher *actually* drew each component from.
@@ -428,42 +429,6 @@ def acquire_board_render(
     )
 
 
-def testpoint_config(
-    designators: Sequence[str],
-    workdir: Path,
-    *,
-    prefix: str = "TP",
-    base: Path | None = None,
-) -> Path:
-    """Write the testpoint configuration for one board, and return its path.
-
-    Cruncher draws a component's outline unless that component says otherwise,
-    and it has no wildcard for saying so -- ``components`` is keyed by exact
-    designator.  So "only the testpoints" is written as every other designator
-    switched off.  The map is a pure function of the board's sorted designator
-    list, which keeps two builds of one board byte-identical here.
-    """
-
-    import json
-
-    source = base or PCB_SVG_TESTPOINT_CONFIG
-    if not source.is_file():
-        raise ArtworkError(f"the Prism testpoint configuration is missing: {source}")
-    config = json.loads(source.read_text(encoding="utf-8"))
-    marker = prefix.strip().upper()
-    config["components"] = {
-        designator: {"assembly_hlr": {"enabled": False}}
-        for designator in sorted({str(d).strip() for d in designators if str(d).strip()})
-        if not designator.strip().upper().startswith(marker)
-    }
-    workdir.mkdir(parents=True, exist_ok=True)
-    written = workdir / "pcb-svg.testpoints.generated.json"
-    written.write_text(
-        json.dumps(config, indent=2, sort_keys=False) + "\n", encoding="utf-8"
-    )
-    return written
-
-
 def acquire_testpoint_views(
     cruncher_path: str,
     board: Path,
@@ -474,7 +439,16 @@ def acquire_testpoint_views(
     runner=subprocess.run,
     timeout_seconds: int = 900,
 ) -> dict[str, AcquiredArtwork]:
-    """Render the testpoint views, keyed ``"testpoint-<side>"``."""
+    """Render the testpoint views, keyed ``"testpoint-<side>"``.
+
+    Cruncher 2026.8.x resolves a footprint designator from the modern
+    ``Reference`` property and otherwise falls back to its library link. Older
+    KiCad boards store the reference in ``fp_text reference`` instead, which
+    makes both the ``TP*`` label selector and component filtering miss. Rather
+    than interpret either the board file or Cruncher's SVG, derive a staging
+    board through Monkey's public object model: retain only testpoint
+    footprints and promote each legacy reference to the modern property.
+    """
 
     views = []
     for side in sides:
@@ -485,19 +459,115 @@ def acquire_testpoint_views(
     if not views:
         return {}
 
-    workdir.mkdir(parents=True, exist_ok=True)
-    config = testpoint_config(designators, workdir)
-    _run_pcb_svg(
-        cruncher_path, board, views, workdir,
-        config_path=config, runner=runner, timeout_seconds=timeout_seconds,
+    source_board = Path(board).resolve()
+    staged_board, staged_designators = _stage_testpoint_board(source_board, workdir)
+    expected = tuple(
+        sorted(
+            {
+                str(reference).strip()
+                for reference in designators
+                if str(reference).strip().upper().startswith("TP")
+            }
+        )
     )
-    viewport = _cruncher_board_viewport(board, config)
+    if designators and expected != staged_designators:
+        missing = sorted(set(expected) - set(staged_designators))
+        unexpected = sorted(set(staged_designators) - set(expected))
+        detail = []
+        if missing:
+            detail.append(f"missing {', '.join(missing)}")
+        if unexpected:
+            detail.append(f"unexpected {', '.join(unexpected)}")
+        raise ArtworkError(
+            "testpoint drawing and board projection disagree: "
+            + ("; ".join(detail) or "designator sets differ")
+        )
+
+    _run_pcb_svg(
+        cruncher_path, staged_board, views, workdir,
+        config_path=PCB_SVG_TESTPOINT_CONFIG,
+        project_dir=source_board.parent,
+        runner=runner,
+        timeout_seconds=timeout_seconds,
+    )
+    viewport = _cruncher_board_viewport(staged_board, PCB_SVG_TESTPOINT_CONFIG)
     return {
         f"testpoint-{side}": _read_assembly_view(
             workdir, f"testpoint-{side}", TESTPOINT_VIEWS[side], viewport
         )
         for side in sides
     }
+
+
+def _stage_testpoint_board(
+    board: Path,
+    workdir: Path,
+    *,
+    prefix: str = "TP",
+    pcb_loader: Callable[[Path], Any] | None = None,
+) -> tuple[Path, tuple[str, ...]]:
+    """Write a testpoint-only Monkey board into *workdir*.
+
+    The input board is never edited. Legacy ``fp_text reference`` values are
+    copied into ``property \"Reference\"`` on the retained staging footprints
+    because that is the public designator contract consumed by released
+    Cruncher 2026.8.x.
+    """
+
+    source = Path(board).resolve()
+    destination_dir = Path(workdir).resolve()
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    if pcb_loader is None:
+        try:
+            from kicad_monkey.kicad_pcb import KiCadPcb
+        except Exception as exc:  # noqa: BLE001 - normalize worker dependency failures
+            raise ArtworkError(f"could not load Monkey for testpoint staging: {exc}") from exc
+        pcb_loader = KiCadPcb.from_file
+
+    try:
+        pcb = pcb_loader(source)
+    except Exception as exc:  # noqa: BLE001 - normalize board parse failures
+        raise ArtworkError(f"could not parse board for testpoint staging: {exc}") from exc
+
+    marker = prefix.strip().upper()
+    if not marker:
+        raise ArtworkError("testpoint prefix cannot be empty")
+
+    retained = []
+    designators: set[str] = set()
+    for footprint in getattr(pcb, "footprints", ()) or ():
+        reference = ""
+        get_property = getattr(footprint, "get_property_value", None)
+        if callable(get_property):
+            reference = str(get_property("Reference", "") or "").strip()
+        if not reference:
+            for fp_text in getattr(footprint, "fp_texts", ()) or ():
+                if str(getattr(fp_text, "text_type", "") or "").lower() == "reference":
+                    reference = str(getattr(fp_text, "text", "") or "").strip()
+                    if reference:
+                        break
+        if not reference.upper().startswith(marker):
+            continue
+        if reference in designators:
+            raise ArtworkError(f"duplicate testpoint designator: {reference}")
+        upsert_property = getattr(footprint, "upsert_property", None)
+        if not callable(upsert_property):
+            raise ArtworkError(
+                f"Monkey footprint {reference} cannot set its Reference property"
+            )
+        upsert_property("Reference", reference)
+        designators.add(reference)
+        retained.append(footprint)
+
+    pcb.footprints = retained
+    destination = destination_dir / f"{source.stem}.testpoints.kicad_pcb"
+    try:
+        pcb.save(destination)
+    except Exception as exc:  # noqa: BLE001 - normalize staging write failures
+        raise ArtworkError(f"could not save testpoint staging board: {exc}") from exc
+    if not destination.is_file():
+        raise ArtworkError("Monkey did not write the testpoint staging board")
+    return destination, tuple(sorted(designators))
 
 
 def acquire_board_views(
@@ -516,9 +586,9 @@ def acquire_board_views(
     Keyed ``"<kind>-<side>"``.
 
     Loading the board dominates: on a 35 MB ``.kicad_pcb`` it is ~70 s against
-    a couple of seconds to render one more view off the same load.  So every
-    view Prism wants is declared in the one checked-in configuration and asked
-    for together -- the testpoint views cost the render, not another load.
+    a couple of seconds to render one more assembly view off the same load, so
+    the source-board assembly views are asked for together. Testpoint views are
+    intentionally acquired separately from a normalized TP-only staging board.
     """
 
     wanted: dict[str, str] = {}
@@ -606,6 +676,7 @@ def _run_pcb_svg(
     workdir: Path,
     *,
     config_path: Path | None,
+    project_dir: Path | None = None,
     runner,
     timeout_seconds: int,
 ) -> None:
@@ -626,7 +697,10 @@ def _run_pcb_svg(
     # directory that contains the board.  Without this binding Geometer cannot
     # open STEPs that are already present in the closed tree.
     env = os.environ.copy()
-    env["KIPRJMOD"] = str(Path(board).resolve().parent)
+    env["KIPRJMOD"] = str(
+        (Path(project_dir) if project_dir is not None else Path(board).resolve().parent)
+        .resolve()
+    )
     try:
         result = runner(
             argv, capture_output=True, text=True, timeout=timeout_seconds, env=env

--- a/backend/app/release_studio/documents/engine.py
+++ b/backend/app/release_studio/documents/engine.py
@@ -120,9 +120,8 @@ DRILL_ARTWORK_KEY = "drill"
 #: into each component's own bounds over a hidden-line-removed outline.
 ASSEMBLY_SIDES: tuple[str, ...] = ("top", "bottom")
 
-#: The testpoint views are the same render with only `TP*` labelled.  They are
-#: extra *views* in the one Cruncher configuration rather than a second
-#: invocation, because loading the board is what costs and the render is cheap.
+#: Testpoint views use a derived board containing only TP footprints, with
+#: legacy references normalized through Monkey before Cruncher renders them.
 TESTPOINT_SIDES: tuple[str, ...] = ("top", "bottom")
 
 #: Key the concurrent acquisition uses for the one job that returns every
@@ -254,8 +253,8 @@ def compose(
     members: Sequence[Mapping[str, Any]],
     testpoints: Mapping[str, Any] | None = None,
     population: Mapping[str, Any] | None = None,
-    #: Every reference designator on the board, for the testpoint view's
-    #: component map.  A build input, not a released projection.
+    #: Every reference designator on the board, used to assert that the staged
+    #: testpoint drawing and its released schedule select the same parts.
     designators: Sequence[str] = (),
     board: Path | None = None,
     cli_path: str | None = None,
@@ -368,11 +367,12 @@ def compose(
             else:
                 assembly[side] = drawing
 
-    # Testpoints are a second full board load: a per-board component map that
-    # hid every non-TP outline would poison the assembly views if the two
-    # shared a configuration.  They run *after* the plot pool (and after the
-    # assembly Cruncher, when that was overlapped with catalogue wave A) so
-    # they cannot steal an acquisition slot from a layer plot.
+    # Testpoints are a second board load from a derived TP-only staging board.
+    # That keeps the assembly input untouched and lets legacy fp_text
+    # references be normalized to Cruncher's property-based designator API.
+    # They run *after* the plot pool (and after the assembly Cruncher, when that
+    # was overlapped with catalogue wave A) so they cannot steal an acquisition
+    # slot from a layer plot.
     #
     # Measured rather than assumed: pooling them alongside the layer plots on
     # JTYU-OBC moved compose from 213.3s to 217.5s. Cruncher is CPU bound, so

--- a/backend/app/release_studio/documents/pcb-svg.testpoints.config.json
+++ b/backend/app/release_studio/documents/pcb-svg.testpoints.config.json
@@ -4,16 +4,16 @@
     "Prism's testpoint view configuration: the board with only its testpoints.",
     "Checked in and hashed into resource_bundle_digest -> toolchain_digest,",
     "like the assembly configuration beside it.",
-    "This is a second file, and a second Cruncher invocation, for one reason:",
-    "designator styles accept `TP*` selectors but component HLR styles do not,",
-    "and `components` is keyed by exact designator and applies to every view in",
-    "a configuration. Drawing testpoint outlines and nothing else therefore",
-    "needs a components map naming every part to suppress -- which would",
-    "suppress them on the assembly views too if it lived in the same file.",
-    "The map is generated per board at build time from the board's own",
-    "designators, written into the build's staging directory, and never placed",
-    "beside the board: a config the build created inside the closure would make",
-    "the closure digest depend on the build."
+    "This is a second file and Cruncher invocation because its input is a",
+    "derived staging board containing only TP footprints. Released Cruncher",
+    "2026.8.x reads designators from property Reference, while legacy KiCad",
+    "boards may store them only in fp_text reference. Prism uses Monkey's",
+    "public object model to retain the TP footprints and promote those legacy",
+    "references before rendering, so both outlines and TP* labels are correct.",
+    "The derived board is written only into build staging and the source board",
+    "is never edited: putting generated input beside the board would make the",
+    "closure digest depend on the build. Components stays empty because the",
+    "staging board itself is the complete testpoint selection."
   ],
   "global": {
     "canvas": {

--- a/backend/app/release_studio/documents/sheets.py
+++ b/backend/app/release_studio/documents/sheets.py
@@ -914,12 +914,10 @@ def testpoint_sheet(
 ) -> tuple[Sheet, float, list]:
     """One side of the board with only its testpoints labelled.
 
-    The same Cruncher render as the assembly view with every non-``TP``
-    designator switched off and the component outlines omitted, so a probe
-    target is not competing with 900 other labels for the reader's attention.
-    The schedule beside it gives each testpoint's position from the position
-    file, which is what makes the sheet usable at a bench rather than only
-    pretty.
+    Cruncher receives a derived board containing only ``TP`` footprints, so a
+    probe target is not competing with hundreds of assembly outlines or
+    labels. The schedule beside it gives each testpoint's board position, which
+    is what makes the sheet usable at a bench rather than only pretty.
     """
 
     label = "TOP" if side == "top" else "BOTTOM"

--- a/backend/tests/test_release_studio_documents.py
+++ b/backend/tests/test_release_studio_documents.py
@@ -1751,6 +1751,151 @@ class SheetSetConsistencyTests(unittest.TestCase):
         self.assertNotIn("The files listed above are the released bytes", note)
 
 
+class TestpointStagingTests(unittest.TestCase):
+    """Legacy and modern boards reach Cruncher through one Monkey contract."""
+
+    class Text:
+        def __init__(self, text_type: str, text: str):
+            self.text_type = text_type
+            self.text = text
+
+    class Footprint:
+        def __init__(self, reference: str = "", *, legacy_reference: str = ""):
+            self.properties = {"Reference": reference} if reference else {}
+            self.fp_texts = (
+                [TestpointStagingTests.Text("reference", legacy_reference)]
+                if legacy_reference
+                else []
+            )
+
+        def get_property_value(self, name: str, default: str = "") -> str:
+            return self.properties.get(name, default)
+
+        def upsert_property(self, name: str, value: str) -> None:
+            self.properties[name] = value
+
+    class Board:
+        def __init__(self, footprints):
+            self.footprints = list(footprints)
+            self.saved_to = None
+
+        def save(self, path: Path) -> None:
+            self.saved_to = path
+            path.write_text("(kicad_pcb)\n", encoding="utf-8")
+
+    def test_stages_only_testpoints_and_promotes_legacy_references(self) -> None:
+        import tempfile
+
+        modern = self.Footprint("TP2")
+        legacy = self.Footprint(legacy_reference="TP49")
+        ordinary = self.Footprint(legacy_reference="D14")
+        parsed = self.Board([ordinary, legacy, modern])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source" / "board.kicad_pcb"
+            source.parent.mkdir()
+            source.write_text("original board\n", encoding="utf-8")
+            staged, designators = artwork_module._stage_testpoint_board(
+                source,
+                root / "staging",
+                pcb_loader=lambda path: parsed,
+            )
+
+            self.assertEqual(source.read_text(encoding="utf-8"), "original board\n")
+            self.assertEqual(staged.parent, (root / "staging").resolve())
+            self.assertTrue(staged.is_file())
+
+        self.assertEqual(designators, ("TP2", "TP49"))
+        self.assertEqual(parsed.footprints, [legacy, modern])
+        self.assertEqual(legacy.properties["Reference"], "TP49")
+        self.assertEqual(modern.properties["Reference"], "TP2")
+        self.assertNotIn(ordinary, parsed.footprints)
+
+    def test_duplicate_testpoint_designators_are_rejected(self) -> None:
+        import tempfile
+
+        parsed = self.Board(
+            [self.Footprint("TP1"), self.Footprint(legacy_reference="TP1")]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "board.kicad_pcb"
+            source.write_text("original board\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                artwork_module.ArtworkError, "duplicate testpoint designator: TP1"
+            ):
+                artwork_module._stage_testpoint_board(
+                    source,
+                    root / "staging",
+                    pcb_loader=lambda path: parsed,
+                )
+
+    def test_staged_board_keeps_the_source_project_model_root(self) -> None:
+        import tempfile
+
+        captured = {}
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def runner(argv, **kwargs):
+            captured["env"] = kwargs["env"]
+            return Result()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            staged = root / "staging" / "board.testpoints.kicad_pcb"
+            staged.parent.mkdir()
+            staged.write_text("(kicad_pcb)\n", encoding="utf-8")
+            project_dir = root / "source-project"
+            artwork_module._run_pcb_svg(
+                "kicad-cruncher",
+                staged,
+                ["testpoint_top_view"],
+                root / "out",
+                config_path=artwork_module.PCB_SVG_TESTPOINT_CONFIG,
+                project_dir=project_dir,
+                runner=runner,
+                timeout_seconds=1,
+            )
+
+        self.assertEqual(captured["env"]["KIPRJMOD"], str(project_dir.resolve()))
+
+    def test_testpoint_views_cannot_bypass_the_staging_board(self) -> None:
+        with self.assertRaisesRegex(
+            artwork_module.ArtworkError, "unknown view kind: 'testpoint'"
+        ):
+            artwork_module.acquire_board_views(
+                "kicad-cruncher",
+                Path("board.kicad_pcb"),
+                Path("out"),
+                kinds=("testpoint",),
+                sides=("top",),
+            )
+
+    def test_projection_and_staged_board_must_select_the_same_testpoints(self) -> None:
+        from unittest.mock import patch
+
+        with patch.object(
+            artwork_module,
+            "_stage_testpoint_board",
+            return_value=(Path("staging/board.testpoints.kicad_pcb"), ("TP2",)),
+        ):
+            with self.assertRaisesRegex(
+                artwork_module.ArtworkError,
+                "testpoint drawing and board projection disagree: missing TP1; unexpected TP2",
+            ):
+                artwork_module.acquire_testpoint_views(
+                    "kicad-cruncher",
+                    Path("board.kicad_pcb"),
+                    Path("out"),
+                    designators=("D1", "TP1"),
+                )
+
+
 class RendererVersionTests(unittest.TestCase):
     """A rendering change must be a deliberate, versioned change.
 
@@ -1761,7 +1906,7 @@ class RendererVersionTests(unittest.TestCase):
     in the same commit.
     """
 
-    #: Recorded for RENDERER_VERSION d20 under the pinned kicad-monkey /
+    #: Recorded for RENDERER_VERSION d22 under the pinned kicad-monkey /
     #: kicad-cruncher toolchain, and verified stable across two runs.
     #: The version and these digests move together, never one without the other.
     GOLDEN = {
@@ -1821,7 +1966,7 @@ class RendererVersionTests(unittest.TestCase):
 
         self.assertEqual(
             RENDERER_VERSION,
-            "release-studio-documents/d21",
+            "release-studio-documents/d22",
             "RENDERER_VERSION changed: re-record GOLDEN in the same commit",
         )
 


### PR DESCRIPTION
## Summary
- stage a derived testpoint-only board through the released kicad-monkey object model
- promote legacy fp_text references to Reference properties for Cruncher compatibility
- keep the source closure immutable and retain the original KIPRJMOD model root
- assert that the drawing and released testpoint schedule select the same references
- bump the document renderer identity to d22

## Verification
- 899 backend tests passed, 84 skipped, 150 subtests passed
- real Cynthion render with kicad-monkey 2026.8.11 and kicad-cruncher 2026.8.11
- top view contains only TP49; bottom view contains the remaining 43 testpoints
- both views are 58 x 58 mm and labels use TP references, not library links
- visually inspected the composed A3 top testpoint PDF at scale 2:1