### PR TITLE
Bundle component evidence behind its generation

### DIFF
--- a/frontend/react-doctor-baseline.json
+++ b/frontend/react-doctor-baseline.json
@@ -1,5 +1,5 @@
 {
   "_": "Ceiling for scripts/react-doctor-gate.mjs. Lower it whenever findings are cleared; raising it needs a reason in the PR.",
   "errors": 0,
-  "warnings": 105
+  "warnings": 92
 }

--- a/frontend/src/components/workspace/library-component-evidence.test.tsx
+++ b/frontend/src/components/workspace/library-component-evidence.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+    fetchJson: vi.fn(),
+    fetchApi: vi.fn(),
+    readApiError: vi.fn(async () => "error"),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { fetchJson } from "@/lib/api";
+import { LibraryComponentWorkspace } from "./library-component-workspace";
+
+// Every tab's evidence is stored as one value carrying the component
+// generation it was loaded for, and useEvidenceResource treats a result from
+// an older generation as nothing loaded. Both halves matter: without the
+// generation on the value the previous component's revisions stay on screen,
+// and without it on the load state the status is still "loaded" so the new
+// component is never fetched at all. A single reset effect used to stand in
+// for both, and this is what it was protecting.
+
+function component(id: string) {
+    return {
+        id, slug: id, name: id.toUpperCase(), mpn: `MPN-${id}`, value: "10k",
+        workflow_stage: "draft", revision: 1, revision_id: `${id}-rev1`,
+        parent_revision_id: "", version: 1, assets: [], representations: [],
+        extra: {}, availability_state: "active", validation_status: "unknown",
+        identity_kind: "mpn", source: "manual", preview_status: {},
+        previews: [],
+        validation: { status: "unknown", error_count: 0, warning_count: 0 },
+    };
+}
+
+function revision(id: string, summary: string) {
+    return {
+        id: `${id}-rev1`, version: 1, release_status: "draft",
+        created_at: "2026-08-01T00:00:00Z", created_by: "someone",
+        change_summary: summary, change_kind: "metadata",
+    };
+}
+
+function routeFor(id: string) {
+    return (url: string) => {
+        if (url === `/api/catalog/components/${id}`) return component(id);
+        if (url === `/api/catalog/components/${id}/revisions`) {
+            return { items: [revision(id, `history for ${id}`)] };
+        }
+        return { items: [] };
+    };
+}
+
+function install(...ids: string[]) {
+    const routes = ids.map(routeFor);
+    vi.mocked(fetchJson).mockImplementation(async (input) => {
+        const url = String(input);
+        for (const route of routes) {
+            const hit = route(url);
+            if (hit) return hit as never;
+        }
+        // Anything this test has not taught the mock is a bug in the test, not
+        // an empty response the component should have to cope with.
+        throw new Error(`unrouted request: ${url}`);
+    });
+}
+
+function Harness({ componentId }: { componentId: string }) {
+    return (
+        <MemoryRouter initialEntries={["/?section=library-manager&componentTab=revisions"]}>
+            <LibraryComponentWorkspace
+                componentId={componentId}
+                user={{ id: "u1", email: "a@b.c", role: "admin" } as never}
+                projects={[]}
+                onBack={vi.fn()}
+            />
+        </MemoryRouter>
+    );
+}
+
+function renderWorkspace(componentId: string) {
+    return render(<Harness componentId={componentId} />);
+}
+
+beforeEach(() => install("comp-a", "comp-b"));
+afterEach(() => vi.clearAllMocks());
+
+describe("component evidence across generations", () => {
+    it("loads the evidence for the component it is showing", async () => {
+        renderWorkspace("comp-a");
+        expect(await screen.findByText("history for comp-a")).toBeInTheDocument();
+    });
+
+
+});

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -1363,6 +1363,26 @@ type EvidenceLoadState = {
 
 const IDLE_EVIDENCE: EvidenceLoadState = { status: "idle", error: "" };
 
+type EvidenceValues = {
+  revisions: CatalogRevisionSummary[];
+  events: CatalogAuditEvent[];
+  verification: CatalogAuditVerification | null;
+  usage: CatalogComponentUsage[];
+  reviews: CatalogReviewDecision[];
+  releases: CatalogReleaseRecord[];
+};
+
+type EvidenceBundle = EvidenceValues & { generation: string };
+
+const EMPTY_EVIDENCE: EvidenceValues = {
+  revisions: [],
+  events: [],
+  verification: null,
+  usage: [],
+  reviews: [],
+  releases: [],
+};
+
 function useEvidenceLoadState() {
   const [state, setState] = useState<EvidenceLoadState>(IDLE_EVIDENCE);
   const stateRef = useRef<EvidenceLoadState>(IDLE_EVIDENCE);
@@ -1402,7 +1422,14 @@ function useEvidenceResource<T>({
   const onLoadedRef = useCommittedRef(onLoaded);
 
   useEffect(() => {
-    if (!enabled || stateRef.current.status !== "idle") return;
+    // A result belonging to an earlier generation is not a result: it is the
+    // previous component's, and counts as nothing loaded. Without this the
+    // status stays "loaded" across a component change and the guard below
+    // refuses to fetch the new one -- which is why the workspace used to reset
+    // every load state by hand.
+    const settledElsewhere = stateRef.current.generation !== undefined
+      && stateRef.current.generation !== generation;
+    if (!enabled || (!settledElsewhere && stateRef.current.status !== "idle")) return;
     const controller = new AbortController();
     let settled = false;
     update({ status: "loading", error: "", generation });
@@ -1771,12 +1798,12 @@ export function LibraryComponentWorkspace({
   const returnLabel = returnView === "releases" ? "Release Queue" : returnView === "imports" ? "Import Center" : "Catalog";
   const [currentComponent, setCurrentComponent] = useState<CatalogComponent | null>(null);
   const [activeComponent, setActiveComponent] = useState<CatalogComponent | null>(null);
-  const [revisions, setRevisions] = useState<CatalogRevisionSummary[]>([]);
-  const [events, setEvents] = useState<CatalogAuditEvent[]>([]);
-  const [verification, setVerification] = useState<CatalogAuditVerification | null>(null);
-  const [usage, setUsage] = useState<CatalogComponentUsage[]>([]);
-  const [reviews, setReviews] = useState<CatalogReviewDecision[]>([]);
-  const [releases, setReleases] = useState<CatalogReleaseRecord[]>([]);
+  // Every tab's evidence belongs to one component generation, so it is stored
+  // as one value carrying that generation. Reading it back through the guard
+  // below is what used to be an effect blanking six pieces of state.
+  const [evidenceStore, setEvidenceStore] = useState<EvidenceBundle>(
+    () => ({ generation: "", ...EMPTY_EVIDENCE }),
+  );
   const [diff, setDiff] = useState<CatalogRevisionDiff | null>(null);
   const [componentLoading, setComponentLoading] = useState(true);
   const [componentError, setComponentError] = useState("");
@@ -1798,7 +1825,11 @@ export function LibraryComponentWorkspace({
   const { state: usageLoadState, stateRef: usageLoadRef, update: setUsageLoad } = usageLoad;
   const { state: auditLoadState, stateRef: auditLoadRef, update: setAuditLoad } = auditLoad;
   const { state: diffLoadState, stateRef: diffLoadRef, update: setDiffLoad } = useEvidenceLoadState();
-  const diffCacheRef = useRef(new Map<string, CatalogRevisionDiff>());
+  // Diffs are cached per revision pair. The cache carries the generation it was
+  // filled for so it can be dropped when the component changes, which the reset
+  // effect used to do; keys already include componentId, so this is about not
+  // holding another component's payloads, not about correctness.
+  const diffCacheRef = useRef({ generation: "", entries: new Map<string, CatalogRevisionDiff>() });
   const [transitionTarget, setTransitionTarget] = useState<WorkflowStage | null>(null);
   const [reviewNote, setReviewNote] = useState("");
   const [overrideReason, setOverrideReason] = useState("");
@@ -1829,6 +1860,17 @@ export function LibraryComponentWorkspace({
   }, [setSearchParams]);
 
   const evidenceGeneration = `${componentId}:${refreshKey}`;
+  const { revisions, events, verification, usage, reviews, releases } =
+    evidenceStore.generation === evidenceGeneration ? evidenceStore : EMPTY_EVIDENCE;
+  const publishEvidence = useCallback(
+    <K extends keyof EvidenceValues>(key: K, value: EvidenceValues[K]) =>
+      setEvidenceStore((current) => ({
+        ...(current.generation === evidenceGeneration ? current : EMPTY_EVIDENCE),
+        generation: evidenceGeneration,
+        [key]: value,
+      })),
+    [evidenceGeneration],
+  );
   const needsRevisions = activeTab === "revisions" || activeTab === "review";
   const needsReviews = activeTab === "review" || activeTab === "audit";
   const needsReleases = activeTab === "review" || activeTab === "audit";
@@ -1836,32 +1878,6 @@ export function LibraryComponentWorkspace({
   const needsAudit = activeTab === "audit";
   const currentRevisionKey = currentComponent?.revision_id || "";
   const componentReady = Boolean(currentRevisionKey && componentGeneration === evidenceGeneration);
-
-  useEffect(() => {
-    setRevisions([]);
-    setEvents([]);
-    setVerification(null);
-    setUsage([]);
-    setReviews([]);
-    setReleases([]);
-    setDiff(null);
-    diffCacheRef.current.clear();
-    setRevisionsLoad(IDLE_EVIDENCE);
-    setReviewsLoad(IDLE_EVIDENCE);
-    setReleasesLoad(IDLE_EVIDENCE);
-    setUsageLoad(IDLE_EVIDENCE);
-    setAuditLoad(IDLE_EVIDENCE);
-    setDiffLoad(IDLE_EVIDENCE);
-  }, [
-    componentId,
-    refreshKey,
-    setRevisionsLoad,
-    setReviewsLoad,
-    setReleasesLoad,
-    setUsageLoad,
-    setAuditLoad,
-    setDiffLoad,
-  ]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -1912,7 +1928,7 @@ export function LibraryComponentWorkspace({
     retryKey: evidenceRetryKey,
     loadState: revisionsLoad,
     load: (signal) => fetchJson<{ items: CatalogRevisionSummary[] }>(`${componentPath}/revisions`, { signal }),
-    onLoaded: (response) => setRevisions(response.items),
+    onLoaded: (response) => publishEvidence("revisions", response.items),
   });
 
   useEvidenceResource({
@@ -1921,7 +1937,7 @@ export function LibraryComponentWorkspace({
     retryKey: evidenceRetryKey,
     loadState: reviewsLoad,
     load: (signal) => fetchJson<{ items: CatalogReviewDecision[] }>(`${componentPath}/reviews`, { signal }),
-    onLoaded: (response) => setReviews(response.items),
+    onLoaded: (response) => publishEvidence("reviews", response.items),
   });
 
   useEvidenceResource({
@@ -1930,7 +1946,7 @@ export function LibraryComponentWorkspace({
     retryKey: evidenceRetryKey,
     loadState: releasesLoad,
     load: (signal) => fetchJson<{ items: CatalogReleaseRecord[] }>(`${componentPath}/releases`, { signal }),
-    onLoaded: (response) => setReleases(response.items),
+    onLoaded: (response) => publishEvidence("releases", response.items),
   });
 
   useEvidenceResource({
@@ -1939,7 +1955,7 @@ export function LibraryComponentWorkspace({
     retryKey: evidenceRetryKey,
     loadState: usageLoad,
     load: (signal) => fetchJson<{ items: CatalogComponentUsage[] }>(`${componentPath}/usage`, { signal }),
-    onLoaded: (response) => setUsage(response.items),
+    onLoaded: (response) => publishEvidence("usage", response.items),
   });
 
   useEvidenceResource({
@@ -1955,8 +1971,8 @@ export function LibraryComponentWorkspace({
         fetchJson<CatalogAuditVerification>(`${componentPath}/audit/verify`, { signal }),
       ]),
     onLoaded: ([eventList, auditVerification]) => {
-      setEvents(eventList.items);
-      setVerification(auditVerification);
+      publishEvidence("events", eventList.items);
+      publishEvidence("verification", auditVerification);
     },
   });
 
@@ -1975,8 +1991,11 @@ export function LibraryComponentWorkspace({
       setDiffLoad({ status: "loaded", error: "", generation: evidenceGeneration });
       return;
     }
+    if (diffCacheRef.current.generation !== evidenceGeneration) {
+      diffCacheRef.current = { generation: evidenceGeneration, entries: new Map() };
+    }
     const cacheKey = `${componentId}:${diffPair.before}:${diffPair.after}`;
-    const cached = diffCacheRef.current.get(cacheKey);
+    const cached = diffCacheRef.current.entries.get(cacheKey);
     if (cached) {
       setDiff(cached);
       setDiffLoad({ status: "loaded", error: "", generation: cacheKey });
@@ -1992,7 +2011,7 @@ export function LibraryComponentWorkspace({
       .then((value) => {
         settled = true;
         if (controller.signal.aborted) return;
-        diffCacheRef.current.set(cacheKey, value);
+        diffCacheRef.current.entries.set(cacheKey, value);
         setDiff(value);
         setDiffLoad({ status: "loaded", error: "", generation: cacheKey });
       })


### PR DESCRIPTION
**Stacked on #186** — base retargets to `dev` automatically once that merges. The diff against `fix/react-doctor-bucket-b` is one commit.

First piece of bucket D, chosen because it is what unblocks the largest remaining bucket B cluster. **105 warnings → 92**, all thirteen from `library-component-workspace.tsx`.

## The effect that was not tidiness

The workspace held six pieces of tab evidence and six load states, and reset all twelve from one effect whenever the component or the refresh key changed. That effect was load-bearing: `useEvidenceResource` skips a fetch unless its load state is `"idle"`, so without the reset, a tab that had loaded for one component would **never load for the next**.

A key could not fix it — `refreshKey` is the component's own state, so there is no parent to hang one on. That is why these thirteen findings were blocked rather than merely awkward.

Both halves now sit where they belong:

- **The hook owns its generation.** `useEvidenceResource` treats a load state from another generation as nothing loaded — which is what its own doc comment already claimed: *"load one tab's evidence once per component generation"*.
- **The evidence carries its generation.** Six separate values become one bundle tagged with the generation it was fetched for, read back through a guard. There is no longer a render in which the previous component's revisions, reviews and audit chain sit on screen under the new component's name.

The diff cache keeps its previous memory behaviour by carrying the same generation. Its keys already included the component id, so that is about not holding another component's payloads rather than about correctness.

## Verification

`tsc -b`, `eslint .`, 446 tests, `scan:gate` at the new 92 baseline. The suite was run five times over — one run showed a single failure that never reproduced across four further runs and could not be attributed to a named test.

## Coverage is one test, not two

`library-component-evidence.test.tsx` pins that a tab loads the evidence for the component being shown, which is the catastrophic failure mode if the generation logic is wrong.

The second test — switching component while mounted — is **not** included, because it fails on a defect that predates this change. `library-manager-workspace.tsx:80` renders the workspace without a key, so `componentId` can change in place while `?revision=` still holds the *previous* component's revision id. The historical fetch then goes to the new component with an old revision id, and whatever comes back is installed as `activeComponent` unchecked; a wrong-shaped success response crashes the header on `activeComponent.validation.status`.

I confirmed it is pre-existing by running the same test against the version of the file before this commit, where it fails identically. It is filed separately rather than smuggled in here. Note the real API would likely 404 rather than return a wrong-shaped 200, so the reachable severity is unclear — the fixture and harness for a proper repro are already in the test file.

## What is left in bucket D

| Findings unblocked | Target | Size |
| ---: | --- | ---: |
| 7 | `comparison-presentation-shell.tsx` + `use-comparison-url-state.ts` — make the URL the single source and let the parent pull layer state rather than be pushed it | 1,498 lines |
| 2 | `design-comparison-workspace.tsx` — cross-tab selection reconciliation | 1,009 lines |
| — | 16 further giant components | ~13,000 lines |

The shell is the next one worth doing, and the only one that unblocks more bucket B.
