### PR TITLE
Check the revision response is a component before showing it

### DIFF
--- a/frontend/src/components/workspace/library-component-evidence.test.tsx
+++ b/frontend/src/components/workspace/library-component-evidence.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -64,9 +64,10 @@ function install(...ids: string[]) {
     });
 }
 
-function Harness({ componentId }: { componentId: string }) {
+function Harness({ componentId, revision }: { componentId: string; revision?: string }) {
+    const query = `/?section=library-manager&componentTab=revisions${revision ? `&revision=${revision}` : ""}`;
     return (
-        <MemoryRouter initialEntries={["/?section=library-manager&componentTab=revisions"]}>
+        <MemoryRouter initialEntries={[query]}>
             <LibraryComponentWorkspace
                 componentId={componentId}
                 user={{ id: "u1", email: "a@b.c", role: "admin" } as never}
@@ -91,4 +92,29 @@ describe("component evidence across generations", () => {
     });
 
 
+
+    // Arriving with a `?revision=` that belongs to a different component. Every
+    // in-app path clears that param and the API scopes the lookup and 404s, so
+    // the reachable version of this is a shared or bookmarked link -- and today
+    // that 404s too. What is being pinned is the boundary: a 200 whose body is
+    // not a component must not become the active component. It used to, and the
+    // header dereferences `validation.status`, so the workspace went white.
+    it("refuses a revision response that is not a component", async () => {
+        vi.mocked(fetchJson).mockImplementation(async (input) => {
+            const url = String(input);
+            if (url === "/api/catalog/components/comp-a") return component("comp-a") as never;
+            // The shape a paginated collection would have, standing in for any
+            // 200 that is not the component this screen asked for.
+            return { items: [] } as never;
+        });
+
+        render(<Harness componentId="comp-a" revision="comp-b-rev1" />);
+
+        expect(
+            await screen.findByText("That revision could not be loaded for this component."),
+        ).toBeInTheDocument();
+        // Still the component's own header, and still a way back.
+        await waitFor(() => expect(screen.getByText("COMP-A")).toBeInTheDocument());
+        expect(screen.getByRole("button", { name: /return to current/i })).toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -237,6 +237,31 @@ const formatBytes = (value?: number) => {
 
 const sleep = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
+/**
+ * Is this response actually a component?
+ *
+ * The revision endpoint is asked for `?revision=`, which survives in the URL
+ * independently of the component being viewed. Every in-app path that opens a
+ * component clears it, and the API scopes the lookup and 404s a revision
+ * belonging to somewhere else -- so the only way here is a link arriving with a
+ * mismatched pair, and today that still 404s. The guard is for the case where
+ * it does not: a 200 carrying anything else was being installed as the active
+ * component, and the header dereferences `validation.status` on it without a
+ * guard, so the whole workspace went white rather than showing the error banner
+ * that already exists for this.
+ *
+ * It checks the fields the header commits to, not the whole shape, because
+ * those are what the crash was about.
+ */
+function isCatalogComponent(value: unknown): value is CatalogComponent {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<CatalogComponent>;
+  return typeof candidate.id === "string"
+    && typeof candidate.revision_id === "string"
+    && typeof candidate.validation === "object"
+    && candidate.validation !== null;
+}
+
 const metadataFormFromComponent = (component: CatalogComponent): MetadataForm => ({
   value: component.value,
   description: component.description,
@@ -1912,7 +1937,14 @@ export function LibraryComponentWorkspace({
     const controller = new AbortController();
     setHistoricalLoading(true);
     void fetchJson<CatalogComponent>(`/api/catalog/components/${encodeURIComponent(componentId)}/revisions/${encodeURIComponent(requestedRevisionId)}`, { signal: controller.signal })
-      .then((component) => { if (!controller.signal.aborted) setActiveComponent(component); })
+      .then((component) => {
+        if (controller.signal.aborted) return;
+        if (!isCatalogComponent(component)) {
+          setHistoricalError("That revision could not be loaded for this component.");
+          return;
+        }
+        setActiveComponent(component);
+      })
       .catch((reason: unknown) => {
         if (!controller.signal.aborted) setHistoricalError(reason instanceof Error ? reason.message : String(reason));
       })


### PR DESCRIPTION
**Stacked on #187** (which is stacked on #186). Bases retarget automatically as each lands; the diff here is one commit.

## The gap

`library-component-workspace.tsx` asks for `?revision=` against whichever component is open and installs whatever comes back as `activeComponent`, unvalidated. The header then reads `activeComponent.validation.status` with no guard, so a 200 carrying anything else takes the whole screen white — rather than showing the error banner that already exists for exactly this case.

The pairing can go wrong because the two halves have different lifetimes: `?revision=` is a search param, and `library-manager-workspace.tsx:80` renders the workspace **without a key**, so the component can change underneath a revision id belonging somewhere else.

## It is not reachable today

Worth stating plainly, because it changes how much this is worth:

- Every in-app path that opens a component already deletes `revision` and `compare` — `openComponent`, `closeComponent` and `setView` all do.
- The API scopes the lookup. `component_catalog_domain.get_component_revision` rejects a revision whose `component_id` does not match, so `catalog_admin.py:876` returns 404 and the existing `.catch` sets `historicalError`.

That leaves a link *arriving* with a mismatched pair — a bookmark or a shared URL — and that 404s too. So this is a boundary-trust fix, not a live defect. I am fixing it anyway because the failure mode was total rather than local: one surprising response blanked the workspace instead of degrading to the banner beside it.

## The change

A narrow type guard, checking the fields the header actually commits to rather than the whole shape, since those are what the crash was about. A bad shape now takes the same path a 404 does, so the reviewer gets the banner and its **Return to current revision** button.

## What I did not do

The task noted keying the workspace on `componentId` as an option, and said it would make several other reset paths unnecessary. It would — but it does **not** fix this: a freshly mounted instance reads the same stale `?revision=` from the URL and makes the same request. Keying is worth doing on its own merits as part of the decomposition work, not as this fix.

## Verification

`tsc -b`, `eslint .`, 447 tests, `scan:gate` at 92. The new test reproduces the original `TypeError: Cannot read properties of undefined (reading 'status')` with the guard removed, and passes with it. It arrives with a mismatched revision the way a shared link would — the only route that reaches this at all.
