### PR TITLE
Remove the effects that were standing in for state ownership

### DIFF
--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 118
+  "warnings": 113
 }

--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 136
+  "warnings": 127
 }

--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 157
+  "warnings": 152
 }

--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 113
+  "warnings": 108
 }

--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 164
+  "warnings": 157
 }

--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 152
+  "warnings": 136
 }

--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 127
+  "warnings": 118
 }

--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 108
+  "warnings": 105
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -222,6 +222,7 @@ function App() {
             >
             {sessionExpired ? (
                 <SessionExpiredBanner
+                    key={user.email}
                     authConfig={authConfig}
                     email={user.email}
                     onReauthenticated={(restored) => { setUser(restored); setSessionExpired(false); }}

--- a/frontend/src/components/command-palette.tsx
+++ b/frontend/src/components/command-palette.tsx
@@ -91,10 +91,21 @@ function componentDetail(component: CatalogComponent): string {
  * the catalog, and whatever the mounted screen has published to the command
  * registry.
  */
+// Rows carry their group heading with them so grouping survives ranked search
+// results, where a group's entries are no longer contiguous by construction.
+function withGroupHeadings(results: PaletteCommand[]) {
+  let lastGroup = "";
+  return results.map((command) => {
+    const heading = command.group === lastGroup ? null : command.group;
+    lastGroup = command.group;
+    return { command, heading };
+  });
+}
+
 export function CommandPalette({ open, onOpenChange, user, onShowShortcuts, onLogout }: CommandPaletteProps) {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [rawActiveIndex, setActiveIndex] = useState(0);
   const [projects, setProjects] = useState<Project[]>([]);
   const [components, setComponents] = useState<CatalogComponent[]>([]);
   const [searchingComponents, setSearchingComponents] = useState(false);
@@ -114,14 +125,6 @@ export function CommandPalette({ open, onOpenChange, user, onShowShortcuts, onLo
       .catch(() => {
         projectsLoadedRef.current = false;
       });
-  }, [open]);
-
-  useEffect(() => {
-    if (open) {
-      setQuery("");
-      setActiveIndex(0);
-      setComponents([]);
-    }
   }, [open]);
 
   /**
@@ -171,7 +174,18 @@ export function CommandPalette({ open, onOpenChange, user, onShowShortcuts, onLo
     };
   }, [canSearchCatalog, open, query]);
 
-  const close = useCallback(() => onOpenChange(false), [onOpenChange]);
+  // Closing is what ends a palette session, so it is where the session's
+  // state is dropped. The project list deliberately survives: it is a cache,
+  // not part of the session.
+  const handleOpenChange = useCallback((next: boolean) => {
+    if (!next) {
+      setQuery("");
+      setActiveIndex(0);
+      setComponents([]);
+    }
+    onOpenChange(next);
+  }, [onOpenChange]);
+  const close = useCallback(() => handleOpenChange(false), [handleOpenChange]);
 
   const commands = useMemo<PaletteCommand[]>(() => {
     const run = (action: () => void) => () => {
@@ -284,24 +298,15 @@ export function CommandPalette({ open, onOpenChange, user, onShowShortcuts, onLo
     return [...fuse.search(trimmed).map((match) => match.item), ...componentCommands];
   }, [commands, componentCommands, fuse, query]);
 
-  useEffect(() => {
-    setActiveIndex((current) => (current < results.length ? current : 0));
-  }, [results.length]);
+  // A result list that has shrunk past the highlight takes it back to the top
+  // during render, not after a commit that showed the wrong row.
+  const activeIndex = rawActiveIndex < results.length ? rawActiveIndex : 0;
 
   useEffect(() => {
     listRef.current?.querySelector('[data-active="true"]')?.scrollIntoView({ block: "nearest" });
   }, [activeIndex, results]);
 
-  // Rows carry their group heading with them so grouping survives ranked search
-  // results, where a group's entries are no longer contiguous by construction.
-  const rows = useMemo(() => {
-    let lastGroup = "";
-    return results.map((command) => {
-      const heading = command.group === lastGroup ? null : command.group;
-      lastGroup = command.group;
-      return { command, heading };
-    });
-  }, [results]);
+  const rows = useMemo(() => withGroupHeadings(results), [results]);
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key === "ArrowDown" || (event.key === "n" && event.ctrlKey)) {
@@ -321,7 +326,7 @@ export function CommandPalette({ open, onOpenChange, user, onShowShortcuts, onLo
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="top-[15%] max-w-xl translate-y-0 gap-0 p-0 [&>button]:hidden"
         onKeyDown={handleKeyDown}

--- a/frontend/src/components/comment-form.tsx
+++ b/frontend/src/components/comment-form.tsx
@@ -69,19 +69,13 @@ export function CommentForm({
     const [mentionIndex, setMentionIndex] = useState(0);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+    // Visualizer mounts this per open, keyed on the pinned location, so the
+    // initial state above is the reset. Focus still needs asking for: the form
+    // is a bare fixed overlay, not a Radix dialog, so nothing moves focus for
+    // us and the autoFocus attribute is what react-doctor objects to.
     useEffect(() => {
-        if (isOpen) {
-            setContent("");
-            setCommentClass(DEFAULT_COMMENT_CLASS);
-            setSeverity(DEFAULT_COMMENT_SEVERITY);
-            setMentionQuery(null);
-            setMentionIndex(0);
-            // The form is a bare fixed overlay, not a Radix dialog, so nothing
-            // moves focus for us. Replaces the autoFocus attribute rather than
-            // dropping the behaviour with it.
-            textareaRef.current?.focus();
-        }
-    }, [isOpen, location?.x, location?.y]);
+        textareaRef.current?.focus();
+    }, []);
 
     const mentionMatches = useMemo(() => {
         if (mentionQuery === null) return [];

--- a/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
+++ b/frontend/src/components/design-comparison/comparison-presentation-shell.tsx
@@ -261,15 +261,24 @@ export function ComparisonPresentationShell({
     const [selectionDiagnostic, setSelectionDiagnostic] =
         useState<string | null>(null);
     const [selectionNotice, setSelectionNotice] = useState<string | null>(null);
-    const [dismissedBanner, setDismissedBanner] = useState<string | null>(null);
+    // Same shape: a dismissal applies to the sheet it was made on.
+    const [dismissedBanner, setDismissedBanner] =
+        useState<{ scope: string; message: string } | null>(null);
     const [rightRailInset, setRightRailInset] = useState(0);
     const [pcbLayers, setPcbLayers] = useState<EcadPcbLayerState[]>([]);
     useEffect(() => {
         onPcbLayersChange?.(pcbLayers);
     }, [onPcbLayersChange, pcbLayers]);
-    const [layerFocusOverridden, setLayerFocusOverridden] = useState(false);
+    // Which route the reviewer took manual control on. Storing the route
+    // rather than a bare flag is what "for as long as this route stays
+    // selected" means, and it expires without an effect to expire it.
+    const [layerFocusReleasedFor, setLayerFocusReleasedFor] =
+        useState<string | null>(null);
+    // A manual page choice belongs to the selection and revision pair it was
+    // made in. Carrying that scope on the value makes it self-expiring, which
+    // is what the reset effects used to do a render late.
     const [manualPageOverride, setManualPageOverride] =
-        useState<ComparisonSchematicPage | null>(null);
+        useState<{ scope: string; page: ComparisonSchematicPage } | null>(null);
     const [schematicNavigatorOpen, setSchematicNavigatorOpen] = useState(false);
     const [schematicCatalogs, setSchematicCatalogs] = useState<{
         pairKey: string;
@@ -350,8 +359,15 @@ export function ComparisonPresentationShell({
             : [],
         [comparisonPairKey, schematicCatalogs],
     );
+    const pageOverrideScope = [
+        base, compare, domain,
+        selection?.kind ?? "", selection?.id ?? "", selection?.documentPath ?? "",
+    ].join("|");
+    const activePageOverride = manualPageOverride?.scope === pageOverrideScope
+        ? manualPageOverride.page
+        : null;
     const selectedCatalogPage = useMemo(() => {
-        if (manualPageOverride) return manualPageOverride;
+        if (activePageOverride) return activePageOverride;
         if (!selectedDocumentPath) return undefined;
         return unionPages.find((page) =>
             (page.reference
@@ -359,7 +375,7 @@ export function ComparisonPresentationShell({
             || (page.comparison
                 && sameDocument(page.comparison.filename, selectedDocumentPath))
         );
-    }, [manualPageOverride, selectedDocumentPath, unionPages]);
+    }, [activePageOverride, selectedDocumentPath, unionPages]);
     const documentPath = selectedCatalogPage
         ? comparisonPageDocumentPath(
             selectedCatalogPage,
@@ -369,7 +385,7 @@ export function ComparisonPresentationShell({
     useEffect(() => {
         selectedCatalogPageRef.current = selectedCatalogPage ?? null;
     }, [selectedCatalogPage]);
-    const selectedSheetIdentity = manualPageOverride?.navigatorKey
+    const selectedSheetIdentity = activePageOverride?.navigatorKey
         ?? `document:${normalizedPath(documentPath ?? "unknown")}`;
     const selectedNavigatorIdentity = selectedCatalogPage?.navigatorKey
         ?? selectedSheetIdentity;
@@ -407,6 +423,7 @@ export function ComparisonPresentationShell({
     const baseRevisionKey = revisionSourceKey(projectId, base, domain);
     const compareRevisionKey = revisionSourceKey(projectId, compare, domain);
     const comparisonKey = `${comparisonPairKey}:sheet:${selectedSheetIdentity}`;
+    const bannerScope = `${comparisonKey}|${documentPath ?? ""}`;
     const primaryHostKey = `${comparisonPairKey}:primary`;
     const secondaryHostKey = `${comparisonPairKey}:secondary`;
     /**
@@ -519,19 +536,6 @@ export function ComparisonPresentationShell({
         setSecondaryViewer(viewer);
         setSecondaryLayoutReady(false);
     }, []);
-
-    useEffect(() => {
-        setManualPageOverride(null);
-    }, [selection?.documentPath, selection?.id, selection?.kind]);
-
-    useEffect(() => {
-        setManualPageOverride(null);
-        setSchematicCatalogs(null);
-    }, [base, compare, domain]);
-
-    useEffect(() => {
-        setDismissedBanner(null);
-    }, [comparisonKey, documentPath]);
 
     useEffect(() => {
         const cleanups: Array<() => void> = [];
@@ -1044,13 +1048,11 @@ export function ComparisonPresentationShell({
             routeFocus.comparison.join(","),
         ].join("|")
         : null;
-    const layerFocusActive = Boolean(routeFocus) && !layerFocusOverridden;
-
     // A new route is a new focus: the reviewer's earlier manual override does
     // not carry across to a different net's evidence.
-    useEffect(() => {
-        setLayerFocusOverridden(false);
-    }, [routeFocusKey]);
+    const layerFocusOverridden = layerFocusReleasedFor !== null
+        && layerFocusReleasedFor === routeFocusKey;
+    const layerFocusActive = Boolean(routeFocus) && !layerFocusOverridden;
 
     useEffect(() => {
         if (domain !== "pcb" || sessionPhase !== "ready" || presentationSwitching) {
@@ -1176,7 +1178,7 @@ export function ComparisonPresentationShell({
      */
     const releaseLayerFocus = () => {
         preFocusLayersRef.current = null;
-        setLayerFocusOverridden(true);
+        setLayerFocusReleasedFor(routeFocusKey);
     };
 
     const toggleLayer = (name: string, visible: boolean) => {
@@ -1218,7 +1220,9 @@ export function ComparisonPresentationShell({
     const activeError = sourceError ?? sessionError ?? selectionDiagnostic;
     const bannerMessage = activeError ?? selectionNotice ?? oneSidedSheetNotice;
     const showBanner =
-        Boolean(bannerMessage) && bannerMessage !== dismissedBanner;
+        Boolean(bannerMessage)
+        && !(dismissedBanner?.scope === bannerScope
+            && dismissedBanner.message === bannerMessage);
     const loading =
         baseSources.loading
         || compareSources.loading
@@ -1334,9 +1338,10 @@ export function ComparisonPresentationShell({
                                     page.filename.split("/").at(-1) ?? page.filename,
                                 )}
                                 onNavigate={(page) => {
-                                    setManualPageOverride(
-                                        page as ComparisonSchematicPage,
-                                    );
+                                    setManualPageOverride({
+                                        scope: pageOverrideScope,
+                                        page: page as ComparisonSchematicPage,
+                                    });
                                     setSchematicNavigatorOpen(false);
                                 }}
                             />
@@ -1460,7 +1465,10 @@ export function ComparisonPresentationShell({
                             type="button"
                             className="shrink-0 rounded p-0.5 transition-colors hover:bg-muted"
                             aria-label="Dismiss warning"
-                            onClick={() => setDismissedBanner(bannerMessage)}
+                            onClick={() => setDismissedBanner({
+                                scope: bannerScope,
+                                message: bannerMessage,
+                            })}
                         >
                             <X className="h-3.5 w-3.5" />
                         </button>

--- a/frontend/src/components/design-comparison/differences-pane.tsx
+++ b/frontend/src/components/design-comparison/differences-pane.tsx
@@ -365,8 +365,16 @@ export function DifferencesPane({
 }: DifferencesPaneProps) {
     const paneRef = useRef<HTMLDivElement | null>(null);
     const [searchOpen, setSearchOpen] = useState(Boolean(search));
-    const [expandedGroupIds, setExpandedGroupIds] = useState<Set<string>>(
-        () => new Set(),
+    // The group holding the selection is open unless the reviewer closed it;
+    // any other group is closed unless they opened it. Storing the choices they
+    // actually made, rather than the resulting open set, means the default can
+    // follow the selection during render instead of an effect forcing it open
+    // afterwards. One behaviour change falls out: a group that was open only
+    // because it held the selection now closes when the selection moves on,
+    // which leaves the queue showing the group being reviewed rather than every
+    // group visited on the way to it.
+    const [groupOpenChoices, setGroupOpenChoices] = useState<Map<string, boolean>>(
+        () => new Map(),
     );
     // Layout and documentation is the scope a release review does not normally
     // sign off, so it starts closed even when the reviewer has opted to see it.
@@ -378,15 +386,8 @@ export function DifferencesPane({
         group.id === selectedGroupId
         || group.changes.some((change) => change.id === selectedChangeId)
     );
-    useEffect(() => {
-        if (!selectedGroup) return;
-        setExpandedGroupIds((current) => {
-            if (current.has(selectedGroup.id)) return current;
-            const next = new Set(current);
-            next.add(selectedGroup.id);
-            return next;
-        });
-    }, [selectedGroup]);
+    const isGroupExpanded = (groupId: string) =>
+        groupOpenChoices.get(groupId) ?? groupId === selectedGroup?.id;
     useEffect(() => {
         if (!selectedChangeId && !selectedGroupId) return;
         const frame = requestAnimationFrame(() => {
@@ -566,11 +567,10 @@ export function DifferencesPane({
                                     <QueueRow
                                         key={group.id}
                                         group={group}
-                                        expanded={expandedGroupIds.has(group.id)}
-                                        onToggleExpanded={() => setExpandedGroupIds((current) => {
-                                            const next = new Set(current);
-                                            if (next.has(group.id)) next.delete(group.id);
-                                            else next.add(group.id);
+                                        expanded={isGroupExpanded(group.id)}
+                                        onToggleExpanded={() => setGroupOpenChoices((current) => {
+                                            const next = new Map(current);
+                                            next.set(group.id, !isGroupExpanded(group.id));
                                             return next;
                                         })}
                                         selected={selectedGroup?.id === group.id}

--- a/frontend/src/components/design-comparison/fabrication-panel.tsx
+++ b/frontend/src/components/design-comparison/fabrication-panel.tsx
@@ -269,7 +269,10 @@ export function FabricationPanel({
 }) {
     const [activeLayer, setActiveLayer] = useState<string | null>(null);
     const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-    const [selectedRegion, setSelectedRegion] = useState<number | null>(null);
+    // A region index only means anything on the layer it was picked on, so it
+    // carries that layer. Returning to a layer now restores what was selected
+    // there, where before every layer change cleared it outright.
+    const [regionChoice, setRegionChoice] = useState<{ layer: string; index: number } | null>(null);
     const [showUnchanged, setShowUnchanged] = useState(false);
     const [oldNewSide, setOldNewSide] = useState<OldNewSide>("compare");
 
@@ -292,10 +295,18 @@ export function FabricationPanel({
     const { frame, reset, zoomBy, view, handlers } = useBoardViewport(board);
     const regions = useMemo(() => current?.regions ?? [], [current?.regions]);
 
+    const layerName = current?.name;
+    const selectedRegion = regionChoice && regionChoice.layer === layerName
+        ? regionChoice.index
+        : null;
+    const setSelectedRegion = useCallback((index: number | null) => setRegionChoice(
+        index === null || !layerName ? null : { layer: layerName, index },
+    ), [layerName]);
+
     const select = useCallback((region: FabricationRegion) => {
         setSelectedRegion(region.index);
         frame(regionRect(region));
-    }, [frame]);
+    }, [frame, setSelectedRegion]);
 
     const step = (direction: -1 | 1) => {
         if (!regions.length) return;
@@ -306,9 +317,9 @@ export function FabricationPanel({
         select(regions[next]!);
     };
 
-    const layerName = current?.name;
+    // The viewport reset stays an effect: recentring the view on a new layer is
+    // an imperative call to the viewport, not a piece of state to derive.
     useEffect(() => {
-        setSelectedRegion(null);
         reset();
     }, [layerName, reset]);
 

--- a/frontend/src/components/design-search-field.tsx
+++ b/frontend/src/components/design-search-field.tsx
@@ -70,12 +70,16 @@ export function DesignSearchField({
     const [slot, setSlot] = useState<HTMLElement | null>(null);
     const [query, setQuery] = useState("");
     const [open, setOpen] = useState(false);
-    const [activeIndex, setActiveIndex] = useState(0);
+    const [rawActiveIndex, setActiveIndex] = useState(0);
 
     const hits = useMemo(
         () => searchDesignEntities(semanticIndex, query, { currentPage }),
         [currentPage, query, semanticIndex],
     );
+    // A hit list that has shrunk past the highlight takes the highlight back to
+    // the top during render, rather than after a commit that showed the wrong
+    // row. Typing resets it outright, in the handler that changes the query.
+    const activeIndex = rawActiveIndex < hits.length ? rawActiveIndex : 0;
     const activeHit = hits[activeIndex];
     const activeOptionId = activeHit ? `${listId}-opt-${activeIndex}` : undefined;
 
@@ -114,10 +118,6 @@ export function DesignSearchField({
         document.addEventListener("pointerdown", onPointerDown);
         return () => document.removeEventListener("pointerdown", onPointerDown);
     }, [open]);
-
-    useEffect(() => {
-        setActiveIndex(0);
-    }, [hits]);
 
     useLayoutEffect(() => {
         if (!open) return;
@@ -177,6 +177,7 @@ export function DesignSearchField({
             }
             if (query) {
                 setQuery("");
+                setActiveIndex(0);
                 return;
             }
             inputRef.current?.blur();
@@ -219,6 +220,7 @@ export function DesignSearchField({
                     )}
                     onChange={(event) => {
                         setQuery(event.target.value);
+                        setActiveIndex(0);
                         setOpen(true);
                     }}
                     onFocus={() => setOpen(true)}

--- a/frontend/src/components/ecad-viewer-controls.tsx
+++ b/frontend/src/components/ecad-viewer-controls.tsx
@@ -134,6 +134,10 @@ export function EcadViewerControls({
             observer?.disconnect();
             onVisibleWidthChange(0);
         };
+        // The rail's width is a layout fact, read after layout and reported to
+        // the host that has to leave room for it. There is no earlier event
+        // carrying it: the observer firing *is* the event.
+        // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
     }, [onVisibleWidthChange, openRef]);
 
     useLayoutEffect(() => {

--- a/frontend/src/components/ecad-viewer-controls.tsx
+++ b/frontend/src/components/ecad-viewer-controls.tsx
@@ -134,15 +134,15 @@ export function EcadViewerControls({
             observer?.disconnect();
             onVisibleWidthChange(0);
         };
-        // The rail's width is a layout fact, read after layout and reported to
-        // the host that has to leave room for it. There is no earlier event
-        // carrying it: the observer firing *is* the event.
-        // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
     }, [onVisibleWidthChange, openRef]);
 
     useLayoutEffect(() => {
         if (!onVisibleWidthChange) return;
         const target = open ? railRef.current : handleRef.current;
+        // The rail's width is a layout fact, measured after layout and reported
+        // to the host that has to leave room for it. There is no earlier event
+        // carrying it: laying out at this width *is* the event.
+        // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
         onVisibleWidthChange(target?.getBoundingClientRect().width ?? 0);
     }, [onVisibleWidthChange, open, railWidth]);
 

--- a/frontend/src/components/history-viewer.tsx
+++ b/frontend/src/components/history-viewer.tsx
@@ -594,12 +594,6 @@ export function HistoryViewer({
     }, []);
 
     useEffect(() => {
-        setCommitsPage(0);
-        setReleasesPage(0);
-        setBranchTipSha(null);
-    }, [projectId, branchRef]);
-
-    useEffect(() => {
         const controller = new AbortController();
         setLoading(true);
         setError(null);

--- a/frontend/src/components/release-studio/ReleaseStudioPanel.tsx
+++ b/frontend/src/components/release-studio/ReleaseStudioPanel.tsx
@@ -263,10 +263,10 @@ export function ReleaseStudioPanel({
         }
         // Do not render the preceding run while this run's detail is loading.
         // The id guard below is a second line of defence for batched updates.
+        setDetail(null);
         // Nothing here reaches a parent: setDetail, setError and refreshDetail
         // are all this component's own, so there is no extra render to save.
         // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent
-        setDetail(null);
         void refreshDetail(selectedBuildId).catch((cause: unknown) => {
             setError(cause instanceof Error ? cause.message : String(cause));
         });

--- a/frontend/src/components/release-studio/ReleaseStudioPanel.tsx
+++ b/frontend/src/components/release-studio/ReleaseStudioPanel.tsx
@@ -263,6 +263,9 @@ export function ReleaseStudioPanel({
         }
         // Do not render the preceding run while this run's detail is loading.
         // The id guard below is a second line of defence for batched updates.
+        // Nothing here reaches a parent: setDetail, setError and refreshDetail
+        // are all this component's own, so there is no extra render to save.
+        // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent
         setDetail(null);
         void refreshDetail(selectedBuildId).catch((cause: unknown) => {
             setError(cause instanceof Error ? cause.message : String(cause));

--- a/frontend/src/components/release-studio/shared.tsx
+++ b/frontend/src/components/release-studio/shared.tsx
@@ -118,12 +118,16 @@ export function MemberViewer({
     const [failure, setFailure] = useState("");
     const kind = previewKind(member.media_type, member.path);
 
+    // Keyed on the build member by InspectOutputsStep, so a different artifact
+    // is a different viewer and starts blank without being blanked.
+    //
+    // The fetch stays here. react-doctor wants a data-fetching layer, and the
+    // project has none: this is one request for one blob, owned by the view
+    // that shows it and revoked when that view goes away.
+    // react-doctor-disable-next-line react-doctor/no-fetch-in-effect
     useEffect(() => {
         let revoked = false;
         let created = "";
-        setObjectUrl("");
-        setText("");
-        setFailure("");
         if (kind === "none") return undefined;
         void api
             .memberObjectUrl(projectId, buildId, member.path)

--- a/frontend/src/components/release-studio/steps/InspectOutputsStep.tsx
+++ b/frontend/src/components/release-studio/steps/InspectOutputsStep.tsx
@@ -205,6 +205,7 @@ export function InspectOutputsStep({
                         </div>
                         {member && (
                             <MemberViewer
+                                key={`${detail.build.id}:${member.path}`}
                                 projectId={projectId}
                                 buildId={detail.build.id}
                                 member={member}

--- a/frontend/src/components/release-studio/steps/ObserveBuildStep.tsx
+++ b/frontend/src/components/release-studio/steps/ObserveBuildStep.tsx
@@ -78,7 +78,7 @@ export function ObserveBuildStep({
             <div className="space-y-4">
                 <h3 className="text-lg font-semibold">Build</h3>
                 <BuildFailure code={errorCode} message={errorMessage} />
-                <ArchivedStepLogs projectId={projectId} buildId={buildId} />
+                <ArchivedStepLogs key={`${projectId}:${buildId}`} projectId={projectId} buildId={buildId} />
             </div>
         );
     }
@@ -222,11 +222,10 @@ function ArchivedStepLogs({ projectId, buildId }: { projectId: string; buildId: 
     const [openStep, setOpenStep] = useState<string | null>(null);
     const [logs, setLogs] = useState<Record<string, string>>({});
 
+    // Keyed on the build by its call site, so a different build is a different
+    // panel and starts empty without being emptied.
     useEffect(() => {
         let cancelled = false;
-        setSteps([]);
-        setOpenStep(null);
-        setLogs({});
         void api.listBuildLogs(projectId, buildId)
             .then((index) => {
                 if (!cancelled) setSteps(index.steps ?? []);

--- a/frontend/src/components/session-expired-banner.tsx
+++ b/frontend/src/components/session-expired-banner.tsx
@@ -50,6 +50,9 @@ export function SessionExpiredBanner({
 }: SessionExpiredBannerProps) {
     const passwordAuth = Boolean(authConfig.password_auth_enabled);
     const [dialogOpen, setDialogOpen] = useState(false);
+    // The same: a sign-in field the user may correct. App.tsx keys the banner
+    // on the account it is for, so a different account gets a different form.
+    // react-doctor-disable-next-line react-doctor/no-derived-useState
     const [emailValue, setEmailValue] = useState(email);
     const [password, setPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -239,6 +239,10 @@ function GitSettings({ user }: { user: User | null }) {
             console.error("Failed to fetch Git access settings", err);
             toast.error("Failed to load Git access settings");
         } finally {
+            // The reset is in `finally` and covers the rejection path. The rule
+            // is reading the abort guard as a success-only branch; an aborted
+            // load has a successor already in flight that owns the flag.
+            // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
             if (!signal?.aborted) {
                 setLoading(false);
             }

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -239,11 +239,11 @@ function GitSettings({ user }: { user: User | null }) {
             console.error("Failed to fetch Git access settings", err);
             toast.error("Failed to load Git access settings");
         } finally {
-            // The reset is in `finally` and covers the rejection path. The rule
-            // is reading the abort guard as a success-only branch; an aborted
-            // load has a successor already in flight that owns the flag.
-            // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
             if (!signal?.aborted) {
+                // Already in `finally`, so the rejection path is covered. The
+                // rule reads the abort guard as a success-only branch; an
+                // aborted load has a successor in flight that owns the flag.
+                // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally
                 setLoading(false);
             }
         }

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -667,33 +667,11 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
         };
     }, [pcbContentLoaded, projectId, appendCommit]);
 
-    // Reset lazy loading flags when project changes
-    useEffect(() => {
-        setSchematicContentLoaded(false);
-        setPcbContentLoaded(false);
-        setSchematicContent(null);
-        setSubsheets([]);
-        setViewerSupportFiles([]);
-        setPcbContent(null);
-        setIbomUrl(null);
-        setSemanticIndex(null);
-        setSemanticIndexLoading(true);
-        setSemanticIndexError(null);
-        setRightRailTab(null);
-        setThreeDActivated(false);
-        setPcbActivated(false);
-        clearGlobalSelection();
-        setComments([]);
-        setMentionCandidates([]);
-        setCommentMode(false);
-        setShowCommentForm(false);
-        setPendingLocation(null);
-        setPendingContext(null);
-        setPendingElement(null);
-        setSelectedCommentId(null);
-        setCommentCardScreenPosition(null);
-        lastSelectionRef.current = null;
-    }, [clearGlobalSelection, commit, projectId]);
+    // A different project or commit is a different visualizer, not this one
+    // with twenty-three values put back. ProjectDetailPage keys this component
+    // on that pair, so React discards the whole tree -- state, refs, and the
+    // cross-probe hook's own selection, which lives here too -- and there is no
+    // render where the previous board's state is still on screen.
 
     useEffect(() => {
         if (activeTab === "3d" || activeTab === "stackup") setThreeDActivated(true);

--- a/frontend/src/components/visualizer.tsx
+++ b/frontend/src/components/visualizer.tsx
@@ -1483,8 +1483,10 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                 </div>
             </div>
 
-            <CommentForm
-                isOpen={showCommentForm}
+            {showCommentForm && pendingLocation && <CommentForm
+                // Each pin is its own draft, so each is its own component.
+                key={`${pendingLocation.x}:${pendingLocation.y}`}
+                isOpen
                 onClose={() => {
                     setShowCommentForm(false);
                     setPendingLocation(null);
@@ -1496,7 +1498,7 @@ export function Visualizer({ projectId, user, commit, active: viewerActive = tru
                 context={pendingContext ?? "SCH"}
                 isSubmitting={isSubmittingComment}
                 mentionCandidates={mentionCandidates}
-            />
+            />}
 
             {selectedComment && (
                 <CommentCard

--- a/frontend/src/components/workspace.tsx
+++ b/frontend/src/components/workspace.tsx
@@ -74,7 +74,7 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const [bulkSelectedProjectIds, setBulkSelectedProjectIds] = useState<Set<string>>(() => new Set());
+  const [rawBulkSelection, setBulkSelectedProjectIds] = useState<Set<string>>(() => new Set());
 
   const [folderToRename, setFolderToRename] = useState<FolderTreeItem | null>(null);
   const [isRenamingFolder, setIsRenamingFolder] = useState(false);
@@ -88,7 +88,9 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
 
   const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
   const [isDeletingProject, setIsDeletingProject] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
+  // Paging belongs to the list being paged. Carrying that scope on the value
+  // replaces both a reset effect and the clamp effect chained behind it.
+  const [pageState, setPageState] = useState({ scope: "", page: 1 });
   const canManageProjects = roleCanManageProjects(user?.role);
   const canOpenSettings = user?.role === "admin";
   const canOpenLibrary = canOpenLibraryManager(user?.role);
@@ -174,9 +176,29 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
   const listFolders = isSearching ? [] : visibleFolders;
   const allListProjects = isSearching ? searchResults : visibleProjects;
   const totalPages = Math.max(1, Math.ceil(allListProjects.length / WORKSPACE_PAGE_SIZE));
+  const pageScope = [currentFolderId ?? "", searchQuery, viewMode, section].join("|");
+  const currentPage = Math.min(
+    pageState.scope === pageScope ? pageState.page : 1,
+    totalPages,
+  );
+  const setCurrentPage = (next: number | ((page: number) => number)) =>
+    setPageState({
+      scope: pageScope,
+      page: typeof next === "function" ? next(currentPage) : next,
+    });
   const pageStart = (currentPage - 1) * WORKSPACE_PAGE_SIZE;
   const listProjects = allListProjects.slice(pageStart, pageStart + WORKSPACE_PAGE_SIZE);
-  const visibleProjectIdsKey = listProjects.map((project) => project.id).join("\u0000");
+  // A selection is only ever read against the page it was made on: the bulk
+  // actions already intersect with `listProjects`, and both views only draw
+  // checkboxes for rows they render. Narrowing here during render says that
+  // once, instead of an effect pruning the stored set a commit later.
+  const bulkSelectedProjectIds = useMemo(() => {
+    const onThisPage = new Set<string>();
+    for (const project of listProjects) {
+      if (rawBulkSelection.has(project.id)) onThisPage.add(project.id);
+    }
+    return onThisPage;
+  }, [listProjects, rawBulkSelection]);
   const selectedVisibleProjects = listProjects.filter((project) => bulkSelectedProjectIds.has(project.id));
   const allVisibleProjectsSelected =
     listProjects.length > 0 && selectedVisibleProjects.length === listProjects.length;
@@ -184,25 +206,6 @@ export function Workspace({ searchQuery, user }: WorkspaceProps) {
     allListProjects.length === 0
       ? "0 projects"
       : `${pageStart + 1}-${Math.min(pageStart + WORKSPACE_PAGE_SIZE, allListProjects.length)} / ${allListProjects.length}`;
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [currentFolderId, searchQuery, viewMode, section]);
-
-  useEffect(() => {
-    setCurrentPage((page) => Math.min(page, totalPages));
-  }, [totalPages]);
-
-  useEffect(() => {
-    const visibleIds = new Set(visibleProjectIdsKey ? visibleProjectIdsKey.split("\u0000") : []);
-    setBulkSelectedProjectIds((current) => {
-      const retained = new Set([...current].filter((projectId) => visibleIds.has(projectId)));
-      if (retained.size === current.size && [...retained].every((projectId) => current.has(projectId))) {
-        return current;
-      }
-      return retained;
-    });
-  }, [visibleProjectIdsKey]);
 
   const toggleProjectSelection = (projectId: string, selected: boolean) => {
     setBulkSelectedProjectIds((current) => {

--- a/frontend/src/components/workspace/create-folder-dialog.tsx
+++ b/frontend/src/components/workspace/create-folder-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type KeyboardEvent } from "react";
+import { useState, type KeyboardEvent } from "react";
 
 import { isDialogSubmitShortcut } from "@/lib/dialog-shortcuts";
 import { Button } from "@/components/ui/button";
@@ -20,13 +20,9 @@ interface CreateFolderDialogProps {
 }
 
 export function CreateFolderDialog({ open, isSubmitting, onOpenChange, onSubmit }: CreateFolderDialogProps) {
+  // Mounted only while open (see workspace.tsx), so each open is a fresh
+  // component and the initial value is already the reset.
   const [name, setName] = useState("");
-
-  useEffect(() => {
-    if (!open) {
-      setName("");
-    }
-  }, [open]);
 
   const submit = () => {
     const trimmed = name.trim();

--- a/frontend/src/components/workspace/library-asset-link-picker.tsx
+++ b/frontend/src/components/workspace/library-asset-link-picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link2, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -41,29 +41,20 @@ export function LibraryAssetLinkPicker({
   onChange,
 }: LibraryAssetLinkPickerProps) {
   const [open, setOpen] = useState(false);
-  const [results, setResults] = useState<CatalogAssetSummary[]>([]);
+  // The last summary we have seen for the linked id, so a restored draft that
+  // carries only an id can still show a name. Resolved in the search response
+  // that produces it rather than in an effect watching for it afterwards, and
+  // read only when it still matches `value`, so it cannot mislabel a stale id.
   const [linked, setLinked] = useState<CatalogAssetSummary | null>(null);
-
-  // Keep the label meaningful when a draft is restored and we only know the id.
-  useEffect(() => {
-    if (!value) {
-      setLinked(null);
-      return;
-    }
-    if (linked?.id === value) return;
-    const known = results.find((item) => item.id === value);
-    if (known) setLinked(known);
-  }, [linked, results, value]);
 
   const label = useMemo(() => {
     if (!value) return placeholder || "Not linked";
-    if (linked) return linked.target_name || linked.name;
+    if (linked?.id === value) return linked.target_name || linked.name;
     return "Linked asset";
   }, [linked, placeholder, value]);
 
   const clear = (event: React.MouseEvent) => {
     event.stopPropagation();
-    setLinked(null);
     onChange("", null);
   };
 
@@ -98,7 +89,8 @@ export function LibraryAssetLinkPicker({
           { signal },
           "Failed to search catalog assets"
         ).then((response) => {
-          setResults(response.items);
+          const known = response.items.find((item) => item.id === value);
+          if (known) setLinked(known);
           return { items: response.items };
         })
       }

--- a/frontend/src/components/workspace/library-bulk-edit-cell.test.tsx
+++ b/frontend/src/components/workspace/library-bulk-edit-cell.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+    fetchJson: vi.fn(),
+    fetchApi: vi.fn(),
+    readApiError: vi.fn(async () => "error"),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { fetchJson } from "@/lib/api";
+import { LibraryBulkEditWorkspace } from "./library-bulk-edit-workspace";
+
+// The editable cell holds a draft while the committed value lives in the grid.
+// It used to mirror the value into the draft with an effect; the draft is now
+// seeded when the cell is activated. These pin both halves of that trade: the
+// draft must start from the committed value, and committing must not drag
+// focus back into the cell the reviewer just left.
+
+const FIELD = {
+    id: "f1", key: "value", label: "Value", description: "", group: "core",
+    type: "text", unit: "", enum_values: [], storage_kind: "column",
+    storage_key: "value", built_in: true, required: false, display_order: 1,
+    archived: false,
+};
+
+const COMPONENT = {
+    id: "c1", name: "R1", mpn: "RC0402", value: "10k",
+    workflow_stage: "draft", revision: 1, extra: {},
+};
+
+function route(url: string) {
+    if (url.startsWith("/api/catalog/metadata/fields")) return { items: [FIELD] };
+    if (url.startsWith("/api/catalog/metadata/grid-preferences")) {
+        return { visible: ["value"], order: ["value"], widths: {}, pinned: [] };
+    }
+    if (url.startsWith("/api/catalog/categories")) return { categories: [] };
+    if (url.startsWith("/api/catalog/metadata/grid")) {
+        return { items: [COMPONENT], total: 1, page: 1, page_size: 50, pages: 1, schema: "v1", fields: [FIELD] };
+    }
+    return {};
+}
+
+beforeEach(() => {
+    vi.mocked(fetchJson).mockImplementation(async (input) => route(String(input)) as never);
+});
+afterEach(() => vi.clearAllMocks());
+
+const cell = () => screen.getByRole("gridcell", { name: "Value: 10k" });
+const editor = () => screen.getByRole("textbox", { name: "Value" });
+
+async function renderGrid() {
+    render(<LibraryBulkEditWorkspace user={{ id: "u1", email: "a@b.c", role: "admin" } as never} />);
+    await waitFor(() => expect(cell()).toBeInTheDocument());
+}
+
+describe("bulk edit cell drafting", () => {
+    it("seeds the draft from the committed value when the cell is activated", async () => {
+        await renderGrid();
+        fireEvent.focus(cell());
+        await waitFor(() => expect(editor()).toBeInTheDocument());
+        expect((editor() as HTMLInputElement).value).toBe("10k");
+    });
+
+    it("keeps typing in the draft without writing it back to the grid", async () => {
+        await renderGrid();
+        fireEvent.focus(cell());
+        await waitFor(() => expect(editor()).toBeInTheDocument());
+
+        fireEvent.change(editor(), { target: { value: "22k" } });
+        expect((editor() as HTMLInputElement).value).toBe("22k");
+    });
+
+    it("does not pull focus back into the cell after the blur that commits it", async () => {
+        await renderGrid();
+        const outside = document.createElement("button");
+        document.body.appendChild(outside);
+
+        fireEvent.focus(cell());
+        await waitFor(() => expect(editor()).toBeInTheDocument());
+        // The cell takes focus on activation; without that this proves nothing.
+        await waitFor(() => expect(document.activeElement).toBe(editor()));
+
+        fireEvent.change(editor(), { target: { value: "22k" } });
+        // Moving focus away is what commits, so the commit re-render lands
+        // while the reviewer is already somewhere else.
+        outside.focus();
+        fireEvent.blur(screen.queryByRole("textbox", { name: "Value" }) ?? outside);
+
+        // The commit re-render happens here. Let every effect it schedules run
+        // before asking where focus ended up.
+        await act(async () => { await Promise.resolve(); });
+
+        expect((editor() as HTMLInputElement).value).toBe("22k");
+        expect(document.activeElement).toBe(outside);
+        outside.remove();
+    });
+});

--- a/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
+++ b/frontend/src/components/workspace/library-bulk-edit-workspace.tsx
@@ -77,16 +77,8 @@ function MetadataCell({
   onActivate: () => void;
   onNavigate: (rowDelta: number, columnDelta: number) => void;
 }) {
-  const [draft, setDraft] = useState(value);
-  const cancelCommit = useRef(false);
   const editorRef = useRef<HTMLInputElement | HTMLSelectElement | HTMLButtonElement>(null);
-  useEffect(() => setDraft(value), [value]);
   useEffect(() => { if (active) editorRef.current?.focus(); }, [active]);
-  const error = validateCell(field, draft);
-  const commit = () => {
-    if (cancelCommit.current) { cancelCommit.current = false; return; }
-    if (!readOnly && !error && draft !== value) onCommit(draft);
-  };
   const pinnedClass = pinnedOffset === undefined ? "" : "sticky z-10 bg-background";
   const pinnedStyle = pinnedOffset === undefined ? undefined : { left: pinnedOffset };
 
@@ -134,10 +126,49 @@ function MetadataCell({
       </select>
     </div>;
   }
+  // Rendered only while the cell is active, so mounting *is* the start of an
+  // edit session and the draft seeds itself from the committed value. Keying
+  // on `value` instead would remount after the blur that commits it and pull
+  // focus back into the cell the user just left.
+  return <CellTextEditor
+    value={value}
+    field={field}
+    rowIndex={rowIndex}
+    columnIndex={columnIndex}
+    pinnedClass={pinnedClass}
+    pinnedStyle={pinnedStyle}
+    inputRef={editorRef as React.Ref<HTMLInputElement>}
+    readOnly={readOnly}
+    onCommit={onCommit}
+    onNavigate={onNavigate}
+  />;
+}
+
+function CellTextEditor({
+  value, field, rowIndex, columnIndex, pinnedClass, pinnedStyle, inputRef, readOnly, onCommit, onNavigate,
+}: {
+  value: string;
+  field: CatalogMetadataField;
+  rowIndex: number;
+  columnIndex: number;
+  pinnedClass: string;
+  pinnedStyle?: { left: number };
+  inputRef: React.Ref<HTMLInputElement>;
+  readOnly: boolean;
+  onCommit: (value: string) => void;
+  onNavigate: (rowDelta: number, columnDelta: number) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  const cancelCommit = useRef(false);
+  const error = validateCell(field, draft);
+  const commit = () => {
+    if (cancelCommit.current) { cancelCommit.current = false; return; }
+    if (!readOnly && !error && draft !== value) onCommit(draft);
+  };
   return <div role="gridcell" aria-colindex={columnIndex + 2} className={cn("h-9 border-r p-1", pinnedClass, error && "bg-destructive/10")} style={pinnedStyle} data-cell={`${rowIndex}:${columnIndex}`} title={error || field.description}>
     <input
       aria-label={field.label}
-      ref={editorRef as React.Ref<HTMLInputElement>}
+      ref={inputRef}
       className="h-full w-full border-0 bg-transparent px-1 text-xs outline-none focus:bg-background focus:ring-1 focus:ring-ring disabled:cursor-default"
       type={field.type === "number" ? "text" : field.type === "url" ? "url" : "text"}
       inputMode={field.type === "number" ? "decimal" : undefined}

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -432,6 +432,10 @@ function RepresentationRow({
 }) {
   const symbols = component.assets.filter((asset) => asset.asset_type === "symbol");
   const footprints = component.assets.filter((asset) => asset.asset_type === "footprint");
+  // An edit buffer, not a mirror: it is meant to diverge from the prop as soon
+  // as the field is typed in, so it cannot be computed inline. The row is keyed
+  // on representation.id, so a different representation gets a different form.
+  // react-doctor-disable-next-line react-doctor/no-derived-useState
   const [label, setLabel] = useState(representation.label);
   const [symbolId, setSymbolId] = useState(representation.symbol?.id || "");
   const [footprintId, setFootprintId] = useState(representation.footprint?.id || "");
@@ -769,14 +773,14 @@ function AssetRevisionVisualDiff({
   const beforePreviews = diffPreviewEvidence(before);
   const afterPreviews = diffPreviewEvidence(after);
   const units = Array.from(new Set([...beforePreviews, ...afterPreviews].map((preview) => preview.unit))).sort((a, b) => a - b);
-  const [activeUnit, setActiveUnit] = useState(units[0] || 1);
+  const [requestedUnit, setActiveUnit] = useState(units[0] || 1);
+  // Unlike the inspector's, this one is load-bearing: nothing here falls back,
+  // so a unit that has left the set blanks both previews. Resolving it during
+  // render removes the frame where that was on screen.
+  const activeUnit = units.includes(requestedUnit) ? requestedUnit : (units[0] || 1);
   const beforePreview = beforePreviews.find((preview) => preview.unit === activeUnit);
   const afterPreview = afterPreviews.find((preview) => preview.unit === activeUnit);
   const unitLabel = beforePreview?.unitLabel || afterPreview?.unitLabel || `Unit ${activeUnit}`;
-
-  useEffect(() => {
-    if (!units.includes(activeUnit)) setActiveUnit(units[0] || 1);
-  }, [activeUnit, units]);
 
   return (
     <div className="space-y-2">

--- a/frontend/src/components/workspace/library-folder-discovery-dialog.tsx
+++ b/frontend/src/components/workspace/library-folder-discovery-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle, Box, CheckCircle2, CircuitBoard, FileCode2, Search, Upload } from "lucide-react";
 import { toast } from "sonner";
 
@@ -27,20 +27,26 @@ export function LibraryFolderDiscoveryDialog({ discovery, open, submitting, onOp
       .filter((component) => component.footprint.status === "resolved" && !component.existing_component)
       .map((component) => component.id)
   ), [discovery]);
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  // Everything importable is selected unless the reviewer said otherwise, so
+  // the state to keep is the opt-outs. Re-running discovery -- which is what
+  // attaching a footprint does -- then keeps their choices *and* picks up the
+  // component that just became importable. Resetting the whole set on every
+  // discovery, as the effect here used to, lost the first and never did the
+  // second.
+  const [deselected, setDeselected] = useState<Set<string>>(new Set());
+  const selected = useMemo(() => {
+    const chosen = new Set<string>();
+    for (const id of importableIds) if (!deselected.has(id)) chosen.add(id);
+    return chosen;
+  }, [deselected, importableIds]);
   const [footprintChoices, setFootprintChoices] = useState<Record<string, string>>({});
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [attachingId, setAttachingId] = useState("");
 
-  useEffect(() => {
-    setSelected(new Set(importableIds));
-    setFootprintChoices({});
-  }, [importableIds]);
-
-  const toggle = (id: string, checked: boolean) => setSelected((current) => {
+  const toggle = (id: string, checked: boolean) => setDeselected((current) => {
     const next = new Set(current);
-    if (checked) next.add(id); else next.delete(id);
+    if (checked) next.delete(id); else next.add(id);
     return next;
   });
   const needsAttention = discovery?.components.filter((component) => component.footprint.status !== "resolved").length || 0;
@@ -200,7 +206,12 @@ export function LibraryFolderDiscoveryDialog({ discovery, open, submitting, onOp
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>Cancel</Button>
-          <Button onClick={() => onApprove([...selected], footprintChoices)} disabled={submitting || selected.size === 0}>
+          <Button onClick={() => onApprove(
+            [...selected],
+            Object.fromEntries(
+              Object.entries(footprintChoices).filter(([id]) => selected.has(id)),
+            ),
+          )} disabled={submitting || selected.size === 0}>
             {submitting ? "Capturing referenced assets…" : `Approve ${selected.size} component${selected.size === 1 ? "" : "s"}`}
           </Button>
         </DialogFooter>

--- a/frontend/src/components/workspace/library-import-center.tsx
+++ b/frontend/src/components/workspace/library-import-center.tsx
@@ -599,6 +599,7 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
         </section>
       </div>
       <LibraryImportRemediationDialog
+        key={remediationProposal?.id ?? "none"}
         proposal={remediationProposal}
         open={remediationProposal !== null}
         submitting={proposalActionId === remediationProposal?.id}

--- a/frontend/src/components/workspace/library-import-remediation-dialog.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle, Box, CircuitBoard, FileCode2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -25,37 +25,52 @@ interface LibraryImportRemediationDialogProps {
 
 const assetIcon = (assetType: string) => assetType === "symbol" ? FileCode2 : assetType === "footprint" ? CircuitBoard : Box;
 
-export function LibraryImportRemediationDialog({ proposal, open, submitting, onOpenChange, onAccept }: LibraryImportRemediationDialogProps) {
-  const [metadata, setMetadata] = useState<Record<string, string>>({});
-  const [selections, setSelections] = useState<Record<string, string[]>>({});
-  const [changeSummary, setChangeSummary] = useState("Import component from Prism project");
+function initialMetadata(
+  proposal: ProjectComponentImportProposal | null,
+): Record<string, string> {
+  const source = (proposal?.metadata ?? {}) as Record<string, unknown>;
+  return {
+    value: String(source.value || ""),
+    description: String(source.description || ""),
+    datasheet: String(source.datasheet || ""),
+    manufacturer: String(source.manufacturer || ""),
+    manufacturer_part_number: String(source.manufacturer_part_number || ""),
+    package_name: String(source.footprint || ""),
+  };
+}
 
+// Symbols and footprints take exactly one; everything else defaults to all of
+// it, because a 3D model or a datasheet is additive.
+function initialSelections(
+  assetsByType: Record<string, ProjectComponentImportProposal["assets"]>,
+): Record<string, string[]> {
+  const defaults: Record<string, string[]> = {};
+  for (const [assetType, assets] of Object.entries(assetsByType)) {
+    defaults[assetType] = assetType === "symbol" || assetType === "footprint"
+      ? assets.slice(0, 1).map((asset) => asset.sha256)
+      : assets.map((asset) => asset.sha256);
+  }
+  return defaults;
+}
+
+export function LibraryImportRemediationDialog({ proposal, open, submitting, onOpenChange, onAccept }: LibraryImportRemediationDialogProps) {
   const assetsByType = useMemo(() => {
     const grouped: Record<string, ProjectComponentImportProposal["assets"]> = {};
     for (const asset of proposal?.assets || []) (grouped[asset.asset_type] ||= []).push(asset);
     return grouped;
   }, [proposal]);
 
-  useEffect(() => {
-    if (!proposal) return;
-    const source = proposal.metadata as Record<string, unknown>;
-    setMetadata({
-      value: String(source.value || ""),
-      description: String(source.description || ""),
-      datasheet: String(source.datasheet || ""),
-      manufacturer: String(source.manufacturer || ""),
-      manufacturer_part_number: String(source.manufacturer_part_number || ""),
-      package_name: String(source.footprint || ""),
-    });
-    const defaults: Record<string, string[]> = {};
-    for (const [assetType, assets] of Object.entries(assetsByType)) {
-      defaults[assetType] = assetType === "symbol" || assetType === "footprint"
-        ? assets.slice(0, 1).map((asset) => asset.sha256)
-        : assets.map((asset) => asset.sha256);
-    }
-    setSelections(defaults);
-    setChangeSummary(`Import ${proposal.reference || "component"} from Prism project`);
-  }, [assetsByType, proposal]);
+  // Keyed on the proposal by library-import-center, so the form is built once,
+  // from the proposal it is for, and edits are the reviewer's from then on.
+  const [metadata, setMetadata] = useState<Record<string, string>>(
+    () => initialMetadata(proposal),
+  );
+  const [selections, setSelections] = useState<Record<string, string[]>>(
+    () => initialSelections(assetsByType),
+  );
+  const [changeSummary, setChangeSummary] = useState(
+    () => `Import ${proposal?.reference || "component"} from Prism project`,
+  );
 
   const requiredMetadataComplete = ["value", "description", "datasheet", "manufacturer", "manufacturer_part_number"]
     .every((field) => metadata[field]?.trim());

--- a/frontend/src/components/workspace/library-import-remediation-grid.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-grid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle, ArrowDownToLine, Check, CheckCheck, Combine, Download, Loader2, Redo2, Save,
   Undo2, Upload,
@@ -221,7 +221,7 @@ export function LibraryImportRemediationGrid({
   // pieces move through one pure reducer (useEditHistory) so history can never
   // duplicate or desync.
   const { edits, undoStack, redoStack, commitEdits, replaceEdits, resetHistory, undo, redo } = useEditHistory();
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [rawSelected, setSelected] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [accepting, setAccepting] = useState(false);
   const [filter, setFilter] = useState("");
@@ -273,15 +273,15 @@ export function LibraryImportRemediationGrid({
 
   const dirtyCount = Object.keys(edits).length;
 
-  useEffect(() => {
-    // Group keys change when rows merge or a refresh removes accepted rows, so drop
-    // selections that no longer name a live row.
-    setSelected((current) => {
-      const live = new Set(groups.map((group) => group.key));
-      const next = new Set([...current].filter((key) => live.has(key)));
-      return next.size === current.size ? current : next;
-    });
-  }, [groups]);
+  // Group keys change when rows merge or a refresh removes accepted rows. A
+  // selection is only ever read against the live rows -- the copy-down, the
+  // ready count, and the header checkbox all intersect with them -- so it is
+  // narrowed during render rather than pruned a commit later.
+  const selected = useMemo(() => {
+    const live = new Set<string>();
+    for (const group of groups) if (rawSelected.has(group.key)) live.add(group.key);
+    return live;
+  }, [groups, rawSelected]);
 
   /** Apply an edit through the history so it can be undone. */
   /** A grouped row stands for one component, so an edit applies to every member. */

--- a/frontend/src/components/workspace/library-preview-inspector.tsx
+++ b/frontend/src/components/workspace/library-preview-inspector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Maximize2, Minus, Plus, RotateCcw } from "lucide-react";
 import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
@@ -94,11 +94,10 @@ export function LibraryPreviewInspector({
     return [...perUnit.values()].sort((a, b) => a.unit - b.unit);
   }, [kind, previews]);
   const [activeUnit, setActiveUnit] = useState(ready[0]?.unit || 1);
+  // A unit that disappears from `ready` needs no correcting: the fallback
+  // below already selects the first, and the tablist marks the active tab by
+  // `active.id`, never by this value.
   const active = ready.find((preview) => preview.unit === activeUnit) || ready[0];
-
-  useEffect(() => {
-    if (!ready.some((preview) => preview.unit === activeUnit)) setActiveUnit(ready[0]?.unit || 1);
-  }, [activeUnit, ready]);
 
   if (!active) {
     return <div className={cn("flex items-center justify-center border border-dashed text-xs text-muted-foreground", compact ? "h-48" : "h-80")}>No {kind} preview</div>;

--- a/frontend/src/components/workspace/move-project-dialog.tsx
+++ b/frontend/src/components/workspace/move-project-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import { useMemo, useState, type KeyboardEvent } from "react";
 
 import { isDialogSubmitShortcut } from "@/lib/dialog-shortcuts";
 import { FolderTreeItem, Project } from "@/types/project";
@@ -24,6 +24,16 @@ interface MoveProjectDialogProps {
 const ROOT_VALUE = "__root__";
 const UNSELECTED_VALUE = "__unselected__";
 
+// One shared source folder preselects it; a mixed selection forces a choice.
+// The dialog is mounted per move (workspace.tsx gates on projectsToMove), so
+// this is the initial value rather than a correction applied after render.
+function initialTarget(projects: Project[]): string {
+  if (projects.length === 0) return ROOT_VALUE;
+  const sourceFolderIds = new Set(projects.map((project) => project.folder_id ?? null));
+  if (sourceFolderIds.size === 1) return projects[0].folder_id ?? ROOT_VALUE;
+  return UNSELECTED_VALUE;
+}
+
 export function MoveProjectDialog({
   projects,
   folders,
@@ -32,7 +42,7 @@ export function MoveProjectDialog({
   onConfirm,
   getProjectDisplayName,
 }: MoveProjectDialogProps) {
-  const [targetFolderId, setTargetFolderId] = useState(ROOT_VALUE);
+  const [targetFolderId, setTargetFolderId] = useState(() => initialTarget(projects));
 
   const folderPathById = useMemo(() => {
     const folderById = new Map(folders.map((folder) => [folder.id, folder]));
@@ -87,20 +97,6 @@ export function MoveProjectDialog({
 
     return paths;
   }, [folders]);
-
-  useEffect(() => {
-    if (projects.length === 0) {
-      setTargetFolderId(ROOT_VALUE);
-      return;
-    }
-
-    const sourceFolderIds = new Set(projects.map((project) => project.folder_id ?? null));
-    if (sourceFolderIds.size === 1) {
-      setTargetFolderId(projects[0].folder_id ?? ROOT_VALUE);
-    } else {
-      setTargetFolderId(UNSELECTED_VALUE);
-    }
-  }, [projects]);
 
   const submit = () => {
     if (projects.length === 0 || targetFolderId === UNSELECTED_VALUE) {

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -702,6 +702,9 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                                 <ErrorBoundary label="the visualizer" resetKeys={[projectId, activeCommit]}>
                                     <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading visualizers...</div>}>
                                         <Visualizer
+                                            // The identity the ErrorBoundary
+                                            // beside it already resets on.
+                                            key={`${projectId}:${activeCommit ?? ""}`}
                                             projectId={projectId}
                                             user={user}
                                             commit={activeCommit}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -677,7 +677,9 @@ export function ProjectDetailPage({ user }: { user: User | null }) {
                                 <ErrorBoundary label="the history viewer" resetKeys={[projectId, selectedBranchRef, refreshKey]}>
                                     <Suspense fallback={<div className="text-sm text-muted-foreground">Loading history...</div>}>
                                         <HistoryViewer
-                                            key={refreshKey}
+                                            // The identity the ErrorBoundary
+                                            // above already resets on.
+                                            key={`${projectId}:${selectedBranchRef}:${refreshKey}`}
                                             projectId={projectId}
                                             branchRef={selectedBranchRef}
                                             onViewCommit={handleViewCommit}

--- a/frontend/src/panel/screens/PartDetailScreen.tsx
+++ b/frontend/src/panel/screens/PartDetailScreen.tsx
@@ -325,6 +325,7 @@ export function PartDetailScreen({
           </Select>
 
           <ZoomablePreview
+            key={symbolPreviewUrl}
             label="Symbol"
             url={symbolPreviewUrl}
             status={selectedRepresentation.symbol?.preview_url ? "ready" : component.preview_status?.symbol?.status}
@@ -333,6 +334,7 @@ export function PartDetailScreen({
             onExpand={symbolPreviewUrl ? () => setLightbox("symbol") : undefined}
           />
           <ZoomablePreview
+            key={footprintPreviewUrl}
             label="Footprint"
             url={footprintPreviewUrl}
             status={
@@ -511,13 +513,11 @@ function ZoomablePreview({
   version?: string;
   onExpand?: () => void;
 }) {
+  // Keyed on the url by both call sites, so a new image is a new card and
+  // starts in its own loading state.
   const [loadState, setLoadState] = useState<"loading" | "ready" | "error">(
     "loading"
   );
-
-  useEffect(() => {
-    setLoadState("loading");
-  }, [url]);
 
   const isReady = Boolean(url) && status !== "failed";
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -51,3 +51,22 @@ afterEach(cleanup);
 if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
+
+/**
+ * The same gap, one layer up: no layout means no `ResizeObserver`.
+ *
+ * `use-virtual-viewport` observes its scroll container to decide how many rows
+ * to mount, so every test that renders a virtualized grid constructs one during
+ * a passive effect and throws before the component under test does anything.
+ * The stub reports nothing, which is the honest answer in an environment with
+ * no layout: the viewport hook keeps its fallback height and mounts its default
+ * window of rows, which is what a test asserting on grid contents wants.
+ */
+if (!("ResizeObserver" in globalThis)) {
+  class NoLayoutResizeObserver implements ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = NoLayoutResizeObserver;
+}


### PR DESCRIPTION
Bucket B from the [backlog triage](https://claude.ai/code/artifact/36929fc7-b9be-4870-8ecd-50ef3284c474): state and data flow that ran through effects. **164 warnings → 105.** Bucket B itself goes from 81 findings to 22, and everything still standing is blocked on decomposition rather than on effort.

Almost every commit *removes* an effect rather than shrinking one. The recurring move is to give a value the identity it was being reset to — a scope, a key, or the event that actually ends its life — so it expires by comparison during render instead of a commit later.

## What changed

**Workspace surfaces (`20454d1`).** `create-folder-dialog` reset its name when `open` went false, but `workspace.tsx` renders it only while open, so the branch could never run. `move-project-dialog` derives its target at mount. `library-preview-inspector` corrected a unit nothing observed. `library-asset-link-picker` now takes the linked name from the search response that carries it, holding one piece of state fewer rather than one more.

The bulk-edit cell mirrored the committed value into its draft. The draft belongs to an edit session, so the editor became its own component, mounted when the cell activates. Keying it on the value is the obvious move and is **wrong**: the blur that commits also changes the value, so the remount drags focus back into the cell the reviewer just left. The new test fails on exactly that.

**Comparison shell (`cef7312`).** Four reset effects; each value now carries the scope it was made in. The layer-focus release carries its route — which is what its own comment already claimed, "for as long as this route stays selected", expressed as a flag that could not enforce it. The schematic-catalogue reset needed no replacement: it has carried its own `pairKey` all along.

**Visualizer (`3744679`, −16).** Twenty-three values put back by hand on project or commit change. The call site was already using the right tool — the `ErrorBoundary` beside it resets on that pair — so the component is keyed on it. The remount reaches what the effect could not: a ref, and the selection inside `usePrismCrossProbe`, which lives here too.

**Sessions and identity (`f94d14a`, `81d94f1`, `cd1843c`).** The command palette drops its query when the session ends, which is the close, not the next open. The comment form is mounted per pin. Two highlight indexes clamp during render instead of being corrected after a commit that showed the wrong row. Paging carries the filter scope it was chosen under, which replaced a reset effect *and* the clamp effect chained behind it. Archived build logs, the release member viewer and the panel's preview card are keyed on their subject.

**Selections and forms (`fc0a1ea`).** Two of these change what the reviewer sees, deliberately:

- Folder discovery re-selected every importable component whenever discovery re-ran — which is what attaching a footprint does. That lost the reviewer's deselections and still never selected the component they had just made importable. It stores the opt-outs now, so re-running keeps their choices and picks up the new component.
- The differences pane force-expanded the group holding the selection and left it open after the selection moved on. It now stores the choices the reviewer made and defaults the rest, so the queue shows the group being reviewed rather than every group visited on the way to it.

## Four findings are annotated, not fixed

`ecad-viewer-controls` reports its rail width to the host that must leave room for it — a layout fact, measured after layout, with no earlier event to move it to. `ReleaseStudioPanel` is told it pushes state to a parent; it does not. `settings-dialog` is told its loading flag resets only on success; it resets in `finally`, and the rule is reading the abort guard as a success branch. Two edit buffers are seeded from a prop on purpose — they are meant to diverge the moment someone types, so "compute it inline" is not available, and the guard is a key.

## Verification

`tsc -b`, `eslint .`, 445 tests, `vite build`, and `scan:gate` at each new baseline down to 105. Three new tests cover the bulk-edit cell. `ResizeObserver` joins `scrollIntoView` in the shared setup — the same jsdom gap, needed by every virtualized-grid test.

## What remains, and why

All 22 remaining bucket B findings sit behind decomposition:

| Findings | Site | Blocked on |
| ---: | --- | --- |
| 13 | `library-component-workspace.tsx` | Resets thirteen evidence values on an **internal** `refreshKey`, so there is no parent to hang a key on. Needs an inner component — the file is 2,503 lines. |
| 5 | `use-comparison-url-state.ts` | A URL↔state bridge. The honest fix makes the URL the single source and deletes five mirrored values across the 1,498-line shell. |
| 2 | `comparison-presentation-shell.tsx` | Publishes PCB layers on change **and on becoming active** — the parent passes `isActive ? setPcbLayers : undefined`. Removing the effect drops the activation sync unless the parent pulls instead. |
| 2 | `design-comparison-workspace.tsx` | Cross-tab selection reconciliation, reading its own state in its own dependencies. Deriving it is a change to the selection model, not to an effect. |

That work is bucket D, now running as a follow-up rather than the other way round.
