### PR TITLE
[codex] Clarify Import Center sources and prepare v3.1.0-alpha

### DIFF
--- a/docs/releases/v3.1.0-alpha.md
+++ b/docs/releases/v3.1.0-alpha.md
@@ -1,0 +1,90 @@
+# KiCAD Prism v3.1.0-alpha — release workflows, catalog representations, and review polish
+
+KiCAD Prism v3.1.0-alpha strengthens the V3 platform around three daily
+workflows: preparing manufacturing releases, governing reusable components, and
+reviewing design changes. It also includes a broad reliability and interface
+pass across the workspace, visualizer, comparison tools, authentication, and
+the KiCad Remote Symbol Provider.
+
+> [!WARNING]
+> **Existing V3 catalogs require a planned epoch-2 cutover.** The new
+> component-as-part model is an intentional destructive catalog boundary. Do
+> not start this release against a populated pre-epoch-2 catalog until you have
+> completed the backup, survivor export, CERN preflight, catalog-only reset,
+> and restore sequence in [Upgrades and backups](../UPGRADES.md#catalog-epoch-2-cutover).
+> Project repositories and non-catalog PostgreSQL schemas are not part of the
+> reset, but rolling an epoch-2 catalog back without restoring its matching
+> backup is unsupported.
+
+This remains an alpha release. Back up a deployment before upgrading, retain
+the verified backup and survivor archive after the cutover, and validate the
+release with representative projects and libraries before reopening access.
+
+## Highlights
+
+### Release Studio
+
+- Adds a source-to-publish manufacturing flow built from an immutable project
+  revision.
+- Produces deterministic fabrication, assembly, documentation, evidence, and
+  vendor-pack artifacts with pinned KiCad tooling.
+- Requires explicit Designer and QA sign-off before publication and records the
+  resulting audit trail.
+- Publishes approved dossiers to GitHub or GitLab Releases while keeping
+  historical revisions buildable but non-publishable.
+
+See the [Release Studio guide](../release-studio/README.md) for configuration,
+operation, artifacts, and recovery details.
+
+### Component catalog and imports
+
+- Makes the component the governed part identity and stores symbols,
+  footprints, and 3D models as typed representations of a revision.
+- Preserves legacy non-CERN catalog work through a checksum-verified survivor
+  archive and guarded restoration workflow.
+- Keeps Remote Symbol Provider metadata compatible while adding richer
+  representation and supply-source data.
+- Improves full-library asset browsing, preview generation, database-library
+  imports, bulk editing, and project-component remediation.
+- Separates Import Center sources into **KiCad libraries** and **Project
+  components**, with clear local-folder, server-folder, selected-project, and
+  all-project actions.
+
+### Design review and visualizer
+
+- Makes comparison state URL-driven so deep links, selected changes, tabs, and
+  presentations remain synchronized.
+- Adds selection-focused copper-layer isolation and more reliable schematic,
+  PCB, BOM, and comparison cross-probing.
+- Reduces compare latency through content-keyed parsing caches, bounded cache
+  eviction, skipped unnecessary parses, and adaptive job polling.
+- Improves long-list, resizable-panel, project-gallery, history, and selection
+  inspector behavior across common laptop and desktop layouts.
+
+### Platform reliability
+
+- Adds local password authentication alongside OIDC for deployments that need
+  it.
+- Pins Python, Node, npm, KiCad Monkey, and KiCad Cruncher identities and checks
+  them in CI.
+- Removes obsolete rendering paths and aligns the shipped ECAD viewer with the
+  tested upstream bundle.
+- Hardens gzip responses, asynchronous UI state, error boundaries, and large
+  catalog workflows.
+
+## Upgrade requirements
+
+1. Record the current release and image digests.
+2. Create and verify a complete Prism backup.
+3. For a populated pre-epoch-2 catalog, complete every gate in the
+   [catalog epoch-2 cutover](../UPGRADES.md#catalog-epoch-2-cutover) before
+   starting the new application.
+4. Carry site-specific values into the new release environment; do not copy an
+   older release file over the new digest pins.
+5. Start the release and verify schema migration output, project browsing,
+   design comparison, catalog search and placement, Import Center, and Release
+   Studio with representative data.
+
+The public release bundle remains Linux AMD64 and is published only after the
+tag points to a successful `main` Quality Gate commit and the complete release
+stack passes its image smoke test.

--- a/frontend/src/components/workspace/library-import-center.test.tsx
+++ b/frontend/src/components/workspace/library-import-center.test.tsx
@@ -48,8 +48,30 @@ describe("LibraryImportCenter sources", () => {
     expect(screen.getByRole("button", { name: "Import From All Projects" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Import project" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Import Center" })).not.toBeInTheDocument();
-    expect(screen.getByTestId("import-source-groups")).toHaveClass("gap-2", "xl:grid-cols-2");
+    expect(screen.getByTestId("import-source-groups")).toHaveClass("grid-cols-1", "gap-2");
+    expect(screen.getByTestId("import-source-groups")).not.toHaveClass("import-source-groups--split");
     expect(screen.getByRole("heading", { name: "KiCad libraries" }).closest("section")).toHaveClass("p-2");
     expect(screen.getByRole("heading", { name: "Project components" }).closest("section")).toHaveClass("p-2");
+  });
+
+  it("allocates more space to project imports when the cards share a row", async () => {
+    vi.mocked(fetchJson).mockImplementation(async <T,>(input: RequestInfo | URL) => {
+      const path = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (path === "/api/catalog/import-sessions") return { items: [] } as T;
+      if (path === "/api/catalog/import-sources/folder-roots") return { items: [] } as T;
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    render(
+      <LibraryImportCenter
+        projects={[project]}
+        user={{ name: "Admin", email: "admin@example.com", role: "admin" }}
+      />,
+    );
+
+    expect(await screen.findByTestId("import-source-groups")).toHaveClass(
+      "grid-cols-1",
+      "import-source-groups--split",
+    );
   });
 });

--- a/frontend/src/components/workspace/library-import-center.test.tsx
+++ b/frontend/src/components/workspace/library-import-center.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Project } from "@/types/project";
+import { fetchJson } from "@/lib/api";
+import { LibraryImportCenter } from "./library-import-center";
+
+vi.mock("@/lib/api", () => ({
+  fetchApi: vi.fn(),
+  fetchJson: vi.fn(),
+  readApiError: vi.fn(),
+}));
+
+const project: Project = {
+  id: "project-1",
+  name: "thunderscope",
+  display_name: "Thunderscope Rev 5.3",
+  description: "",
+  path: "/projects/thunderscope",
+  last_modified: "2026-08-27T00:00:00Z",
+};
+
+describe("LibraryImportCenter sources", () => {
+  beforeEach(() => {
+    vi.mocked(fetchJson).mockImplementation(async <T,>(input: RequestInfo | URL) => {
+      const path = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (path === "/api/catalog/import-sessions") return { items: [] } as T;
+      if (path === "/api/catalog/import-sources/folder-roots") {
+        return { items: [{ name: "cern", path_hint: "/libraries/cern" }] } as T;
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+  });
+
+  it("separates library and project imports and uses source-oriented project labels", async () => {
+    render(
+      <LibraryImportCenter
+        projects={[project]}
+        user={{ name: "Admin", email: "admin@example.com", role: "admin" }}
+      />,
+    );
+
+    expect(await screen.findByRole("heading", { name: "KiCad libraries" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Project components" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Choose local folder" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Import server folder" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import From Project" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import From All Projects" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Import project" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("import-source-groups")).toHaveClass("xl:grid-cols-2");
+  });
+});

--- a/frontend/src/components/workspace/library-import-center.test.tsx
+++ b/frontend/src/components/workspace/library-import-center.test.tsx
@@ -47,6 +47,9 @@ describe("LibraryImportCenter sources", () => {
     expect(screen.getByRole("button", { name: "Import From Project" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Import From All Projects" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Import project" })).not.toBeInTheDocument();
-    expect(screen.getByTestId("import-source-groups")).toHaveClass("xl:grid-cols-2");
+    expect(screen.queryByRole("heading", { name: "Import Center" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("import-source-groups")).toHaveClass("gap-2", "xl:grid-cols-2");
+    expect(screen.getByRole("heading", { name: "KiCad libraries" }).closest("section")).toHaveClass("p-2");
+    expect(screen.getByRole("heading", { name: "Project components" }).closest("section")).toHaveClass("p-2");
   });
 });

--- a/frontend/src/components/workspace/library-import-center.tsx
+++ b/frontend/src/components/workspace/library-import-center.tsx
@@ -550,7 +550,14 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
           )}
         </aside>
 
-        <section className="min-h-0 overflow-y-auto p-4">
+        <section
+          className={cn(
+            "min-h-0 p-4",
+            selectedSession && proposals.length > 0 && reviewMode === "grid"
+              ? "overflow-hidden"
+              : "overflow-y-auto"
+          )}
+        >
           {!selectedSession ? (
             <div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground"><FolderSearch className="mb-3 h-8 w-8" /><p>Select or create an import session.</p></div>
           ) : selectedSession.status === "failed" ? (
@@ -558,7 +565,7 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
           ) : proposals.length === 0 ? (
             <div className="flex h-full items-center justify-center text-sm text-muted-foreground">{selectedSession.status === "staged" ? "No components were discovered." : selectedSession.scope === "folder" ? "Resolving symbols, footprints, and referenced 3D models…" : "Scanning captured project revisions…"}</div>
           ) : reviewMode === "grid" ? (
-            <div>
+            <div className="h-full min-h-0">
               <LibraryImportRemediationGrid
                 sessionId={selectedSession.id}
                 proposals={proposals}

--- a/frontend/src/components/workspace/library-import-center.tsx
+++ b/frontend/src/components/workspace/library-import-center.tsx
@@ -409,7 +409,7 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="border-b p-3">
+      <header className="import-sources-container border-b p-3">
         <input
           ref={folderInputRef}
           type="file"
@@ -426,15 +426,21 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
           allowedRoles={["designer", "admin"]}
           className="flex w-full max-w-none"
         >
-          <div className="grid w-full gap-2 xl:grid-cols-2" data-testid="import-source-groups">
-            <section aria-labelledby="library-import-source" className="flex min-w-0 flex-wrap items-center gap-3 border bg-card p-2">
+          <div
+            className={cn(
+              "import-source-groups grid w-full grid-cols-1 gap-2",
+              serverRoots.length === 0 && "import-source-groups--split"
+            )}
+            data-testid="import-source-groups"
+          >
+            <section aria-labelledby="library-import-source" className="import-source-card flex min-w-0 flex-wrap items-center gap-3 border bg-card p-2">
               <div className="flex shrink-0 items-center gap-2">
                 <div className="flex size-8 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
                   <FolderOpen className="h-4 w-4" />
                 </div>
                 <h3 id="library-import-source" className="whitespace-nowrap text-sm font-semibold">KiCad libraries</h3>
               </div>
-              <div className="ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
+              <div className="import-source-controls ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
                 <Button variant="outline" onClick={() => folderInputRef.current?.click()} disabled={!canWrite || creating}>
                   <FolderOpen className="mr-2 h-4 w-4" />Choose local folder
                 </Button>
@@ -454,14 +460,14 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
               </div>
             </section>
 
-            <section aria-labelledby="project-import-source" className="flex min-w-0 flex-wrap items-center gap-3 border bg-card p-2">
+            <section aria-labelledby="project-import-source" className="import-source-card flex min-w-0 flex-wrap items-center gap-3 border bg-card p-2">
               <div className="flex shrink-0 items-center gap-2">
                 <div className="flex size-8 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
                   <CircuitBoard className="h-4 w-4" />
                 </div>
                 <h3 id="project-import-source" className="whitespace-nowrap text-sm font-semibold">Project components</h3>
               </div>
-              <div className="ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
+              <div className="import-source-controls ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
                 <Select value={projectId} onValueChange={setProjectId} disabled={!canWrite || creating}>
                   <SelectTrigger className="min-w-40 flex-1"><SelectValue placeholder="Select a project" /></SelectTrigger>
                   <SelectContent>

--- a/frontend/src/components/workspace/library-import-center.tsx
+++ b/frontend/src/components/workspace/library-import-center.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type InputHTMLAttributes } from "react";
-import { AlertTriangle, Check, ChevronRight, FolderOpen, FolderSearch, HardDrive, LoaderCircle, PanelLeftClose, PanelLeftOpen, RefreshCw, Rows3, Table2, X } from "lucide-react";
+import { AlertTriangle, Check, ChevronRight, CircuitBoard, FolderOpen, FolderSearch, HardDrive, LoaderCircle, PanelLeftClose, PanelLeftOpen, RefreshCw, Rows3, Table2, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -410,61 +410,90 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="border-b p-4">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-semibold">Import Center</h2>
-          </div>
-          {/* One hint for the whole cluster: six identical tooltips on six
-              adjacent buttons is noise, and the reason is the same for all. */}
-          <PermissionHint
-            blocked={!canWrite}
-            action="import components into the catalog"
-            allowedRoles={["designer", "admin"]}
-            className="max-w-4xl"
-          >
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <input
-              ref={folderInputRef}
-              type="file"
-              multiple
-              className="hidden"
-              {...DIRECTORY_INPUT_PROPS}
-              onChange={(event) => void uploadFolder(event.currentTarget.files)}
-            />
-            <Button variant="outline" onClick={() => folderInputRef.current?.click()} disabled={!canWrite || creating}>
-              <FolderOpen className="mr-2 h-4 w-4" />Choose library folder
-            </Button>
-            {serverRoots.length > 0 && (
-              <>
-                <Select value={serverRoot} onValueChange={setServerRoot} disabled={!canWrite || creating}>
-                  <SelectTrigger className="w-44"><SelectValue placeholder="Server root" /></SelectTrigger>
-                  <SelectContent>{serverRoots.map((root) => <SelectItem key={root.name} value={root.name}>{root.name}</SelectItem>)}</SelectContent>
-                </Select>
-                <Input className="w-48" value={serverSubpath} onChange={(event) => setServerSubpath(event.target.value)} placeholder="Optional subfolder" disabled={creating} />
-                <Button variant="outline" onClick={() => void importServerFolder()} disabled={!canWrite || creating}>
-                  <HardDrive className="mr-2 h-4 w-4" />Import server folder
-                </Button>
-              </>
-            )}
-            <Select value={projectId} onValueChange={setProjectId} disabled={!canWrite || creating}>
-              <SelectTrigger className="w-64"><SelectValue placeholder="Select a project" /></SelectTrigger>
-              <SelectContent>
-                {projects.map((project) => <SelectItem key={project.id} value={project.id}>{project.display_name || project.name}</SelectItem>)}
-              </SelectContent>
-            </Select>
-            <Button variant="outline" onClick={() => void createSession("project")} disabled={!canWrite || !projectId || creating}>Import project</Button>
-            <Button onClick={() => void createSession("all-projects")} disabled={!canWrite || creating}>Import all projects</Button>
-          </div>
-          </PermissionHint>
-        </div>
-        {folderProgress && (
-          <div className="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
-            <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-            {folderProgress.label} {folderProgress.completed}/{folderProgress.total}
-            <div className="h-1.5 w-40 overflow-hidden rounded-full bg-muted">
-              <div className="h-full bg-primary transition-[width]" style={{ width: `${(folderProgress.completed / folderProgress.total) * 100}%` }} />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold">Import Center</h2>
+          {folderProgress && (
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+              <span>{folderProgress.label} {folderProgress.completed}/{folderProgress.total}</span>
+              <div className="h-1.5 w-40 overflow-hidden rounded-full bg-muted">
+                <div className="h-full bg-primary transition-[width]" style={{ width: `${(folderProgress.completed / folderProgress.total) * 100}%` }} />
+              </div>
             </div>
+          )}
+        </div>
+        <input
+          ref={folderInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          {...DIRECTORY_INPUT_PROPS}
+          onChange={(event) => void uploadFolder(event.currentTarget.files)}
+        />
+        {/* One hint for the whole cluster: the permission and allowed roles are
+            identical for every import source. */}
+        <PermissionHint
+          blocked={!canWrite}
+          action="import components into the catalog"
+          allowedRoles={["designer", "admin"]}
+          className="flex w-full max-w-none"
+        >
+          <div className="mt-4 grid w-full gap-3 xl:grid-cols-2" data-testid="import-source-groups">
+            <section aria-labelledby="library-import-source" className="min-w-0 border bg-card p-3">
+              <div className="flex items-center gap-3">
+                <div className="flex size-9 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
+                  <FolderOpen className="h-4 w-4" />
+                </div>
+                <div className="min-w-0">
+                  <h3 id="library-import-source" className="text-sm font-semibold">KiCad libraries</h3>
+                  <p className="text-xs text-muted-foreground">Symbols, footprints, and 3D models</p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <Button variant="outline" onClick={() => folderInputRef.current?.click()} disabled={!canWrite || creating}>
+                  <FolderOpen className="mr-2 h-4 w-4" />Choose local folder
+                </Button>
+                {serverRoots.length > 0 && (
+                  <>
+                    <div className="hidden h-6 w-px bg-border sm:block" aria-hidden="true" />
+                    <Select value={serverRoot} onValueChange={setServerRoot} disabled={!canWrite || creating}>
+                      <SelectTrigger className="min-w-32 flex-1"><SelectValue placeholder="Server root" /></SelectTrigger>
+                      <SelectContent>{serverRoots.map((root) => <SelectItem key={root.name} value={root.name}>{root.name}</SelectItem>)}</SelectContent>
+                    </Select>
+                    <Input className="min-w-40 flex-1" value={serverSubpath} onChange={(event) => setServerSubpath(event.target.value)} placeholder="Optional subfolder" disabled={creating} />
+                    <Button variant="outline" onClick={() => void importServerFolder()} disabled={!canWrite || creating}>
+                      <HardDrive className="mr-2 h-4 w-4" />Import server folder
+                    </Button>
+                  </>
+                )}
+              </div>
+            </section>
+
+            <section aria-labelledby="project-import-source" className="min-w-0 border bg-card p-3">
+              <div className="flex items-center gap-3">
+                <div className="flex size-9 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
+                  <CircuitBoard className="h-4 w-4" />
+                </div>
+                <div className="min-w-0">
+                  <h3 id="project-import-source" className="text-sm font-semibold">Project components</h3>
+                  <p className="text-xs text-muted-foreground">Parts captured from project revisions</p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <Select value={projectId} onValueChange={setProjectId} disabled={!canWrite || creating}>
+                  <SelectTrigger className="min-w-56 flex-1"><SelectValue placeholder="Select a project" /></SelectTrigger>
+                  <SelectContent>
+                    {projects.map((project) => <SelectItem key={project.id} value={project.id}>{project.display_name || project.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+                <Button variant="outline" onClick={() => void createSession("project")} disabled={!canWrite || !projectId || creating}>Import From Project</Button>
+                <Button onClick={() => void createSession("all-projects")} disabled={!canWrite || creating}>Import From All Projects</Button>
+              </div>
+            </section>
           </div>
+        </PermissionHint>
+        {folderProgress && (
+          <span className="sr-only" aria-live="polite">{folderProgress.label} {folderProgress.completed} of {folderProgress.total}</span>
         )}
       </header>
 

--- a/frontend/src/components/workspace/library-import-center.tsx
+++ b/frontend/src/components/workspace/library-import-center.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type InputHTMLAttributes } from "react";
-import { AlertTriangle, Check, ChevronRight, CircuitBoard, FolderOpen, FolderSearch, HardDrive, LoaderCircle, PanelLeftClose, PanelLeftOpen, RefreshCw, Rows3, Table2, X } from "lucide-react";
+import { AlertTriangle, Check, ChevronRight, CircuitBoard, FolderOpen, FolderSearch, HardDrive, LoaderCircle, PanelLeftClose, PanelLeftOpen, RefreshCw, Table2, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -409,19 +409,7 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="border-b p-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h2 className="text-lg font-semibold">Import Center</h2>
-          {folderProgress && (
-            <div className="flex items-center gap-3 text-xs text-muted-foreground">
-              <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-              <span>{folderProgress.label} {folderProgress.completed}/{folderProgress.total}</span>
-              <div className="h-1.5 w-40 overflow-hidden rounded-full bg-muted">
-                <div className="h-full bg-primary transition-[width]" style={{ width: `${(folderProgress.completed / folderProgress.total) * 100}%` }} />
-              </div>
-            </div>
-          )}
-        </div>
+      <header className="border-b p-3">
         <input
           ref={folderInputRef}
           type="file"
@@ -438,18 +426,15 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
           allowedRoles={["designer", "admin"]}
           className="flex w-full max-w-none"
         >
-          <div className="mt-4 grid w-full gap-3 xl:grid-cols-2" data-testid="import-source-groups">
-            <section aria-labelledby="library-import-source" className="min-w-0 border bg-card p-3">
-              <div className="flex items-center gap-3">
-                <div className="flex size-9 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
+          <div className="grid w-full gap-2 xl:grid-cols-2" data-testid="import-source-groups">
+            <section aria-labelledby="library-import-source" className="flex min-w-0 flex-wrap items-center gap-3 border bg-card p-2">
+              <div className="flex shrink-0 items-center gap-2">
+                <div className="flex size-8 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
                   <FolderOpen className="h-4 w-4" />
                 </div>
-                <div className="min-w-0">
-                  <h3 id="library-import-source" className="text-sm font-semibold">KiCad libraries</h3>
-                  <p className="text-xs text-muted-foreground">Symbols, footprints, and 3D models</p>
-                </div>
+                <h3 id="library-import-source" className="whitespace-nowrap text-sm font-semibold">KiCad libraries</h3>
               </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2">
+              <div className="ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
                 <Button variant="outline" onClick={() => folderInputRef.current?.click()} disabled={!canWrite || creating}>
                   <FolderOpen className="mr-2 h-4 w-4" />Choose local folder
                 </Button>
@@ -469,19 +454,16 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
               </div>
             </section>
 
-            <section aria-labelledby="project-import-source" className="min-w-0 border bg-card p-3">
-              <div className="flex items-center gap-3">
-                <div className="flex size-9 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
+            <section aria-labelledby="project-import-source" className="flex min-w-0 flex-wrap items-center gap-3 border bg-card p-2">
+              <div className="flex shrink-0 items-center gap-2">
+                <div className="flex size-8 shrink-0 items-center justify-center border bg-muted/40 text-muted-foreground">
                   <CircuitBoard className="h-4 w-4" />
                 </div>
-                <div className="min-w-0">
-                  <h3 id="project-import-source" className="text-sm font-semibold">Project components</h3>
-                  <p className="text-xs text-muted-foreground">Parts captured from project revisions</p>
-                </div>
+                <h3 id="project-import-source" className="whitespace-nowrap text-sm font-semibold">Project components</h3>
               </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2">
+              <div className="ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
                 <Select value={projectId} onValueChange={setProjectId} disabled={!canWrite || creating}>
-                  <SelectTrigger className="min-w-56 flex-1"><SelectValue placeholder="Select a project" /></SelectTrigger>
+                  <SelectTrigger className="min-w-40 flex-1"><SelectValue placeholder="Select a project" /></SelectTrigger>
                   <SelectContent>
                     {projects.map((project) => <SelectItem key={project.id} value={project.id}>{project.display_name || project.name}</SelectItem>)}
                   </SelectContent>
@@ -493,7 +475,13 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
           </div>
         </PermissionHint>
         {folderProgress && (
-          <span className="sr-only" aria-live="polite">{folderProgress.label} {folderProgress.completed} of {folderProgress.total}</span>
+          <div className="mt-2 flex items-center justify-end gap-3 text-xs text-muted-foreground" role="status">
+            <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+            <span>{folderProgress.label} {folderProgress.completed}/{folderProgress.total}</span>
+            <div className="h-1.5 w-40 overflow-hidden rounded-full bg-muted">
+              <div className="h-full bg-primary transition-[width]" style={{ width: `${(folderProgress.completed / folderProgress.total) * 100}%` }} />
+            </div>
+          </div>
         )}
       </header>
 
@@ -564,19 +552,12 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
           ) : proposals.length === 0 ? (
             <div className="flex h-full items-center justify-center text-sm text-muted-foreground">{selectedSession.status === "staged" ? "No components were discovered." : selectedSession.scope === "folder" ? "Resolving symbols, footprints, and referenced 3D models…" : "Scanning captured project revisions…"}</div>
           ) : reviewMode === "grid" ? (
-            <div className="space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-sm text-muted-foreground">
-                  Resolve missing metadata and footprints across every row, then import in bulk.
-                </p>
-                <Button variant="outline" size="sm" className="h-8 text-xs" onClick={() => setReviewMode("cards")}>
-                  <Rows3 className="mr-1.5 h-3.5 w-3.5" />Detail view
-                </Button>
-              </div>
+            <div>
               <LibraryImportRemediationGrid
                 sessionId={selectedSession.id}
                 proposals={proposals}
                 canWrite={canWrite}
+                onShowDetailView={() => setReviewMode("cards")}
                 onRefresh={async () => {
                   await Promise.all([loadSessions(), loadProposals(selectedSession.id)]);
                 }}

--- a/frontend/src/components/workspace/library-import-remediation-grid-layout.test.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-grid-layout.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProjectComponentImportProposal } from "@/types/catalog";
+import { LibraryImportRemediationGrid } from "./library-import-remediation-grid";
+
+const proposal: ProjectComponentImportProposal = {
+  id: "proposal-1",
+  session_id: "session-1",
+  dedupe_key: "key-1",
+  component_uid: "uid-1",
+  reference: "C1",
+  status: "candidate",
+  accepted_component_id: "",
+  metadata: {
+    value: "10uF_50V_1210",
+    manufacturer: "Samsung Electro-Mechanics",
+    manufacturer_part_number: "CL32B106KBJNNNE",
+    description: "Unpolarized capacitor",
+    datasheet: "https://example.com/datasheet.pdf",
+    footprint: "Capacitor_SMD:C_1210_3225Metric",
+  },
+  assets: [
+    {
+      asset_type: "symbol",
+      filename: "C.kicad_sym",
+      sha256: "a".repeat(64),
+      size_bytes: 128,
+      target_library: "Prism_Imported",
+      target_name: "C",
+      source_path: "project/C.kicad_sym",
+    },
+    {
+      asset_type: "footprint",
+      filename: "C_1210.kicad_mod",
+      sha256: "b".repeat(64),
+      size_bytes: 256,
+      target_library: "Prism_Imported",
+      target_name: "C_1210",
+      source_path: "project/C_1210.kicad_mod",
+    },
+  ],
+  provenance: [],
+  findings: [],
+};
+
+describe("LibraryImportRemediationGrid layout", () => {
+  it("keeps controls and column headings outside the scrolling rows", () => {
+    render(
+      <LibraryImportRemediationGrid
+        sessionId="session-1"
+        proposals={[proposal]}
+        canWrite
+        onShowDetailView={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("import-remediation-grid")).toHaveClass("h-full", "min-h-0", "flex-col");
+    expect(screen.getByTestId("import-remediation-controls")).toHaveClass("shrink-0");
+    expect(screen.getByTestId("import-remediation-scroll-region")).toHaveClass(
+      "min-h-0",
+      "flex-1",
+      "overflow-auto",
+    );
+    expect(screen.getByTestId("import-remediation-column-headings")).toHaveClass(
+      "sticky",
+      "top-0",
+      "bg-muted",
+    );
+  });
+});

--- a/frontend/src/components/workspace/library-import-remediation-grid-layout.test.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-grid-layout.test.tsx
@@ -68,5 +68,7 @@ describe("LibraryImportRemediationGrid layout", () => {
       "top-0",
       "bg-muted",
     );
+    expect(screen.queryByText(/Each row is one catalog component/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Showing one row per placed reference/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/workspace/library-import-remediation-grid.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-grid.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle, ArrowDownToLine, Check, CheckCheck, Combine, Download, Loader2, Redo2, Save,
-  Undo2, Upload,
+  Rows3, Undo2, Upload,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -23,6 +23,7 @@ interface LibraryImportRemediationGridProps {
   sessionId: string;
   proposals: ProjectComponentImportProposal[];
   canWrite: boolean;
+  onShowDetailView: () => void;
   onRefresh: () => Promise<void> | void;
 }
 
@@ -215,6 +216,7 @@ export function LibraryImportRemediationGrid({
   sessionId,
   proposals,
   canWrite,
+  onShowDetailView,
   onRefresh,
 }: LibraryImportRemediationGridProps) {
   // Every cell edit, fill-down, and link change pushes the previous state here so a
@@ -543,34 +545,36 @@ export function LibraryImportRemediationGrid({
           Group by MPN
           {groupByMpn && mergedGroupCount > 0 ? ` (${mergedGroupCount} merged)` : ""}
         </Button>
+        <Button variant="outline" size="sm" className="ml-auto h-8 text-xs" onClick={onShowDetailView}>
+          <Rows3 className="mr-1.5 h-3.5 w-3.5" />Detail view
+        </Button>
 
         <PermissionHint
           blocked={!canWrite}
           action="edit or accept import proposals"
           allowedRoles={["designer", "admin"]}
-          className="ml-auto"
+          className="basis-full"
         >
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex w-full basis-full flex-wrap items-center gap-2">
           <Button
             variant="outline"
-            size="sm"
-            className="h-8 text-xs"
+            size="icon-sm"
+            aria-label="Undo"
             title="Undo (⌘Z)"
             disabled={!canWrite || undoStack.length === 0}
             onClick={undo}
           >
-            <Undo2 className="mr-1.5 h-3.5 w-3.5" /> Undo
+            <Undo2 className="h-3.5 w-3.5" />
           </Button>
           <Button
             variant="outline"
-            size="sm"
-            className="h-8 text-xs"
+            size="icon-sm"
+            aria-label="Redo"
             title="Redo (⇧⌘Z)"
             disabled={!canWrite || redoStack.length === 0}
             onClick={redo}
           >
             <Redo2 className="h-3.5 w-3.5" />
-            <span className="sr-only">Redo</span>
           </Button>
           <Button variant="outline" size="sm" className="h-8 text-xs" onClick={exportCsv}>
             <Download className="mr-1.5 h-3.5 w-3.5" /> Export CSV
@@ -605,29 +609,31 @@ export function LibraryImportRemediationGrid({
             )}
             Save edits{dirtyCount > 0 ? ` (${dirtyCount})` : ""}
           </Button>
-          <Button
-            size="sm"
-            className="h-8 text-xs"
-            disabled={!canWrite || accepting || selectedReady.length === 0}
-            onClick={() => void acceptRows(selectedReady)}
-          >
-            {accepting ? (
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Check className="mr-1.5 h-3.5 w-3.5" />
-            )}
-            Import selected ({selectedReady.length})
-          </Button>
-          <Button
-            size="sm"
-            variant="secondary"
-            className="h-8 text-xs"
-            disabled={!canWrite || accepting || readyRows.length === 0}
-            onClick={() => void acceptRows(readyRows)}
-          >
-            <CheckCheck className="mr-1.5 h-3.5 w-3.5" />
-            Import all ready ({readyRows.length})
-          </Button>
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              size="sm"
+              className="h-8 text-xs"
+              disabled={!canWrite || accepting || selectedReady.length === 0}
+              onClick={() => void acceptRows(selectedReady)}
+            >
+              {accepting ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Check className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              Import selected ({selectedReady.length})
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="h-8 text-xs"
+              disabled={!canWrite || accepting || readyRows.length === 0}
+              onClick={() => void acceptRows(readyRows)}
+            >
+              <CheckCheck className="mr-1.5 h-3.5 w-3.5" />
+              Import all ready ({readyRows.length})
+            </Button>
+          </div>
         </div>
         </PermissionHint>
       </div>

--- a/frontend/src/components/workspace/library-import-remediation-grid.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-grid.tsx
@@ -517,8 +517,8 @@ export function LibraryImportRemediationGrid({
   const gridTemplate = `36px 40px 150px ${COLUMNS.map((column) => `${column.width}px`).join(" ")} 200px`;
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-2">
+    <div className="flex h-full min-h-0 flex-col gap-3" data-testid="import-remediation-grid">
+      <div className="flex shrink-0 flex-wrap items-center gap-2" data-testid="import-remediation-controls">
         <Input
           value={filter}
           onChange={(event) => setFilter(event.target.value)}
@@ -638,10 +638,11 @@ export function LibraryImportRemediationGrid({
         </PermissionHint>
       </div>
 
-      <div className="overflow-x-auto border">
+      <div className="themed-scrollbar min-h-0 flex-1 overflow-auto border" data-testid="import-remediation-scroll-region">
         <div className="min-w-max">
           <div
-            className="sticky top-0 z-20 grid items-center border-b bg-muted/60 text-xs font-medium"
+            className="sticky top-0 z-20 grid items-center border-b bg-muted text-xs font-medium"
+            data-testid="import-remediation-column-headings"
             style={{ gridTemplateColumns: gridTemplate }}
           >
             <div className="flex h-9 items-center justify-center border-r">
@@ -769,7 +770,7 @@ export function LibraryImportRemediationGrid({
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+      <div className="flex shrink-0 flex-wrap items-center gap-3 text-xs text-muted-foreground">
         <Badge variant="outline">{visibleRows.length} shown</Badge>
         <Badge variant="outline">{readyRows.length} ready</Badge>
         <Badge variant="outline">{groups.length - readyRows.length} need attention</Badge>

--- a/frontend/src/components/workspace/library-import-remediation-grid.tsx
+++ b/frontend/src/components/workspace/library-import-remediation-grid.tsx
@@ -774,11 +774,6 @@ export function LibraryImportRemediationGrid({
         <Badge variant="outline">{visibleRows.length} shown</Badge>
         <Badge variant="outline">{readyRows.length} ready</Badge>
         <Badge variant="outline">{groups.length - readyRows.length} need attention</Badge>
-        <span>
-          {groupByMpn
-            ? "Each row is one catalog component. Linking a footprint reuses an existing asset instead of importing a duplicate."
-            : "Showing one row per placed reference. Linking a footprint reuses an existing asset instead of importing a duplicate."}
-        </span>
       </div>
     </div>
   );

--- a/frontend/src/components/workspace/library-release-queue.test.tsx
+++ b/frontend/src/components/workspace/library-release-queue.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchJson } from "@/lib/api";
+import { LibraryReleaseQueue } from "./library-release-queue";
+
+vi.mock("@/lib/api", () => ({ fetchJson: vi.fn() }));
+
+describe("LibraryReleaseQueue empty states", () => {
+  beforeEach(() => {
+    vi.mocked(fetchJson).mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      page_size: 50,
+      pages: 1,
+      summary: { qa_review: 0, done: 0, blocked: 0 },
+    });
+  });
+
+  it("keeps the unfiltered empty state concise", async () => {
+    render(
+      <MemoryRouter>
+        <LibraryReleaseQueue onOpenComponent={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Release queue is clear")).toBeInTheDocument();
+    expect(screen.queryByText(/Components submitted for QA/)).not.toBeInTheDocument();
+  });
+
+  it("retains recovery guidance when filters hide every result", async () => {
+    render(
+      <MemoryRouter initialEntries={["/?releaseQueueStage=qa_review"]}>
+        <LibraryReleaseQueue onOpenComponent={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("No matching release work")).toBeInTheDocument();
+    expect(screen.getByText("Try a different search or stage filter.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workspace/library-release-queue.tsx
+++ b/frontend/src/components/workspace/library-release-queue.tsx
@@ -109,7 +109,7 @@ function QueueEmpty({ filtered }: { filtered: boolean }) {
     <div className="flex min-h-64 flex-col items-center justify-center gap-2 border border-dashed p-6 text-center">
       <ClipboardCheck className="h-7 w-7 text-muted-foreground" />
       <p className="text-sm font-medium">{filtered ? "No matching release work" : "Release queue is clear"}</p>
-      <p className="max-w-xl text-xs text-muted-foreground">{filtered ? "Try a different search or stage filter." : "Components submitted for QA or approved for release will appear here automatically."}</p>
+      {filtered ? <p className="max-w-xl text-xs text-muted-foreground">Try a different search or stage filter.</p> : null}
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -86,6 +86,26 @@
   }
 }
 
+@layer components {
+  /* The workspace sidebar changes this region's width without changing the
+     viewport breakpoint. Size the import cards from their own container so
+     the project controls keep a single row in either shell state. */
+  .import-sources-container {
+    container: import-sources / inline-size;
+  }
+
+  @container import-sources (min-width: 72rem) {
+    .import-source-groups--split {
+      grid-template-columns: minmax(23rem, 1fr) minmax(0, 2fr);
+    }
+
+    .import-source-card,
+    .import-source-controls {
+      flex-wrap: nowrap;
+    }
+  }
+}
+
 @layer utilities {
   .bg-preview-surface {
     background-color: hsl(var(--preview-surface));


### PR DESCRIPTION
## What this changes

The Import Center presented every component-import source in one undifferentiated toolbar. A local KiCad library folder, a read-only server folder, one selected project, and every project all looked like variations of the same action. At common desktop widths the controls also wrapped without preserving those relationships, which made the top of the page difficult to scan and made **Import project** sound like it was importing a project into Prism rather than capturing components from an existing project.

This PR gives the two source families their own bounded panels:

- **KiCad libraries** contains local-folder and server-folder capture.
- **Project components** contains the project selector, **Import From Project**, and **Import From All Projects**.

The existing APIs, permissions, loading state, folder progress, and import-session behavior are unchanged. The layout uses the existing semantic theme tokens, lucide icons, controls, and responsive wrapping rules.

## Release preparation

The release review found that the planned v3.1.0-alpha promotion is code-ready but is not merely a cosmetic release. Relative to the authoritative v3.0.2-alpha commit, dev includes Release Studio and the intentional catalog epoch-2 boundary. This PR therefore adds concise v3.1.0-alpha release notes with the backup, survivor-export, CERN-preflight, catalog-reset, and restore warning linked to the complete upgrade runbook.

The release tag must still wait for this PR to merge into `dev`, a reviewed `dev` to `main` promotion, and a successful `main` Quality Gate. The tag workflow independently refuses a commit without that successful main run.

## Verification

- Focused Import Center test: 1 passed.
- Complete frontend suite: 491 tests passed across 62 files.
- Frontend lint: passed.
- React Doctor gate: 0 errors and 0 warnings at baseline.
- Frontend production build: passed.
- Remote Symbol Provider panel build: passed.
- Release metadata parser accepts `v3.1.0-alpha` as a prerelease and emits only the `3.1.0-alpha` image tag.
- Release-bundle unit tests: 4 passed.
- Latest pre-PR `dev` Quality Gate at `4f916abd` passed Frontend, Backend, Semantic viewer, Deployment configuration, Dependency identity, and live KiCad Release Studio lanes.

The local browser safety layer blocked localhost visual automation. The layout was reviewed against the supplied screenshots, the rendered DOM is covered by the focused test, and the production build completed successfully.
