### PR TITLE
fix(import): identify a project by its file, not its directory

### DIFF
--- a/backend/app/api/_helpers.py
+++ b/backend/app/api/_helpers.py
@@ -36,6 +36,7 @@ def _row_to_project(row: dict) -> project_service.Project:
         registered_at=row.get("registered_at"),
         thumbnail_url=project_service.thumbnail_url_for_row(row),
         sub_path=row.get("relative_path") if row.get("relative_path") != "." else None,
+        project_file=row.get("project_file_rel") or None,
         parent_repo=row.get("parent_repo"),
         repo_url=row.get("repo_url"),
         import_type=row.get("import_type"),

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -168,7 +168,7 @@ def _default_commit_path_config() -> PathConfig:
 
 def _path_config_from_commit(project: project_service.Project, commit: Optional[str]) -> PathConfig:
     if not commit:
-        return path_config_service.get_path_config(project.path)
+        return project_service.path_config_for(project)
 
     repo_path, sub_path = _repo_context(project)
     try:
@@ -406,7 +406,7 @@ def _load_project_readme_content(
                 return None
             raise
 
-    resolved = path_config_service.resolve_paths(project.path, config)
+    resolved = project_service.resolved_paths_for(project, config)
     readme_path = resolved.readme_path
     if not readme_path:
         return None
@@ -1128,8 +1128,9 @@ def _build_project_properties(project: project_service.Project) -> ProjectProper
     latest_commit = latest_commits[0] if latest_commits else None
     latest_tag = releases[0] if releases else None
 
-    schematic_path = project_service.find_schematic_file(project.path)
-    pcb_path = project_service.find_pcb_file(project.path)
+    anchor = project_service.project_anchor(project)
+    schematic_path = project_service.find_schematic_file(project.path, anchor)
+    pcb_path = project_service.find_pcb_file(project.path, anchor)
     schematic_metadata = project_properties_service.extract_schematic_metadata(project.path, schematic_path)
     pcb_metadata = project_properties_service.extract_pcb_metadata(project.path, pcb_path)
 
@@ -1633,7 +1634,9 @@ async def get_project_schematic(
         )
         return _commit_file_response(commit_file, inline=True)
     
-    path = project_service.find_schematic_file(project.path)
+    path = project_service.find_schematic_file(
+        project.path, project_service.project_anchor(project)
+    )
     if not path:
         raise HTTPException(status_code=404, detail="Schematic not found")
     return FileResponse(path)
@@ -1680,7 +1683,9 @@ async def get_project_subsheets(
         ]
         return {"files": subsheet_urls}
     
-    main_path = project_service.find_schematic_file(project.path)
+    main_path = project_service.find_schematic_file(
+        project.path, project_service.project_anchor(project)
+    )
     if not main_path:
         raise HTTPException(status_code=404, detail="Schematic not found")
         
@@ -1761,7 +1766,9 @@ async def get_project_viewer_support_files(
                 )
         return {"files": files}
 
-    project_file = semantic_visualizer_service.find_kicad_project(project.path)
+    project_file = semantic_visualizer_service.find_kicad_project(
+        project.path, project_service.project_anchor(project)
+    )
     files = [
         {
             "filename": project_file.name,
@@ -1818,7 +1825,9 @@ async def get_project_pcb(
         )
         return _commit_file_response(commit_file, inline=True)
     
-    path = project_service.find_pcb_file(project.path)
+    path = project_service.find_pcb_file(
+        project.path, project_service.project_anchor(project)
+    )
     if not path:
         raise HTTPException(status_code=404, detail="PCB not found")
     return FileResponse(path)
@@ -1878,9 +1887,10 @@ async def get_project_config(project_id: str, user: AuthenticatedUser = Depends(
     """
     project = get_project_for_role_or_404(project_id, user.role)
     
-    config = path_config_service.get_path_config(project.path)
-    resolved = path_config_service.resolve_paths(project.path, config)
-    explicit_config = path_config_service._load_prism_config(project.path)
+    anchor = project_service.project_anchor(project)
+    config = project_service.path_config_for(project)
+    resolved = project_service.resolved_paths_for(project, config)
+    explicit_config = path_config_service._load_prism_config(project.path, anchor)
     effective_config = config.model_copy(deep=True)
     if not effective_config.project_name:
         effective_config.project_name = project.display_name
@@ -1934,14 +1944,14 @@ async def update_project_config(
     validation = path_config_service.validate_config(project.path, config)
     
     # Save the configuration
-    path_config_service.save_path_config(project.path, config)
-    
+    project_service.save_path_config_for(project, config)
+
     # Clear cache to ensure fresh resolution
     path_config_service.clear_config_cache(project.path)
     file_service.invalidate_file_listing_cache()
-    
+
     # Get resolved paths
-    resolved = path_config_service.resolve_paths(project.path, config)
+    resolved = project_service.resolved_paths_for(project, config)
     
     return {
         "config": config.model_dump(),
@@ -1988,13 +1998,13 @@ async def update_project_name(
         raise HTTPException(status_code=400, detail="Display name cannot be empty")
 
     # Get current config
-    config = path_config_service.get_path_config(project.path)
-    
+    config = project_service.path_config_for(project)
+
     # Update project name
     config.project_name = display_name
     
     # Save to .prism.json
-    path_config_service.save_path_config(project.path, config)
+    project_service.save_path_config_for(project, config)
     await asyncio.to_thread(workspace.update_project, project_id, display_name=display_name)
     
     return {
@@ -2035,9 +2045,9 @@ async def update_project_description(
         raise HTTPException(status_code=404, detail="Project not found")
 
     # Also persist to .prism.json for compatibility
-    config = path_config_service.get_path_config(project.path)
+    config = project_service.path_config_for(project)
     config.description = next_description
-    path_config_service.save_path_config(project.path, config)
+    project_service.save_path_config_for(project, config)
 
     return {
         "description": next_description,

--- a/backend/app/services/path_config_service.py
+++ b/backend/app/services/path_config_service.py
@@ -146,6 +146,55 @@ def _normalize_config_values(config: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
+def anchor_stem(anchor: Optional[str]) -> Optional[str]:
+    """The bare name a project's files share, e.g. ``top`` for ``top.kicad_pro``.
+
+    A directory may hold more than one KiCad project -- KiCad allows it, and
+    teams use it for the two halves of a fixture. The anchor is the one file
+    that says which of them a Prism project is, so every "guess the board"
+    fallback below can be skipped when it is known.
+    """
+    if not anchor:
+        return None
+    stem = Path(anchor).stem.strip()
+    return stem or None
+
+
+def anchor_for_project(project: Any) -> Optional[str]:
+    """The anchor recorded for a project, given a `Project` model or a DB row."""
+    if isinstance(project, dict):
+        value = project.get("project_file_rel")
+    else:
+        value = getattr(project, "project_file", None)
+    return str(value or "").strip() or None
+
+
+def _sibling_project_stems(project_path: Path, anchor: Optional[str]) -> set[str]:
+    """Stems belonging to the *other* KiCad projects in this directory.
+
+    KiCad associates a project's files by name: `top.kicad_pro` owns
+    `top.kicad_pcb` and `top.kicad_sch`, and nothing else. Prism's detectors
+    fall back to "the first board in the directory" when no name matches, which
+    is right for a lone project whose board is named differently, and wrong the
+    moment a sibling project is standing next to it -- that fallback is how a
+    project ended up rendering its neighbour's board. Excluding files another
+    project owns keeps the fallback without letting it cross that line.
+    """
+    stem = anchor_stem(anchor)
+    if not stem:
+        return set()
+    try:
+        stems = {item.stem for item in project_path.glob("*.kicad_pro")}
+    except OSError:
+        return set()
+    return {other for other in stems if other.casefold() != stem.casefold()}
+
+
+def _cache_key(project_path: str, anchor: Optional[str] = None) -> str:
+    key = str(Path(project_path).resolve())
+    return f"{key}\0{anchor}" if anchor else key
+
+
 def _get_prism_mtime(project_path: str) -> Optional[float]:
     """Return .prism.json mtime to validate cached config freshness."""
     config_path = Path(project_path) / ".prism.json"
@@ -157,25 +206,49 @@ def _get_prism_mtime(project_path: str) -> Optional[float]:
         return None
 
 
-def _load_prism_config(project_path: str) -> Optional[Dict[str, Any]]:
-    """Load .prism.json configuration if it exists."""
+def _flatten_prism_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten one `.prism.json` object into a single mapping of settings."""
+    result: Dict[str, Any] = {}
+    # Handle legacy format with paths nested
+    if isinstance(config.get("paths"), dict):
+        result.update(config["paths"])
+    # Add top-level fields like project_name
+    for key, value in config.items():
+        if key not in ("paths", "projects"):
+            result[key] = value
+    return result
+
+
+def _load_prism_config(
+    project_path: str, anchor: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Load .prism.json configuration if it exists.
+
+    One `.prism.json` sits per directory, but a directory can hold more than one
+    project. Settings for a particular project live under
+    ``projects.<anchor>``; the flat/`paths` shape every existing file uses stays
+    the shared default, so nothing written by an earlier Prism stops working.
+    """
     config_path = Path(project_path) / ".prism.json"
-    if config_path.exists():
-        try:
-            with open(config_path, 'r', encoding='utf-8') as f:
-                config = json.load(f)
-                result = {}
-                # Handle legacy format with paths nested
-                if "paths" in config:
-                    result.update(config["paths"])
-                # Add top-level fields like project_name
-                for key, value in config.items():
-                    if key != "paths":
-                        result[key] = value
-                return result
-        except (json.JSONDecodeError, IOError) as e:
-            logger.warning("Failed to parse .prism.json: %s", e)
-    return None
+    if not config_path.exists():
+        return None
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning("Failed to parse .prism.json: %s", e)
+        return None
+    if not isinstance(config, dict):
+        return None
+
+    result = _flatten_prism_config(config)
+    if anchor:
+        namespaced = config.get("projects")
+        if isinstance(namespaced, dict):
+            entry = namespaced.get(anchor)
+            if isinstance(entry, dict):
+                result.update(_flatten_prism_config(entry))
+    return result
 
 
 def _find_files_by_pattern(directory: Path, pattern: str) -> List[Path]:
@@ -224,7 +297,11 @@ def _find_directory_by_keywords(directory: Path, keywords: List[str], required_c
     return None
 
 
-def _select_root_schematic(project_path: Path, candidates: List[Path]) -> Optional[Path]:
+def _select_root_schematic(
+    project_path: Path,
+    candidates: List[Path],
+    anchor: Optional[str] = None,
+) -> Optional[Path]:
     """Select the project root schematic from candidate .kicad_sch files."""
     sch_files = sorted(
         {candidate for candidate in candidates if candidate.is_file()},
@@ -232,6 +309,23 @@ def _select_root_schematic(project_path: Path, candidates: List[Path]) -> Option
     )
     if not sch_files:
         return None
+
+    stem = anchor_stem(anchor)
+    if stem:
+        for sch_file in sch_files:
+            if sch_file.stem.casefold() == stem.casefold():
+                return sch_file
+        # No schematic of this project's own name: fall through to the general
+        # rules, but never onto a schematic another project in this directory
+        # owns.
+        owned_elsewhere = _sibling_project_stems(project_path, anchor)
+        sch_files = [
+            sch_file
+            for sch_file in sch_files
+            if sch_file.stem.casefold() not in {s.casefold() for s in owned_elsewhere}
+        ]
+        if not sch_files:
+            return None
 
     pro_files = sorted(project_path.glob("*.kicad_pro"), key=lambda item: item.name.casefold())
     for pro_file in pro_files:
@@ -250,29 +344,47 @@ def _select_root_schematic(project_path: Path, candidates: List[Path]) -> Option
     return None
 
 
-def _detect_schematic_path(project_path: Path) -> Optional[str]:
+def _detect_schematic_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect main schematic file path."""
-    selected = _select_root_schematic(project_path, list(project_path.glob("*.kicad_sch")))
+    selected = _select_root_schematic(
+        project_path, list(project_path.glob("*.kicad_sch")), anchor
+    )
     if not selected:
         return None
     return selected.relative_to(project_path).as_posix()
 
 
-def _detect_pcb_path(project_path: Path) -> Optional[str]:
+def _detect_pcb_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect main PCB file path."""
-    # Look for .kicad_pcb files in root
-    pcb_files = list(project_path.glob("*.kicad_pcb"))
-    if pcb_files:
-        # Prefer one matching project directory name, otherwise first found
-        project_name = project_path.name
+    # Look for .kicad_pcb files in root. Sorted, because `glob` yields whatever
+    # order the filesystem hands back: a directory with two boards used to
+    # resolve to a different one depending on the machine.
+    pcb_files = sorted(project_path.glob("*.kicad_pcb"), key=lambda item: item.name.casefold())
+    if not pcb_files:
+        return None
+
+    # The anchor names this project's board outright; nothing below can beat it.
+    stem = anchor_stem(anchor)
+    if stem:
         for pcb in pcb_files:
-            if pcb.stem.lower() == project_name.lower():
+            if pcb.stem.casefold() == stem.casefold():
                 return pcb.name
-        return pcb_files[0].name
-    return None
+        # Same rule as KiCad's: a board named after another project in this
+        # directory belongs to that project, not to this one.
+        owned_elsewhere = {s.casefold() for s in _sibling_project_stems(project_path, anchor)}
+        pcb_files = [pcb for pcb in pcb_files if pcb.stem.casefold() not in owned_elsewhere]
+        if not pcb_files:
+            return None
+
+    # Prefer one matching project directory name, otherwise first found
+    project_name = project_path.name
+    for pcb in pcb_files:
+        if pcb.stem.lower() == project_name.lower():
+            return pcb.name
+    return pcb_files[0].name
 
 
-def _detect_subsheets_path(project_path: Path) -> Optional[str]:
+def _detect_subsheets_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect subsheets directory."""
     # Look for directories containing .kicad_sch files (excluding root)
     keywords = ["sheet", "schematic", "sch", "page", "hierarchical", "sub"]
@@ -299,28 +411,28 @@ def _detect_subsheets_path(project_path: Path) -> Optional[str]:
     return None
 
 
-def _detect_design_outputs_path(project_path: Path) -> Optional[str]:
+def _detect_design_outputs_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect design outputs directory."""
     keywords = ["output", "export", "build", "dist", "release", "artefact", "artifact"]
     required_content = ["*.pdf", "*.html", "*.step", "*.glb", "*.csv", "*.net"]
     return _find_directory_by_keywords(project_path, keywords, required_content)
 
 
-def _detect_manufacturing_outputs_path(project_path: Path) -> Optional[str]:
+def _detect_manufacturing_outputs_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect manufacturing outputs directory."""
     keywords = ["gerber", "fab", "mfg", "manufacturing", "production", "pcbfab"]
     required_content = ["*.gbr", "*.drl", "*.txt", "*.zip"]
     return _find_directory_by_keywords(project_path, keywords, required_content)
 
 
-def _detect_documentation_path(project_path: Path) -> Optional[str]:
+def _detect_documentation_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect documentation directory."""
     keywords = ["doc", "wiki", "guide", "manual", "help", "reference"]
     required_content = ["*.md", "*.txt", "*.pdf"]
     return _find_directory_by_keywords(project_path, keywords, required_content)
 
 
-def _detect_thumbnail_path(project_path: Path) -> Optional[str]:
+def _detect_thumbnail_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect thumbnail/images directory."""
     # First check for assets subdirectory
     assets_dir = project_path / "assets"
@@ -336,7 +448,7 @@ def _detect_thumbnail_path(project_path: Path) -> Optional[str]:
     return _find_directory_by_keywords(project_path, keywords)
 
 
-def _detect_readme_path(project_path: Path) -> Optional[str]:
+def _detect_readme_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect README file path."""
     patterns = ["README*", "readme*", "INDEX*", "index*", "OVERVIEW*", "overview*"]
     for pattern in patterns:
@@ -347,12 +459,19 @@ def _detect_readme_path(project_path: Path) -> Optional[str]:
     return None
 
 
-def _detect_jobset_path(project_path: Path) -> Optional[str]:
+def _detect_jobset_path(project_path: Path, anchor: Optional[str] = None) -> Optional[str]:
     """Detect KiCAD jobset file path."""
-    jobset_files = list(project_path.glob("*.kicad_jobset"))
-    if jobset_files:
-        return jobset_files[0].name
-    return None
+    jobset_files = sorted(
+        project_path.glob("*.kicad_jobset"), key=lambda item: item.name.casefold()
+    )
+    if not jobset_files:
+        return None
+    stem = anchor_stem(anchor)
+    if stem:
+        for jobset in jobset_files:
+            if jobset.stem.casefold() == stem.casefold():
+                return jobset.name
+    return jobset_files[0].name
 
 
 PATH_DETECTORS = {
@@ -368,44 +487,54 @@ PATH_DETECTORS = {
 }
 
 
-def detect_paths(project_path: str) -> PathConfig:
+def detect_paths(project_path: str, anchor: Optional[str] = None) -> PathConfig:
     """
     Auto-detect path configuration for a project.
-    
+
     Args:
         project_path: Absolute path to project root
-        
+        anchor: This project's own ``.kicad_pro``/board filename, when the
+            directory holds more than one project
+
     Returns:
         PathConfig with detected paths
     """
     project_dir = Path(project_path)
-    
+
     return PathConfig(
-        schematic=_detect_schematic_path(project_dir),
-        pcb=_detect_pcb_path(project_dir),
-        subsheets=_detect_subsheets_path(project_dir),
-        designOutputs=_detect_design_outputs_path(project_dir),
-        manufacturingOutputs=_detect_manufacturing_outputs_path(project_dir),
-        documentation=_detect_documentation_path(project_dir),
-        thumbnail=_detect_thumbnail_path(project_dir),
-        readme=_detect_readme_path(project_dir),
-        jobset=_detect_jobset_path(project_dir)
+        schematic=_detect_schematic_path(project_dir, anchor),
+        pcb=_detect_pcb_path(project_dir, anchor),
+        subsheets=_detect_subsheets_path(project_dir, anchor),
+        designOutputs=_detect_design_outputs_path(project_dir, anchor),
+        manufacturingOutputs=_detect_manufacturing_outputs_path(project_dir, anchor),
+        documentation=_detect_documentation_path(project_dir, anchor),
+        thumbnail=_detect_thumbnail_path(project_dir, anchor),
+        readme=_detect_readme_path(project_dir, anchor),
+        jobset=_detect_jobset_path(project_dir, anchor)
     )
 
 
-def get_path_config(project_path: str, use_cache: bool = True) -> PathConfig:
+def get_path_config(
+    project_path: str,
+    use_cache: bool = True,
+    anchor: Optional[str] = None,
+) -> PathConfig:
     """
     Get path configuration for a project.
     Priority: 1) .prism.json, 2) auto-detect, 3) defaults
-    
+
     Args:
         project_path: Absolute path to project root
         use_cache: Whether to use cached config
-        
+        anchor: This project's own ``.kicad_pro``/board filename, when the
+            directory holds more than one project
+
     Returns:
         PathConfig with resolved paths
     """
-    cache_key = str(Path(project_path).resolve())
+    # Two projects can share a directory, so the directory alone does not
+    # identify a configuration.
+    cache_key = _cache_key(project_path, anchor)
     prism_mtime = _get_prism_mtime(project_path)
     
     # Check cache
@@ -417,12 +546,12 @@ def get_path_config(project_path: str, use_cache: bool = True) -> PathConfig:
     project_dir = Path(project_path)
 
     # Start from explicit config so complete `.prism.json` files skip auto-detection.
-    explicit_config = _normalize_config_values(_load_prism_config(project_path) or {})
+    explicit_config = _normalize_config_values(_load_prism_config(project_path, anchor) or {})
     merged_dict: Dict[str, Any] = dict(explicit_config)
 
     for key in PATH_FIELDS:
         if merged_dict.get(key) is None:
-            detected_value = PATH_DETECTORS[key](project_dir)
+            detected_value = PATH_DETECTORS[key](project_dir, anchor)
             if detected_value is not None:
                 merged_dict[key] = detected_value
             elif key != "subsheets":
@@ -436,19 +565,25 @@ def get_path_config(project_path: str, use_cache: bool = True) -> PathConfig:
     return merged
 
 
-def resolve_paths(project_path: str, config: Optional[PathConfig] = None) -> ResolvedPaths:
+def resolve_paths(
+    project_path: str,
+    config: Optional[PathConfig] = None,
+    anchor: Optional[str] = None,
+) -> ResolvedPaths:
     """
     Resolve all paths to absolute paths.
-    
+
     Args:
         project_path: Absolute path to project root
         config: Optional PathConfig (will be loaded if not provided)
-        
+        anchor: This project's own ``.kicad_pro``/board filename, when the
+            directory holds more than one project
+
     Returns:
         ResolvedPaths with absolute paths
     """
     if config is None:
-        config = get_path_config(project_path)
+        config = get_path_config(project_path, anchor=anchor)
     
     project_dir = Path(project_path)
     
@@ -462,7 +597,9 @@ def resolve_paths(project_path: str, config: Optional[PathConfig] = None) -> Res
     schematic_path = None
     if config.schematic:
         if '*' in config.schematic:
-            selected = _select_root_schematic(project_dir, list(project_dir.glob(config.schematic)))
+            selected = _select_root_schematic(
+                project_dir, list(project_dir.glob(config.schematic)), anchor
+            )
             if selected:
                 schematic_path = str(selected)
         else:
@@ -471,9 +608,25 @@ def resolve_paths(project_path: str, config: Optional[PathConfig] = None) -> Res
     pcb_path = None
     if config.pcb:
         if '*' in config.pcb:
-            matches = list(project_dir.glob(config.pcb))
-            if matches:
-                pcb_path = str(matches[0])
+            matches = sorted(project_dir.glob(config.pcb), key=lambda item: item.name.casefold())
+            stem = anchor_stem(anchor)
+            anchored = next(
+                (item for item in matches if stem and item.stem.casefold() == stem.casefold()),
+                None,
+            )
+            if anchored is None and stem:
+                # A default glob must not sweep up a board another project in
+                # this directory owns.
+                owned_elsewhere = {
+                    other.casefold()
+                    for other in _sibling_project_stems(project_dir, anchor)
+                }
+                matches = [
+                    item for item in matches if item.stem.casefold() not in owned_elsewhere
+                ]
+            chosen = anchored or (matches[0] if matches else None)
+            if chosen:
+                pcb_path = str(chosen)
         else:
             pcb_path = resolve_path(config.pcb)
     
@@ -535,13 +688,22 @@ def get_portfolio_config(project_path: str) -> Optional[Dict[str, Any]]:
     return config.portfolio
 
 
-def save_path_config(project_path: str, config: PathConfig) -> None:
+def save_path_config(
+    project_path: str,
+    config: PathConfig,
+    anchor: Optional[str] = None,
+) -> None:
     """
     Save path configuration to .prism.json.
-    
+
+    With an anchor the settings are written under ``projects.<anchor>`` so the
+    two projects sharing a directory keep separate paths; without one they are
+    written flat, exactly as before.
+
     Args:
         project_path: Absolute path to project root
         config: PathConfig to save
+        anchor: This project's own ``.kicad_pro``/board filename
     """
     config_path = Path(project_path) / ".prism.json"
     
@@ -556,27 +718,42 @@ def save_path_config(project_path: str, config: PathConfig) -> None:
     
     # Update paths and other fields
     config_dict = config.dict(exclude_none=True)
-    
-    # Separate paths and other fields
-    if "paths" not in existing:
-        existing["paths"] = {}
-    
+    non_path_fields = ["project_name", "description", "workflows", "portfolio"]
+
+    if anchor:
+        namespaced = existing.get("projects")
+        if not isinstance(namespaced, dict):
+            namespaced = {}
+            existing["projects"] = namespaced
+        entry = namespaced.get(anchor)
+        if not isinstance(entry, dict):
+            entry = {}
+            namespaced[anchor] = entry
+        target_paths = entry.setdefault("paths", {})
+        target_top = entry
+    else:
+        # Separate paths and other fields
+        if not isinstance(existing.get("paths"), dict):
+            existing["paths"] = {}
+        target_paths = existing["paths"]
+        target_top = existing
+
     # Path fields go under paths key
     for field in PATH_FIELDS:
         if field in config_dict:
-            existing["paths"][field] = config_dict[field]
-    
+            target_paths[field] = config_dict[field]
+
     # Non-path fields go at top level
-    non_path_fields = ["project_name", "description", "workflows", "portfolio"]
     for field in non_path_fields:
         if field in config_dict:
-            existing[field] = config_dict[field]
-    
+            target_top[field] = config_dict[field]
+
     # Save
     with open(config_path, 'w', encoding='utf-8') as f:
         json.dump(existing, f, indent=2)
-    
-    # Config file changed; force reload on next access.
+
+    # Config file changed; force reload on next access. Every project sharing
+    # this directory reads the same file, so drop all of their entries.
     clear_config_cache(project_path)
 
 
@@ -584,8 +761,15 @@ def clear_config_cache(project_path: Optional[str] = None) -> None:
     """Clear configuration cache."""
     global _config_cache
     if project_path:
-        cache_key = str(Path(project_path).resolve())
-        _config_cache.pop(cache_key, None)
+        # Entries are keyed by directory *and* anchor, so clearing one project's
+        # directory has to drop every anchored variant of it too.
+        prefix = str(Path(project_path).resolve())
+        for key in [
+            key
+            for key in _config_cache
+            if key == prefix or key.startswith(f"{prefix}\0")
+        ]:
+            _config_cache.pop(key, None)
     else:
         _config_cache = {}
 

--- a/backend/app/services/project_import_service.py
+++ b/backend/app/services/project_import_service.py
@@ -22,6 +22,28 @@ from app.services.job_service import jobs as v3_jobs
 from app.services.workspace_service import workspace
 
 
+# Separates a directory from the project file inside it. A directory may hold
+# several KiCad projects, so the directory alone cannot name one.
+PROJECT_KEY_SEPARATOR = "::"
+
+
+def make_project_key(relative_path: str, project_file: str) -> str:
+    """The stable identifier for one project inside a repository.
+
+    Prism used to identify a project by its directory. That silently merged the
+    two projects of a repository that keeps, say, a fixture's top and base plate
+    side by side in the root: one checkbox ticked both, one of the two was
+    registered, and it was named after one board while the viewer rendered the
+    other. Naming the project file as well keeps them apart.
+
+    Projects registered before the anchor existed have no project file recorded;
+    their key stays the bare directory, which is what it has always been.
+    """
+    if not project_file:
+        return relative_path
+    return f"{relative_path}{PROJECT_KEY_SEPARATOR}{project_file}"
+
+
 @dataclass
 class DiscoveredProject:
     """A KiCAD project discovered within a repository."""
@@ -34,6 +56,14 @@ class DiscoveredProject:
     # teams gitignore the project file because KiCad rewrites it on every open,
     # so its absence must not hide the board.
     has_project_file: bool = True
+    # The project's own file within ``relative_path``: its ``.kicad_pro``, or the
+    # board/schematic KiCad would regenerate one from. This is what tells two
+    # projects in the same directory apart.
+    project_file: str = ""
+
+    @property
+    def project_key(self) -> str:
+        return make_project_key(self.relative_path, self.project_file)
 
 
 def remote_url_policy() -> RemoteUrlPolicy:
@@ -321,13 +351,24 @@ def discover_projects_from_repo(repo: Repo) -> List[DiscoveredProject]:
         relative_path = dir_path if dir_path != "." else "."
         if pro_files:
             for pro_file in pro_files:
+                stem = Path(pro_file).stem
+                # With several projects in one directory, the subtree answer
+                # above ("does anything here have a board?") is about the
+                # directory, not about this project. Ask per project file.
+                if len(pro_files) > 1:
+                    project_has_sch = f"{stem}.kicad_sch" in filenames
+                    project_has_pcb = f"{stem}.kicad_pcb" in filenames
+                else:
+                    project_has_sch = has_sch
+                    project_has_pcb = has_pcb
                 projects.append(DiscoveredProject(
-                    name=Path(pro_file).stem,
+                    name=stem,
                     relative_path=relative_path,
                     full_path="", # No checkout path
-                    has_schematic=has_sch,
-                    has_pcb=has_pcb,
+                    has_schematic=project_has_sch,
+                    has_pcb=project_has_pcb,
                     has_project_file=True,
+                    project_file=pro_file,
                 ))
             continue
 
@@ -341,6 +382,7 @@ def discover_projects_from_repo(repo: Repo) -> List[DiscoveredProject]:
             has_schematic=has_sch,
             has_pcb=has_pcb,
             has_project_file=False,
+            project_file=anchor,
         ))
 
     # A `Subsheets/` or `sch/` directory sits inside a project and holds that
@@ -372,14 +414,20 @@ def discover_projects_from_repo(repo: Repo) -> List[DiscoveredProject]:
     return projects
 
 
-def resolve_cached_paths(project_path: str, *, current_source: Optional[str] = None) -> dict:
+def resolve_cached_paths(
+    project_path: str,
+    *,
+    current_source: Optional[str] = None,
+    anchor: Optional[str] = None,
+) -> dict:
     """Resolve and return cached path info for a project directory.
 
     ``current_source`` is the project's recorded ``thumbnail_source``, so a
-    thumbnail the user chose deliberately survives a re-scan.
+    thumbnail the user chose deliberately survives a re-scan. ``anchor`` is the
+    project's own file, needed when the directory holds more than one project.
     """
     try:
-        resolved = path_config_service.resolve_paths(project_path)
+        resolved = path_config_service.resolve_paths(project_path, anchor=anchor)
         sch = resolved.schematic
         pcb = resolved.pcb
         thumb = resolved.thumbnail_dir
@@ -457,6 +505,7 @@ def resolve_cached_paths(project_path: str, *, current_source: Optional[str] = N
                     if f.lower().endswith(('.glb', '.step', '.stp')):
                         has_3d = True
         return {
+            'project_file_rel': anchor or '',
             'schematic_rel': _rel(sch),
             'pcb_rel': _rel(pcb),
             'thumbnail_rel': thumb_rel,
@@ -472,6 +521,24 @@ def resolve_cached_paths(project_path: str, *, current_source: Optional[str] = N
         return {}
 
 
+def infer_project_anchor(project_path: str) -> str:
+    """Guess a project's own file for a row registered before anchors existed.
+
+    Only answers when the guess cannot be wrong: a directory holding exactly one
+    ``.kicad_pro`` has exactly one project, which is every project Prism has
+    registered so far that still works. A directory with several is the case
+    this whole mechanism exists for, and it must be re-imported rather than
+    guessed at.
+    """
+    try:
+        pro_files = sorted(
+            name for name in os.listdir(project_path) if name.endswith(".kicad_pro")
+        )
+    except OSError:
+        return ""
+    return pro_files[0] if len(pro_files) == 1 else ""
+
+
 def refresh_project_assets(project_id: str) -> dict:
     """Re-scan a registered project's files, preserving its thumbnail choice.
 
@@ -484,22 +551,29 @@ def refresh_project_assets(project_id: str) -> dict:
     project_path = str(row.get("path") or "")
     if not project_path:
         return {}
+    anchor = str(row.get("project_file_rel") or "") or infer_project_anchor(project_path)
     cached = resolve_cached_paths(
-        project_path, current_source=str(row.get("thumbnail_source") or "") or None
+        project_path,
+        current_source=str(row.get("thumbnail_source") or "") or None,
+        anchor=anchor,
     )
     if cached:
         workspace.update_project(project_id, **cached)
     return cached
 
 
-def generate_thumbnail_for_project(project_path: str, logs_list: Optional[List[str]] = None) -> bool:
+def generate_thumbnail_for_project(
+    project_path: str,
+    logs_list: Optional[List[str]] = None,
+    anchor: Optional[str] = None,
+) -> bool:
     """
     Find the main .kicad_pcb file and run kicad-cli pcb render to generate a thumbnail.
     """
     try:
         from PIL import Image
 
-        resolved = path_config_service.resolve_paths(project_path)
+        resolved = path_config_service.resolve_paths(project_path, anchor=anchor)
         pcb_file = resolved.pcb
         if not pcb_file or not os.path.exists(pcb_file):
             if logs_list is not None:
@@ -757,10 +831,20 @@ def run_project_analyze_job_v3(context: JobContext) -> JobResult:
     existing_repo = find_existing_repository(parsed)
     imported_paths: list[str] = []
     if existing_repo:
-        imported_paths = [
-            str(row.get("relative_path") or ".")
-            for row in workspace.get_projects_by_repo(str(existing_repo["id"]))
-        ]
+        rows = workspace.get_projects_by_repo(str(existing_repo["id"]))
+        # Both spellings: the key a project registered today reports, and the
+        # bare directory a project registered before anchors existed reports.
+        # The dialog matches on either, so an older project still shows as
+        # imported without hiding a sibling that shares its directory.
+        imported_paths = list(
+            dict.fromkeys(
+                make_project_key(
+                    str(row.get("relative_path") or "."),
+                    str(row.get("project_file_rel") or ""),
+                )
+                for row in rows
+            )
+        )
 
     result = {
         "repo_name": parsed.repo_name,
@@ -775,6 +859,8 @@ def run_project_analyze_job_v3(context: JobContext) -> JobResult:
             {
                 "name": project.name,
                 "relative_path": project.relative_path,
+                "project_key": project.project_key,
+                "project_file": project.project_file,
                 "has_schematic": project.has_schematic,
                 "has_pcb": project.has_pcb,
                 "has_project_file": project.has_project_file,
@@ -901,22 +987,58 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
     already_imported: set[str] = set()
     if existing_repo:
         already_imported = {
-            str(row.get("relative_path") or ".")
+            make_project_key(
+                str(row.get("relative_path") or "."),
+                str(row.get("project_file_rel") or ""),
+            )
             for row in workspace.get_projects_by_repo(str(existing_repo["id"]))
         }
 
-    discovered_paths = {project.relative_path for project in discovered}
-    discovered_names = {project.relative_path: project.name for project in discovered}
+    discovered_by_key = {project.project_key: project for project in discovered}
+    projects_by_directory: dict[str, list[DiscoveredProject]] = {}
+    for project in discovered:
+        projects_by_directory.setdefault(project.relative_path, []).append(project)
+
+    def is_already_imported(project: DiscoveredProject) -> bool:
+        if project.project_key in already_imported:
+            return True
+        # A row registered before anchors existed is keyed by its directory
+        # alone. It stands for that directory's one project -- which is only
+        # unambiguous while the directory still holds one.
+        return (
+            project.relative_path in already_imported
+            and len(projects_by_directory[project.relative_path]) == 1
+        )
+
     if import_type == "type1":
-        requested_paths = ["."]
-    unknown = sorted(set(requested_paths) - discovered_paths)
+        requested_paths = [discovered[0].project_key]
+
+    # A caller may name a project by its key, or name a directory and mean every
+    # project in it -- which is what every client sent before projects had keys.
+    resolved_selection: list[str] = []
+    unknown: list[str] = []
+    for path in requested_paths:
+        if path in discovered_by_key:
+            resolved_selection.append(path)
+        elif path in projects_by_directory:
+            resolved_selection.extend(
+                project.project_key for project in projects_by_directory[path]
+            )
+        else:
+            unknown.append(path)
     if unknown:
         raise ValueError(
             "Selected paths are not KiCad projects in this repository: "
-            + ", ".join(unknown)
+            + ", ".join(sorted(set(unknown)))
         )
-    selected_paths = [path for path in requested_paths if path not in already_imported]
-    if not selected_paths:
+
+    selected_keys = list(dict.fromkeys(resolved_selection))
+    selected_projects = [
+        discovered_by_key[key]
+        for key in selected_keys
+        if not is_already_imported(discovered_by_key[key])
+    ]
+    if not selected_projects:
         if requested_paths and already_imported:
             raise ValueError(
                 f"Every selected project is already imported from "
@@ -994,7 +1116,8 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
             )
         imported_ids: list[str] = []
         if import_type == "type1":
-            cached = resolve_cached_paths(str(target_path))
+            project = selected_projects[0]
+            cached = resolve_cached_paths(str(target_path), anchor=project.project_file)
             imported_ids.append(
                 workspace.register_project(
                     repo_id=repo_id,
@@ -1006,8 +1129,9 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
             )
         else:
             checkout_root = target_path.resolve()
-            for index, relative_path in enumerate(selected_paths):
+            for index, project in enumerate(selected_projects):
                 context.check_cancelled()
+                relative_path = project.relative_path
                 full_project_path = target_path / relative_path
                 # Paths are already validated against discovery; this keeps the
                 # guarantee local to the place that does the filesystem write.
@@ -1015,10 +1139,10 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
                     raise ValueError(f"Project path escapes the checkout: {relative_path}")
                 # Discovery already worked out the board name, including for
                 # directories whose .kicad_pro is gitignored.
-                board_name = discovered_names.get(
-                    relative_path, os.path.basename(relative_path)
+                board_name = project.name or os.path.basename(relative_path)
+                cached = resolve_cached_paths(
+                    str(full_project_path), anchor=project.project_file
                 )
-                cached = resolve_cached_paths(str(full_project_path))
                 imported_ids.append(
                     workspace.register_project(
                         repo_id=repo_id,
@@ -1030,8 +1154,8 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
                 )
                 context.progress(
                     stage="register-projects",
-                    message=f"Registered {index + 1} of {len(selected_paths)} projects",
-                    percent=80 + (15 * (index + 1) / len(selected_paths)),
+                    message=f"Registered {index + 1} of {len(selected_projects)} projects",
+                    percent=80 + (15 * (index + 1) / len(selected_projects)),
                 )
         # Render boards in their own jobs. The projects are registered and
         # browsable now; thumbnails fill in as each render finishes, rather than
@@ -1153,6 +1277,7 @@ def run_project_thumbnail_job_v3(context: JobContext) -> JobResult:
     project_path = str(row.get("path") or "")
     if not project_path or not os.path.isdir(project_path):
         raise ValueError(f"Project path not found: {project_path}")
+    anchor = str(row.get("project_file_rel") or "") or infer_project_anchor(project_path)
 
     context.progress(
         stage="render-thumbnail",
@@ -1161,7 +1286,7 @@ def run_project_thumbnail_job_v3(context: JobContext) -> JobResult:
         force=True,
     )
     logs: list[str] = []
-    rendered = generate_thumbnail_for_project(project_path, logs)
+    rendered = generate_thumbnail_for_project(project_path, logs, anchor=anchor)
     for line in logs:
         print(line, flush=True)
     context.check_cancelled()

--- a/backend/app/services/project_import_service.py
+++ b/backend/app/services/project_import_service.py
@@ -80,14 +80,22 @@ def find_existing_repository(parsed: ParsedRemote) -> Optional[dict]:
     Compares canonical identities rather than URL strings, so importing
     ``git@github.com:org/repo.git`` after ``https://github.com/org/repo`` is
     recognised as the same repository instead of cloning it twice.
+
+    A stored URL is read under this deployment's policy, not the default one.
+    An operator running an internal Git server without TLS enables
+    ``IMPORT_ALLOW_INSECURE_HTTP`` to import from it; reading its own rows back
+    under a policy that rejects ``http://`` made those repositories fail to
+    canonicalize, leaving deduplication to an exact string comparison that a
+    trailing ``.git`` or a change of case defeats.
     """
+    policy = remote_url_policy()
     target = parsed.dedup_key
     for repository in workspace.get_repositories():
         stored = str(repository.get("url") or "")
         if not stored:
             continue
         try:
-            if parse_remote_url(stored).dedup_key == target:
+            if parse_remote_url(stored, policy).dedup_key == target:
                 return repository
         except Exception:
             # A row predating URL validation should not block a valid import.
@@ -1057,10 +1065,16 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
         adopted_checkout = False
         if target_path.exists():
             existing_checkout = Repo(str(target_path))
+            # Under this deployment's policy, for the same reason as
+            # `find_existing_repository`: the default policy rejects `http://`,
+            # so on a workspace configured for a plaintext internal Git server
+            # every remote here raised and was dropped, and the checkout Prism
+            # had just cloned itself was reported as belonging to someone else.
+            policy = remote_url_policy()
             remotes = set()
             for remote in existing_checkout.remotes:
                 try:
-                    remotes.add(parse_remote_url(remote.url).dedup_key)
+                    remotes.add(parse_remote_url(remote.url, policy).dedup_key)
                 except Exception:
                     continue
             if parsed.dedup_key not in remotes:

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -33,6 +33,11 @@ class Project(BaseModel):
     # this to know which thumbnail actions to offer.
     thumbnail_source: Optional[str] = None
     sub_path: Optional[str] = None  # Relative path within parent repo
+    # This project's own file inside its directory (its .kicad_pro, or the board
+    # KiCad would regenerate one from). A directory can hold several KiCad
+    # projects, and this is what tells them apart. Empty for projects registered
+    # before Prism recorded it, which are the only project in their directory.
+    project_file: Optional[str] = None
     parent_repo: Optional[str] = None  # Parent monorepo name
     repo_url: Optional[str] = None  # Original Git URL
     import_type: Optional[str] = None  # "type1" or "type2_subproject"
@@ -95,6 +100,42 @@ def _save_project_registry(registry: Dict[str, dict]) -> None:
         invalidate_project_caches()
     except IOError as e:
         print(f"Warning: Failed to save project registry: {e}")
+
+
+# The project file that identifies one project inside a shared directory.
+# Accepts either a `Project` or a raw workspace row, because callers hold one or
+# the other depending on how deep in the stack they are.
+project_anchor = path_config_service.anchor_for_project
+
+
+def _project_path_of(project: Any) -> str:
+    if isinstance(project, dict):
+        return str(project.get("path") or "")
+    return str(getattr(project, "path", "") or "")
+
+
+def path_config_for(project: Any, use_cache: bool = True) -> path_config_service.PathConfig:
+    """Load a project's path configuration, honouring its anchor."""
+    return path_config_service.get_path_config(
+        _project_path_of(project), use_cache, anchor=project_anchor(project)
+    )
+
+
+def resolved_paths_for(
+    project: Any,
+    config: Optional[path_config_service.PathConfig] = None,
+) -> path_config_service.ResolvedPaths:
+    """Resolve a project's paths, honouring its anchor."""
+    return path_config_service.resolve_paths(
+        _project_path_of(project), config, anchor=project_anchor(project)
+    )
+
+
+def save_path_config_for(project: Any, config: path_config_service.PathConfig) -> None:
+    """Persist a project's path configuration under its own anchor."""
+    path_config_service.save_path_config(
+        _project_path_of(project), config, anchor=project_anchor(project)
+    )
 
 
 def invalidate_project_caches() -> None:
@@ -755,15 +796,19 @@ def run_kicad_workflow_job_v3(context: JobContext) -> JobResult:
     )
     context.check_cancelled()
 
-    pro_file = next(
-        (name for name in sorted(os.listdir(project.path)) if name.endswith(".kicad_pro")),
-        None,
-    )
+    # This project's own .kicad_pro, not whichever one sorts first: a directory
+    # holding two projects would otherwise build the wrong board.
+    pro_file = project_anchor(project)
+    if not pro_file or not pro_file.endswith(".kicad_pro"):
+        pro_file = next(
+            (name for name in sorted(os.listdir(project.path)) if name.endswith(".kicad_pro")),
+            None,
+        )
     if not pro_file:
         raise ValueError(".kicad_pro file not found in project root")
 
-    config = path_config_service.get_path_config(project.path)
-    resolved_paths = path_config_service.resolve_paths(project.path, config)
+    config = path_config_for(project)
+    resolved_paths = resolved_paths_for(project, config)
     jobset_path = resolved_paths.jobset_path
     configured_jobset = config.jobset or "Outputs.kicad_jobset"
     if not jobset_path:
@@ -802,8 +847,8 @@ def get_project_thumbnail_path(project_id: str) -> Optional[str]:
         return None
     
     # Use path config service to get thumbnail path
-    config = path_config_service.get_path_config(project.path)
-    resolved = path_config_service.resolve_paths(project.path, config)
+    config = path_config_for(project)
+    resolved = resolved_paths_for(project, config)
     thumbnail_path = resolved.thumbnail_dir
     
     print(f"[DEBUG] Project: {project.path}")
@@ -830,14 +875,14 @@ def get_project_thumbnail_path(project_id: str) -> Optional[str]:
     print(f"[DEBUG] No valid thumbnail found")
     return None
 
-def find_schematic_file(project_path: str) -> Optional[str]:
+def find_schematic_file(project_path: str, anchor: Optional[str] = None) -> Optional[str]:
     """Find the main .kicad_sch file using path config."""
-    resolved = path_config_service.resolve_paths(project_path)
+    resolved = path_config_service.resolve_paths(project_path, anchor=anchor)
     return resolved.schematic
 
-def find_pcb_file(project_path: str) -> Optional[str]:
+def find_pcb_file(project_path: str, anchor: Optional[str] = None) -> Optional[str]:
     """Find the main .kicad_pcb file using path config."""
-    resolved = path_config_service.resolve_paths(project_path)
+    resolved = path_config_service.resolve_paths(project_path, anchor=anchor)
     return resolved.pcb
 
 def find_3d_model(project_path: str) -> Optional[str]:
@@ -944,9 +989,9 @@ def update_project_description(project_id: str, description: str) -> bool:
     if not project:
         return False
 
-    config = path_config_service.get_path_config(project.path)
+    config = path_config_for(project)
     config.description = description
-    path_config_service.save_path_config(project.path, config)
+    save_path_config_for(project, config)
 
     # Keep registry mirrored for legacy fallback/search compatibility on older code paths.
     registry = _load_project_registry()

--- a/backend/app/services/semantic_index_service.py
+++ b/backend/app/services/semantic_index_service.py
@@ -16,7 +16,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Iterable, Iterator
 
 from app.core.config import settings
-from app.services import semantic_visualizer_service
+from app.services import path_config_service, semantic_visualizer_service
 
 
 SCHEMA = "prism.semantic_index_a0"
@@ -198,13 +198,16 @@ def _revision_identity(project: Any, commit: str | None) -> tuple[str, str | Non
     same question, because git's blob ids are content hashes already.
     """
 
+    anchor = path_config_service.anchor_for_project(project)
     if not commit:
-        project_file = semantic_visualizer_service.find_kicad_project(project.path)
+        project_file = semantic_visualizer_service.find_kicad_project(project.path, anchor)
         return _revision_key(_source_entries_on_disk(project_file.resolve().parent)), None
 
     repo_root = semantic_visualizer_service._repo_root(Path(project.path))
     resolved_commit = semantic_visualizer_service._resolve_commit(repo_root, commit)
-    project_rel = semantic_visualizer_service._project_relative_path(repo_root, Path(project.path))
+    project_rel = semantic_visualizer_service._project_relative_path(
+        repo_root, Path(project.path), anchor
+    )
     project_dir = PurePosixPath(project_rel).parent.as_posix()
     if project_dir == ".":
         project_dir = ""
@@ -214,13 +217,16 @@ def _revision_identity(project: Any, commit: str | None) -> tuple[str, str | Non
 
 @contextlib.contextmanager
 def _project_file_for_revision(project: Any, commit: str | None) -> Iterator[tuple[Path, str | None]]:
+    anchor = path_config_service.anchor_for_project(project)
     if not commit:
-        yield semantic_visualizer_service.find_kicad_project(project.path), None
+        yield semantic_visualizer_service.find_kicad_project(project.path, anchor), None
         return
 
     repo_root = semantic_visualizer_service._repo_root(Path(project.path))
     resolved_commit = semantic_visualizer_service._resolve_commit(repo_root, commit)
-    project_rel = semantic_visualizer_service._project_relative_path(repo_root, Path(project.path))
+    project_rel = semantic_visualizer_service._project_relative_path(
+        repo_root, Path(project.path), anchor
+    )
     with tempfile.TemporaryDirectory(prefix="semantic-index-commit-") as tmp:
         checkout = Path(tmp) / "checkout"
         semantic_visualizer_service._archive_checkout(repo_root, resolved_commit, checkout)

--- a/backend/app/services/semantic_visualizer_service.py
+++ b/backend/app/services/semantic_visualizer_service.py
@@ -133,14 +133,42 @@ def semantic_tile_size_mm() -> str:
     return str(value) if 1.0 <= value <= 1000.0 else "auto"
 
 
-def find_kicad_project(project_path: str) -> Path:
+def find_kicad_project(project_path: str, anchor: Optional[str] = None) -> Path:
+    """Locate the .kicad_pro this project is.
+
+    This used to return whichever project file sorted first in the directory,
+    ignoring the schematic and PCB paths configured for the project. A repo with
+    two projects in one directory therefore always rendered the same board, and
+    correcting the paths in project settings changed nothing.
+    """
     root = Path(project_path)
-    config = path_config_service.get_path_config(project_path)
-    configured = getattr(config, "project", None) or getattr(config, "project_file", None)
-    if configured:
-      candidate = (root / str(configured)).resolve()
-      if candidate.is_file() and candidate.suffix == ".kicad_pro":
-          return candidate
+    config = path_config_service.get_path_config(project_path, anchor=anchor)
+
+    def _candidate(name: object) -> Optional[Path]:
+        if not name:
+            return None
+        candidate = (root / str(name)).resolve()
+        return candidate if candidate.is_file() and candidate.suffix == ".kicad_pro" else None
+
+    # The project's own anchor first, then an explicitly configured project file.
+    for configured in (
+        anchor,
+        getattr(config, "project", None),
+        getattr(config, "project_file", None),
+    ):
+        candidate = _candidate(configured)
+        if candidate is not None:
+            return candidate
+
+    # Then the project file belonging to the configured board or schematic, so
+    # pointing settings at a board actually moves the viewer to it.
+    for configured in (config.pcb, config.schematic):
+        if not configured or "*" in str(configured):
+            continue
+        candidate = _candidate(f"{Path(str(configured)).stem}.kicad_pro")
+        if candidate is not None:
+            return candidate
+
     direct = sorted(root.glob("*.kicad_pro"))
     if direct:
         return direct[0]
@@ -167,9 +195,10 @@ def source_fingerprint_for_root(
     for path in sorted(root.rglob("*")):
         if not path.is_file() or ".git" in path.parts:
             continue
-        if path.name == ".prism.json":
-            continue
-        if path.suffix.lower() not in SOURCE_SUFFIXES:
+        # `.prism.json` decides which board a project resolves to, so a bundle
+        # built before it changed is stale. Excluding it here was why editing the
+        # schematic or PCB path in project settings appeared to do nothing.
+        if path.name != ".prism.json" and path.suffix.lower() not in SOURCE_SUFFIXES:
             continue
         rel = path.relative_to(root).as_posix()
         stat = path.stat()
@@ -367,7 +396,9 @@ def get_status_for_source(
 def get_status_for_commit(project: Any, commit: str, project_rel: str | None = None) -> Dict[str, Any]:
     repo_root = _repo_root(Path(project.path))
     resolved_commit = _resolve_commit(repo_root, commit)
-    rel = project_rel or _project_relative_path(repo_root, Path(project.path))
+    rel = project_rel or _project_relative_path(
+        repo_root, Path(project.path), path_config_service.anchor_for_project(project)
+    )
     indexed = lookup_commit_source(project.id, resolved_commit, rel)
     if indexed:
         indexed_status = get_status_for_source(project, indexed["source_fingerprint"], commit=resolved_commit, project_rel=rel)
@@ -838,7 +869,7 @@ def build_visualizer_bundle(
     force: bool = False,
 ) -> Dict[str, Any]:
     total_started = time.perf_counter()
-    project_file = find_kicad_project(project.path)
+    project_file = find_kicad_project(project.path, path_config_service.anchor_for_project(project))
     source_hash = source_fingerprint_for_root(project_file.resolve().parent, _job_profiler(job, persist))
     status = build_visualizer_bundle_from_project_file(
         project,
@@ -863,7 +894,9 @@ def build_visualizer_bundle_for_commit(
     total_started = time.perf_counter()
     repo_root = _repo_root(Path(project.path))
     resolved_commit = _resolve_commit(repo_root, commit)
-    rel = _project_relative_path(repo_root, Path(project.path))
+    rel = _project_relative_path(
+        repo_root, Path(project.path), path_config_service.anchor_for_project(project)
+    )
     indexed = lookup_commit_source(project.id, resolved_commit, rel)
     if indexed and not force:
         status = get_status_for_source(
@@ -1139,8 +1172,10 @@ def _repo_root(project_path: Path) -> Path:
     return Path(result.stdout.strip()).resolve()
 
 
-def _project_relative_path(repo_root: Path, project_path: Path) -> str:
-    project_file = find_kicad_project(str(project_path))
+def _project_relative_path(
+    repo_root: Path, project_path: Path, anchor: Optional[str] = None
+) -> str:
+    project_file = find_kicad_project(str(project_path), anchor)
     return project_file.resolve().relative_to(repo_root).as_posix()
 
 

--- a/backend/app/services/workspace_schema_migrations.py
+++ b/backend/app/services/workspace_schema_migrations.py
@@ -1627,6 +1627,55 @@ def _release_studio_project_signoff(conn: Any) -> None:
     )
 
 
+def _project_file_anchor(conn: Any) -> None:
+    """Record which project file inside a directory a project actually is.
+
+    A project used to be identified by its directory alone. KiCad allows several
+    projects in one directory -- a fixture's top and base plate, say -- and such
+    a repository imported as a single project named after one board while the
+    viewer rendered another. Recording the project's own file tells them apart.
+
+    Every existing row predates this and is the only project in its directory,
+    which is exactly what the empty default means, so nothing needs backfilling
+    here; `infer_project_anchor` fills it in on the next refresh.
+    """
+    conn.execute(
+        """
+        ALTER TABLE ws_projects
+            ADD COLUMN IF NOT EXISTS project_file_rel TEXT NOT NULL DEFAULT ''
+        """
+    )
+    # `UNIQUE(repo_id, relative_path)` made the second project in a directory
+    # impossible to register at all. Widening it to include the project file
+    # only ever admits rows the old constraint rejected, so this cannot fail on
+    # existing data. Guarded on `relative_path` because the release-studio
+    # migration tests run this chain against a minimal `ws_projects`.
+    conn.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_attribute
+                WHERE attrelid = 'ws_projects'::regclass
+                  AND attname = 'relative_path'
+                  AND NOT attisdropped
+            ) AND NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'ws_projects'::regclass
+                  AND conname = 'ws_projects_repo_path_file_key'
+            ) THEN
+                ALTER TABLE ws_projects
+                    DROP CONSTRAINT IF EXISTS ws_projects_repo_id_relative_path_key;
+                ALTER TABLE ws_projects
+                    ADD CONSTRAINT ws_projects_repo_path_file_key
+                    UNIQUE (repo_id, relative_path, project_file_rel);
+            END IF;
+        END
+        $$
+        """
+    )
+
+
 MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (1, "v3_job_foundation", _v3_job_foundation),
     (2, "workspace_read_versions", _workspace_read_versions),
@@ -1643,6 +1692,7 @@ MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (17, "release_studio_terminal_and_identity_guards", _release_studio_terminal_and_identity_guards),
     (18, "release_studio_source_defaults", _release_studio_source_defaults),
     (19, "release_studio_project_signoff", _release_studio_project_signoff),
+    (20, "project_file_anchor", _project_file_anchor),
 )
 
 

--- a/backend/app/services/workspace_service.py
+++ b/backend/app/services/workspace_service.py
@@ -132,6 +132,7 @@ class WorkspaceService:
                 display_name    TEXT,
                 description     TEXT NOT NULL DEFAULT '',
                 relative_path   TEXT NOT NULL DEFAULT '.',
+                project_file_rel TEXT NOT NULL DEFAULT '',
                 folder_id       TEXT REFERENCES ws_folders(id) ON DELETE SET NULL,
                 schematic_rel   TEXT,
                 pcb_rel         TEXT,
@@ -142,7 +143,12 @@ class WorkspaceService:
                 registered_at   TIMESTAMPTZ NOT NULL,
                 last_modified   TIMESTAMPTZ NOT NULL,
                 prism_json_hash TEXT,
-                UNIQUE(repo_id, relative_path)
+                -- A directory can hold more than one KiCad project, so it does
+                -- not identify one on its own. Keying uniqueness on the
+                -- directory alone made a repository with two projects in its
+                -- root importable only as one of them.
+                CONSTRAINT ws_projects_repo_path_file_key
+                    UNIQUE (repo_id, relative_path, project_file_rel)
             );
             CREATE INDEX IF NOT EXISTS idx_ws_projects_folder ON ws_projects(folder_id);
             CREATE INDEX IF NOT EXISTS idx_ws_projects_repo   ON ws_projects(repo_id);
@@ -283,6 +289,7 @@ class WorkspaceService:
         display_name: Optional[str] = None,
         description: str = "",
         folder_id: Optional[str] = None,
+        project_file_rel: str = "",
         schematic_rel: Optional[str] = None,
         pcb_rel: Optional[str] = None,
         thumbnail_rel: Optional[str] = None,
@@ -301,12 +308,14 @@ class WorkspaceService:
             conn.execute(
                 """INSERT INTO ws_projects
                    (id,repo_id,name,display_name,description,relative_path,folder_id,
+                    project_file_rel,
                     schematic_rel,pcb_rel,thumbnail_rel,thumbnail_source,thumbnail_digest,
                     thumbnail_media_type,thumbnail_size_bytes,jobset_rel,
                     has_3d_model,has_ibom,registered_at,last_modified,prism_json_hash)
-                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
                 (
                     project_id, repo_id, name, display_name, description, relative_path, folder_id,
+                    project_file_rel,
                     schematic_rel, pcb_rel, thumbnail_rel, thumbnail_source, thumbnail_digest,
                     thumbnail_media_type, thumbnail_size_bytes, jobset_rel,
                     has_3d_model, has_ibom, now, now, prism_json_hash,
@@ -406,6 +415,7 @@ class WorkspaceService:
             return False
         allowed = {
             "name", "display_name", "description", "folder_id",
+            "project_file_rel",
             "schematic_rel", "pcb_rel", "thumbnail_rel", "jobset_rel",
             "thumbnail_source", "thumbnail_digest", "thumbnail_media_type",
             "thumbnail_size_bytes",

--- a/backend/tests/test_import_branch_and_incremental.py
+++ b/backend/tests/test_import_branch_and_incremental.py
@@ -17,13 +17,16 @@ from unittest import mock
 from app.services import project_import_service
 
 
-def _project(relative_path: str, name: str) -> project_import_service.DiscoveredProject:
+def _project(
+    relative_path: str, name: str, project_file: str = ""
+) -> project_import_service.DiscoveredProject:
     return project_import_service.DiscoveredProject(
         name=name,
         relative_path=relative_path,
         full_path="",
         has_schematic=True,
         has_pcb=True,
+        project_file=project_file,
     )
 
 
@@ -36,6 +39,7 @@ class ImportRunner:
         self.existing_projects = list(existing_projects)
         self.clone_calls: list[dict] = []
         self.registered_projects: list[dict] = []
+        self.resolved_anchors: list[str | None] = []
         self.register_repository = mock.Mock(return_value="repo-new")
 
     def run(self, payload: dict, projects_root: str):
@@ -53,6 +57,10 @@ class ImportRunner:
         def register_project(**kwargs):
             self.registered_projects.append(kwargs)
             return f"prj-{len(self.registered_projects)}"
+
+        def resolve_cached_paths(project_path, *, current_source=None, anchor=None):
+            self.resolved_anchors.append(anchor)
+            return {"project_file_rel": anchor or ""}
 
         with (
             mock.patch.object(
@@ -93,7 +101,9 @@ class ImportRunner:
                 project_import_service, "generate_thumbnail_for_project", return_value=False
             ),
             mock.patch.object(
-                project_import_service, "resolve_cached_paths", return_value={}
+                project_import_service,
+                "resolve_cached_paths",
+                side_effect=resolve_cached_paths,
             ),
         ):
             return project_import_service.run_project_import_job_v3(context)
@@ -243,3 +253,93 @@ class AddsProjectsToAnAlreadyImportedRepository(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ImportsProjectsThatShareADirectory(unittest.TestCase):
+    """Two KiCad projects in one directory are two projects, not one.
+
+    A repository keeping a fixture's top and base plate side by side in its root
+    imported as a single project: both were discovered, but both answered to the
+    directory `"."`, so only one row was registered -- named after one board
+    while the viewer rendered the other.
+    """
+
+    def setUp(self) -> None:
+        self.discovered = [
+            _project(".", "base", "base.kicad_pro"),
+            _project(".", "top", "top.kicad_pro"),
+        ]
+
+    def _run(self, payload_paths, existing_projects=(), existing_repo=None):
+        runner = ImportRunner(
+            self.discovered,
+            existing_repo=existing_repo,
+            existing_projects=existing_projects,
+        )
+        with tempfile.TemporaryDirectory() as root:
+            if existing_repo:
+                (Path(root) / "type2" / "boards").mkdir(parents=True)
+                with mock.patch.object(
+                    project_import_service,
+                    "Repo",
+                    side_effect=AddsProjectsToAnAlreadyImportedRepository._adoptable_repo,
+                ):
+                    result = runner.run(self._payload(payload_paths), root)
+            else:
+                result = runner.run(self._payload(payload_paths), root)
+        return runner, result
+
+    @staticmethod
+    def _payload(paths):
+        return {
+            "repo_url": "https://example.com/boards.git",
+            "import_type": "type2",
+            "selected_paths": paths,
+        }
+
+    def test_selecting_one_project_imports_only_that_project(self) -> None:
+        runner, result = self._run([".::top.kicad_pro"])
+        self.assertEqual(len(result.details["project_ids"]), 1)
+        self.assertEqual([p["name"] for p in runner.registered_projects], ["top"])
+        self.assertEqual(runner.resolved_anchors, ["top.kicad_pro"])
+
+    def test_selecting_both_projects_registers_both(self) -> None:
+        runner, result = self._run([".::base.kicad_pro", ".::top.kicad_pro"])
+        self.assertEqual(len(result.details["project_ids"]), 2)
+        self.assertEqual([p["name"] for p in runner.registered_projects], ["base", "top"])
+        self.assertEqual(
+            [p["relative_path"] for p in runner.registered_projects], [".", "."]
+        )
+        self.assertEqual(
+            [p["project_file_rel"] for p in runner.registered_projects],
+            ["base.kicad_pro", "top.kicad_pro"],
+        )
+
+    def test_naming_a_directory_still_means_every_project_in_it(self) -> None:
+        # What every client sent before projects had keys.
+        runner, _ = self._run(["."])
+        self.assertEqual([p["name"] for p in runner.registered_projects], ["base", "top"])
+
+    def test_a_sibling_is_still_importable_once_the_other_is_registered(self) -> None:
+        runner, _ = self._run(
+            [".::top.kicad_pro"],
+            existing_projects=[{"relative_path": ".", "project_file_rel": "base.kicad_pro"}],
+            existing_repo={"id": "repo-1", "name": "boards"},
+        )
+        self.assertEqual([p["name"] for p in runner.registered_projects], ["top"])
+
+    def test_a_project_registered_twice_is_refused(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            self._run(
+                [".::base.kicad_pro"],
+                existing_projects=[
+                    {"relative_path": ".", "project_file_rel": "base.kicad_pro"}
+                ],
+                existing_repo={"id": "repo-1", "name": "boards"},
+            )
+        self.assertIn("already imported", str(caught.exception))
+
+    def test_an_unknown_project_key_is_rejected(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            self._run([".::missing.kicad_pro"])
+        self.assertIn("not KiCad projects", str(caught.exception))

--- a/backend/tests/test_import_branch_and_incremental.py
+++ b/backend/tests/test_import_branch_and_incremental.py
@@ -343,3 +343,78 @@ class ImportsProjectsThatShareADirectory(unittest.TestCase):
         with self.assertRaises(ValueError) as caught:
             self._run([".::missing.kicad_pro"])
         self.assertIn("not KiCad projects", str(caught.exception))
+
+
+class ImportsFromAPlaintextSelfHostedServer(unittest.TestCase):
+    """An internal Git server without TLS, once the operator has allowed one.
+
+    `http://` is refused by default and enabled with `IMPORT_ALLOW_INSECURE_HTTP`.
+    That switch only ever governed the URL the user types: the two places that
+    read a remote back -- the deduplication scan and the checkout-adoption
+    check -- parsed it under the default policy instead, so a workspace
+    configured for a plaintext server could import a repository once and then
+    failed every time it went back to the same checkout.
+    """
+
+    url = "http://git.internal.example/hw/boards.git"
+
+    def setUp(self) -> None:
+        self.discovered = [
+            _project("hardware/board-a", "board-a"),
+            _project("hardware/board-b", "board-b"),
+        ]
+        patcher = mock.patch.object(
+            project_import_service,
+            "remote_url_policy",
+            return_value=project_import_service.RemoteUrlPolicy.build(
+                allow_insecure_http=True
+            ),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _checkout_on_this_remote(self, path):
+        repo = mock.Mock()
+        repo.remotes = [SimpleNamespace(url=self.url)]
+        repo.working_tree_dir = str(path)
+        repo.git.ls_files.return_value = ""
+        return repo
+
+    def test_a_second_import_adopts_the_existing_checkout(self) -> None:
+        runner = ImportRunner(
+            self.discovered,
+            existing_repo={"id": "repo-1", "name": "boards"},
+            existing_projects=[{"relative_path": "hardware/board-a"}],
+        )
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "type2" / "boards").mkdir(parents=True)
+            with mock.patch.object(
+                project_import_service, "Repo", side_effect=self._checkout_on_this_remote
+            ):
+                result = runner.run(
+                    {
+                        "repo_url": self.url,
+                        "import_type": "type2",
+                        "selected_paths": ["hardware/board-b"],
+                    },
+                    root,
+                )
+        self.assertEqual(len(result.details["project_ids"]), 1)
+        self.assertEqual(
+            [p["relative_path"] for p in runner.registered_projects],
+            ["hardware/board-b"],
+        )
+
+    def test_a_stored_plaintext_url_is_recognised_across_spellings(self) -> None:
+        # Deduplication fell back to an exact string comparison, which a
+        # trailing `.git` defeats -- so the same repository imported twice.
+        stored = [{"id": "repo-1", "url": "http://git.internal.example/hw/boards"}]
+        with mock.patch.object(
+            project_import_service.workspace, "get_repositories", return_value=stored
+        ):
+            found = project_import_service.find_existing_repository(
+                project_import_service.parse_remote_url(
+                    self.url, project_import_service.remote_url_policy()
+                )
+            )
+        self.assertEqual(found, stored[0])

--- a/backend/tests/test_project_anchor_paths.py
+++ b/backend/tests/test_project_anchor_paths.py
@@ -1,0 +1,217 @@
+"""Path resolution when a directory holds more than one KiCad project.
+
+KiCad allows two projects to share a directory. Prism resolved a project's
+board and schematic from the directory alone, so the two halves of a fixture
+kept side by side in a repository root both resolved to whichever file sorted
+first -- and editing the paths in project settings could not move either of
+them, because the viewer never consulted those settings.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.services import path_config_service, semantic_visualizer_service
+
+
+def write_tree(root: Path, names: list[str]) -> None:
+    for name in names:
+        (root / name).write_text("", encoding="utf-8")
+
+
+class ResolvesTheAnchoredProject(unittest.TestCase):
+    names = [
+        "base.kicad_pro",
+        "base.kicad_pcb",
+        "base.kicad_sch",
+        "top.kicad_pro",
+        "top.kicad_pcb",
+        "top.kicad_sch",
+    ]
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        write_tree(self.root, self.names)
+        path_config_service.clear_config_cache()
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(path_config_service.clear_config_cache)
+
+    def test_each_anchor_detects_its_own_board(self) -> None:
+        for anchor, board in (("top.kicad_pro", "top.kicad_pcb"), ("base.kicad_pro", "base.kicad_pcb")):
+            with self.subTest(anchor=anchor):
+                config = path_config_service.get_path_config(str(self.root), anchor=anchor)
+                self.assertEqual(config.pcb, board)
+
+    def test_each_anchor_detects_its_own_schematic(self) -> None:
+        config = path_config_service.get_path_config(str(self.root), anchor="top.kicad_pro")
+        self.assertEqual(config.schematic, "top.kicad_sch")
+
+    def test_anchored_configs_do_not_share_a_cache_entry(self) -> None:
+        # Same directory, same `.prism.json` mtime: the cache used to answer the
+        # second project with the first project's paths.
+        first = path_config_service.get_path_config(str(self.root), anchor="base.kicad_pro")
+        second = path_config_service.get_path_config(str(self.root), anchor="top.kicad_pro")
+        self.assertEqual(first.pcb, "base.kicad_pcb")
+        self.assertEqual(second.pcb, "top.kicad_pcb")
+
+    def test_resolved_paths_follow_the_anchor(self) -> None:
+        resolved = path_config_service.resolve_paths(str(self.root), anchor="top.kicad_pro")
+        self.assertEqual(Path(resolved.pcb or "").name, "top.kicad_pcb")
+        self.assertEqual(Path(resolved.schematic or "").name, "top.kicad_sch")
+
+    def test_a_glob_config_still_honours_the_anchor(self) -> None:
+        config = path_config_service.PathConfig(pcb="*.kicad_pcb")
+        resolved = path_config_service.resolve_paths(str(self.root), config, anchor="top.kicad_pro")
+        self.assertEqual(Path(resolved.pcb or "").name, "top.kicad_pcb")
+
+    def test_without_an_anchor_detection_is_deterministic(self) -> None:
+        # Unsorted `glob` meant this answer could differ between machines.
+        config = path_config_service.get_path_config(str(self.root), anchor=None)
+        self.assertEqual(config.pcb, "base.kicad_pcb")
+
+
+class NamespacedPrismConfig(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        write_tree(self.root, ["base.kicad_pro", "base.kicad_pcb", "top.kicad_pro", "top.kicad_pcb"])
+        path_config_service.clear_config_cache()
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(path_config_service.clear_config_cache)
+
+    def test_settings_saved_for_one_project_do_not_move_its_sibling(self) -> None:
+        path_config_service.save_path_config(
+            str(self.root),
+            path_config_service.PathConfig(pcb="top.kicad_pcb"),
+            anchor="top.kicad_pro",
+        )
+        top = path_config_service.get_path_config(str(self.root), anchor="top.kicad_pro")
+        base = path_config_service.get_path_config(str(self.root), anchor="base.kicad_pro")
+        self.assertEqual(top.pcb, "top.kicad_pcb")
+        self.assertEqual(base.pcb, "base.kicad_pcb")
+
+    def test_a_namespaced_override_beats_detection(self) -> None:
+        (self.root / ".prism.json").write_text(
+            json.dumps({"projects": {"top.kicad_pro": {"paths": {"pcb": "base.kicad_pcb"}}}}),
+            encoding="utf-8",
+        )
+        config = path_config_service.get_path_config(str(self.root), anchor="top.kicad_pro")
+        self.assertEqual(config.pcb, "base.kicad_pcb")
+
+    def test_a_flat_config_written_by_an_earlier_prism_still_applies(self) -> None:
+        (self.root / ".prism.json").write_text(
+            json.dumps({"paths": {"pcb": "base.kicad_pcb"}, "project_name": "Fixture"}),
+            encoding="utf-8",
+        )
+        config = path_config_service.get_path_config(str(self.root), anchor="top.kicad_pro")
+        self.assertEqual(config.pcb, "base.kicad_pcb")
+        self.assertEqual(config.project_name, "Fixture")
+
+    def test_saving_without_an_anchor_keeps_the_flat_shape(self) -> None:
+        path_config_service.save_path_config(
+            str(self.root), path_config_service.PathConfig(pcb="top.kicad_pcb")
+        )
+        written = json.loads((self.root / ".prism.json").read_text(encoding="utf-8"))
+        self.assertEqual(written["paths"]["pcb"], "top.kicad_pcb")
+        self.assertNotIn("projects", written)
+
+
+class FindsTheProjectFileTheViewerShouldRender(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        write_tree(self.root, ["base.kicad_pro", "base.kicad_pcb", "top.kicad_pro", "top.kicad_pcb"])
+        path_config_service.clear_config_cache()
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(path_config_service.clear_config_cache)
+
+    def test_the_anchor_decides_which_project_is_opened(self) -> None:
+        found = semantic_visualizer_service.find_kicad_project(str(self.root), "top.kicad_pro")
+        self.assertEqual(found.name, "top.kicad_pro")
+
+    def test_a_configured_board_moves_the_viewer_to_its_project(self) -> None:
+        # The reported symptom: settings pointed at the top plate, the viewer
+        # kept rendering the base plate.
+        (self.root / ".prism.json").write_text(
+            json.dumps({"paths": {"pcb": "top.kicad_pcb"}}), encoding="utf-8"
+        )
+        found = semantic_visualizer_service.find_kicad_project(str(self.root))
+        self.assertEqual(found.name, "top.kicad_pro")
+
+    def test_without_an_anchor_or_config_the_first_project_is_used(self) -> None:
+        found = semantic_visualizer_service.find_kicad_project(str(self.root))
+        self.assertEqual(found.name, "base.kicad_pro")
+
+
+class SettingsChangesInvalidateTheCachedBundle(unittest.TestCase):
+    def test_editing_prism_json_changes_the_source_fingerprint(self) -> None:
+        # `.prism.json` was excluded from the fingerprint, so a settings change
+        # left the previously built bundle in place and appeared to do nothing.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_tree(root, ["board.kicad_pro", "board.kicad_pcb"])
+            before = semantic_visualizer_service.source_fingerprint_for_root(root)
+            (root / ".prism.json").write_text(
+                json.dumps({"paths": {"pcb": "board.kicad_pcb"}}), encoding="utf-8"
+            )
+            after = semantic_visualizer_service.source_fingerprint_for_root(root)
+            self.assertNotEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class NeverResolvesOntoASiblingProject(unittest.TestCase):
+    """KiCad associates files by name: `top.kicad_pro` owns `top.kicad_pcb`.
+
+    Prism's fallback ("the first board in the directory") is right for a lone
+    project whose board happens to be named differently, and wrong the moment a
+    sibling project stands next to it -- that fallback is how a project rendered
+    its neighbour's board.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        path_config_service.clear_config_cache()
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(path_config_service.clear_config_cache)
+
+    def test_a_project_without_its_own_board_does_not_borrow_a_siblings(self) -> None:
+        write_tree(self.root, ["base.kicad_pro", "base.kicad_pcb", "top.kicad_pro"])
+        resolved = path_config_service.resolve_paths(str(self.root), anchor="top.kicad_pro")
+        self.assertIsNone(resolved.pcb)
+
+    def test_a_project_without_its_own_schematic_does_not_borrow_a_siblings(self) -> None:
+        write_tree(self.root, ["base.kicad_pro", "base.kicad_sch", "top.kicad_pro"])
+        resolved = path_config_service.resolve_paths(str(self.root), anchor="top.kicad_pro")
+        self.assertIsNone(resolved.schematic)
+
+    def test_a_lone_project_still_finds_a_differently_named_board(self) -> None:
+        # No sibling to confuse it with, so the existing fallback still applies:
+        # plenty of repositories name the board something other than the project.
+        write_tree(self.root, ["fixture.kicad_pro", "mainboard.kicad_pcb"])
+        config = path_config_service.get_path_config(str(self.root), anchor="fixture.kicad_pro")
+        self.assertEqual(config.pcb, "mainboard.kicad_pcb")
+
+    def test_an_unowned_board_is_still_available_to_a_project(self) -> None:
+        # `shared.kicad_pcb` belongs to no project file, so the anchored project
+        # may still fall back to it.
+        write_tree(self.root, ["top.kicad_pro", "shared.kicad_pcb"])
+        config = path_config_service.get_path_config(str(self.root), anchor="top.kicad_pro")
+        self.assertEqual(config.pcb, "shared.kicad_pcb")
+
+    def test_an_explicit_setting_still_wins(self) -> None:
+        # Ownership shapes detection, not a choice the user made deliberately.
+        write_tree(self.root, ["base.kicad_pro", "base.kicad_pcb", "top.kicad_pro"])
+        (self.root / ".prism.json").write_text(
+            json.dumps({"projects": {"top.kicad_pro": {"paths": {"pcb": "base.kicad_pcb"}}}}),
+            encoding="utf-8",
+        )
+        config = path_config_service.get_path_config(str(self.root), anchor="top.kicad_pro")
+        self.assertEqual(config.pcb, "base.kicad_pcb")

--- a/backend/tests/test_project_discovery.py
+++ b/backend/tests/test_project_discovery.py
@@ -135,3 +135,82 @@ class KeepsExistingBehaviour(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SeveralProjectsInOneDirectory(unittest.TestCase):
+    """KiCad allows two projects to share a directory; Prism has to as well.
+
+    A fixture repository keeping its top and base plate side by side in the root
+    used to import as a single project: both were discovered, but both answered
+    to the same directory, so one checkbox ticked both, one row was registered,
+    and it was named after one board while the viewer rendered the other.
+    """
+
+    tree = [
+        "bed_of_nails_base.kicad_pro",
+        "bed_of_nails_base.kicad_pcb",
+        "bed_of_nails_base.kicad_sch",
+        "bed_of_nails_top.kicad_pro",
+        "bed_of_nails_top.kicad_pcb",
+        "bed_of_nails_top.kicad_sch",
+        "README.md",
+    ]
+
+    def test_both_projects_are_discovered(self) -> None:
+        projects = discover(self.tree)
+        self.assertEqual(
+            [p.name for p in projects], ["bed_of_nails_base", "bed_of_nails_top"]
+        )
+        self.assertEqual([p.relative_path for p in projects], [".", "."])
+
+    def test_each_project_records_its_own_file(self) -> None:
+        projects = discover(self.tree)
+        self.assertEqual(
+            [p.project_file for p in projects],
+            ["bed_of_nails_base.kicad_pro", "bed_of_nails_top.kicad_pro"],
+        )
+
+    def test_project_keys_are_distinct(self) -> None:
+        keys = [p.project_key for p in discover(self.tree)]
+        self.assertEqual(
+            keys,
+            [".::bed_of_nails_base.kicad_pro", ".::bed_of_nails_top.kicad_pro"],
+        )
+        self.assertEqual(len(set(keys)), 2)
+
+    def test_design_files_are_attributed_per_project(self) -> None:
+        # "Is there a board anywhere in this directory?" is the right question
+        # for one project per directory and the wrong one for two.
+        projects = discover(
+            [
+                "with_board.kicad_pro",
+                "with_board.kicad_pcb",
+                "sch_only.kicad_pro",
+                "sch_only.kicad_sch",
+            ]
+        )
+        by_name = {p.name: p for p in projects}
+        self.assertTrue(by_name["with_board"].has_pcb)
+        self.assertFalse(by_name["with_board"].has_schematic)
+        self.assertFalse(by_name["sch_only"].has_pcb)
+        self.assertTrue(by_name["sch_only"].has_schematic)
+
+    def test_two_root_projects_are_type2(self) -> None:
+        self.assertEqual(
+            project_import_service.classify_import_type(discover(self.tree)), "type2"
+        )
+
+
+class ProjectKeys(unittest.TestCase):
+    def test_a_lone_project_keeps_its_bare_directory_key(self) -> None:
+        # Single-project repositories are the overwhelming majority, and their
+        # keys have to keep the spelling already recorded against them.
+        projects = discover(["board.kicad_pro", "board.kicad_pcb"])
+        self.assertEqual(projects[0].project_key, ".::board.kicad_pro")
+
+    def test_a_project_without_a_project_file_is_anchored_on_its_board(self) -> None:
+        projects = discover(["board.kicad_pcb"])
+        self.assertEqual(projects[0].project_file, "board.kicad_pcb")
+
+    def test_a_row_without_an_anchor_keys_on_its_directory_alone(self) -> None:
+        self.assertEqual(project_import_service.make_project_key("hardware/a", ""), "hardware/a")

--- a/backend/tests/test_release_studio_schema_migration.py
+++ b/backend/tests/test_release_studio_schema_migration.py
@@ -1782,6 +1782,7 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
                 (17, "release_studio_terminal_and_identity_guards"),
                 (18, "release_studio_source_defaults"),
                 (19, "release_studio_project_signoff"),
+                (20, "project_file_anchor"),
             ],
         )
 

--- a/backend/tests/test_thumbnail_jobs.py
+++ b/backend/tests/test_thumbnail_jobs.py
@@ -137,7 +137,7 @@ class ThumbnailJobHandler(unittest.TestCase):
                 progress=lambda **values: None,
             )
 
-            def failed_render(_project_path, logs):
+            def failed_render(_project_path, logs, anchor=None):
                 logs.append("kicad-cli render failed (code 1): render error")
                 return False
 
@@ -169,7 +169,7 @@ class ThumbnailJobHandler(unittest.TestCase):
                 progress=lambda **values: None,
             )
 
-            def no_board(_project_path, logs):
+            def no_board(_project_path, logs, anchor=None):
                 logs.append(f"No .kicad_pcb file found to generate thumbnail for {_project_path}")
                 return False
 

--- a/frontend/src/components/import-dialog.test.ts
+++ b/frontend/src/components/import-dialog.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { importReviewTitle } from "./import-dialog";
+import {
+  importReviewTitle,
+  isProjectAlreadyImported,
+  projectKeyOf,
+  projectsPerDirectory,
+  selectableProjectKeys,
+  type DiscoveredProject,
+} from "./import-dialog";
+
+const project = (
+  overrides: Partial<DiscoveredProject> & Pick<DiscoveredProject, "name">,
+): DiscoveredProject => ({
+  relative_path: ".",
+  has_schematic: true,
+  has_pcb: true,
+  ...overrides,
+});
 
 describe("importReviewTitle", () => {
   it("reports an empty analysis instead of claiming multiple projects", () => {
@@ -10,17 +26,79 @@ describe("importReviewTitle", () => {
   });
 
   it("preserves the single and multiple project titles", () => {
-    const project = {
-      name: "Power",
-      relative_path: ".",
-      has_schematic: true,
-      has_pcb: true,
-    };
-    expect(importReviewTitle({ import_type: "type1", projects: [project] })).toBe(
+    const power = project({ name: "Power" });
+    expect(importReviewTitle({ import_type: "type1", projects: [power] })).toBe(
       "Single Project Detected",
     );
-    expect(importReviewTitle({ import_type: "type2", projects: [project] })).toBe(
+    expect(importReviewTitle({ import_type: "type2", projects: [power] })).toBe(
       "Multiple Projects Detected",
     );
+  });
+});
+
+describe("selecting projects that share a directory", () => {
+  // Two KiCad projects in a repository root both report "." as their location.
+  // Selection used to be keyed on that, so ticking one ticked both and only one
+  // of the two could ever be imported.
+  const base = project({
+    name: "base",
+    project_key: ".::base.kicad_pro",
+    project_file: "base.kicad_pro",
+  });
+  const top = project({
+    name: "top",
+    project_key: ".::top.kicad_pro",
+    project_file: "top.kicad_pro",
+  });
+
+  it("gives each project its own key", () => {
+    expect(projectKeyOf(base)).not.toBe(projectKeyOf(top));
+  });
+
+  it("offers both projects for import", () => {
+    expect(selectableProjectKeys([base, top], new Set())).toEqual([
+      ".::base.kicad_pro",
+      ".::top.kicad_pro",
+    ]);
+  });
+
+  it("marks only the imported one as done", () => {
+    const imported = new Set([".::base.kicad_pro"]);
+    const perDirectory = projectsPerDirectory([base, top]);
+    expect(isProjectAlreadyImported(base, imported, perDirectory)).toBe(true);
+    expect(isProjectAlreadyImported(top, imported, perDirectory)).toBe(false);
+    expect(selectableProjectKeys([base, top], imported)).toEqual([
+      ".::top.kicad_pro",
+    ]);
+  });
+
+  it("keeps a selection of one project to one project", () => {
+    const selected = new Set<string>();
+    selected.add(projectKeyOf(top));
+    expect(selected.has(projectKeyOf(top))).toBe(true);
+    expect(selected.has(projectKeyOf(base))).toBe(false);
+    expect(selected.size).toBe(1);
+  });
+});
+
+describe("projects registered before Prism recorded project files", () => {
+  it("still counts as imported when it is alone in its directory", () => {
+    const only = project({ name: "board", relative_path: "hardware/board" });
+    const perDirectory = projectsPerDirectory([only]);
+    expect(
+      isProjectAlreadyImported(only, new Set(["hardware/board"]), perDirectory),
+    ).toBe(true);
+  });
+
+  it("does not mark a sibling that shares its directory as imported", () => {
+    const base = project({ name: "base", project_key: ".::base.kicad_pro" });
+    const top = project({ name: "top", project_key: ".::top.kicad_pro" });
+    const perDirectory = projectsPerDirectory([base, top]);
+    expect(isProjectAlreadyImported(top, new Set(["."]), perDirectory)).toBe(false);
+  });
+
+  it("falls back to the directory when the backend sends no key", () => {
+    const legacy = project({ name: "board", relative_path: "hardware/board" });
+    expect(projectKeyOf(legacy)).toBe("hardware/board");
   });
 });

--- a/frontend/src/components/import-dialog.tsx
+++ b/frontend/src/components/import-dialog.tsx
@@ -15,12 +15,65 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, Check, AlertCircle } from "lucide-react";
 import { isDialogSubmitShortcut } from "@/lib/dialog-shortcuts";
 
-interface DiscoveredProject {
+export interface DiscoveredProject {
   name: string;
   relative_path: string;
+  /**
+   * Identifies one project. A directory can hold several KiCad projects, so the
+   * directory alone cannot: selecting by `relative_path` used to tick every
+   * project sharing a directory at once. Older backends do not send this.
+   */
+  project_key?: string;
+  /** The project's own .kicad_pro (or board) file within `relative_path`. */
+  project_file?: string;
   has_schematic: boolean;
   has_pcb: boolean;
   has_project_file?: boolean;
+}
+
+/** The key a project is selected by, falling back to pre-`project_key` behaviour. */
+export const projectKeyOf = (project: DiscoveredProject): string =>
+  project.project_key ?? project.relative_path;
+
+/** How many discovered projects share each directory. */
+export function projectsPerDirectory(
+  projects: DiscoveredProject[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const project of projects) {
+    counts.set(project.relative_path, (counts.get(project.relative_path) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function isProjectAlreadyImported(
+  project: DiscoveredProject,
+  importedPaths: Set<string>,
+  perDirectory: Map<string, number>,
+): boolean {
+  if (importedPaths.has(projectKeyOf(project))) {
+    return true;
+  }
+  // A project registered before Prism recorded project files reports its bare
+  // directory. It stands for that directory's one project, so it must not mark
+  // a sibling that shares the directory as imported.
+  return (
+    importedPaths.has(project.relative_path) &&
+    perDirectory.get(project.relative_path) === 1
+  );
+}
+
+/** The keys of the projects the user can still choose to import. */
+export function selectableProjectKeys(
+  projects: DiscoveredProject[],
+  importedPaths: Set<string>,
+): string[] {
+  const perDirectory = projectsPerDirectory(projects);
+  return projects.flatMap((project) =>
+    isProjectAlreadyImported(project, importedPaths, perDirectory)
+      ? []
+      : [projectKeyOf(project)],
+  );
 }
 
 interface AnalysisResult {
@@ -34,7 +87,7 @@ interface AnalysisResult {
   default_branch?: string | null;
   ref?: string | null;
   already_imported?: boolean;
-  /** Relative paths already registered, so they can be shown as done. */
+  /** Project keys already registered, so they can be shown as done. */
   imported_paths?: string[];
 }
 
@@ -263,7 +316,7 @@ export function ImportDialog({
 
           // Auto-select type1
           if (result.import_type === "type1" && result.projects.length === 1) {
-            setSelectedPaths(new Set([result.projects[0].relative_path]));
+            setSelectedPaths(new Set([projectKeyOf(result.projects[0])]));
           } else {
             // Adding to an existing repository: preselect nothing, so the user
             // picks only what they actually want on top of what is there.
@@ -477,17 +530,25 @@ export function ImportDialog({
     handleClose();
   };
 
-  const toggleProjectSelection = (relativePath: string) => {
+  const toggleProjectSelection = (projectKey: string) => {
     setSelectedPaths((prev) => {
       const next = new Set(prev);
-      if (next.has(relativePath)) {
-        next.delete(relativePath);
+      if (next.has(projectKey)) {
+        next.delete(projectKey);
       } else {
-        next.add(relativePath);
+        next.add(projectKey);
       }
       return next;
     });
   };
+
+  const perDirectory = useMemo(
+    () =>
+      projectsPerDirectory(
+        state.step === "review" ? state.analysis.projects : [],
+      ),
+    [state],
+  );
 
   const importedPathSet = useMemo(
       () => new Set(
@@ -497,11 +558,12 @@ export function ImportDialog({
       ),
       [state],
   );
+  const isAlreadyImported = (project: DiscoveredProject): boolean =>
+    isProjectAlreadyImported(project, importedPathSet, perDirectory);
+
   const importablePaths =
     state.step === "review"
-      ? state.analysis.projects.flatMap((p) => (
-          importedPathSet.has(p.relative_path) ? [] : [p.relative_path]
-        ))
+      ? selectableProjectKeys(state.analysis.projects, importedPathSet)
       : [];
   const importableCount = importablePaths.length;
 
@@ -694,27 +756,29 @@ export function ImportDialog({
 
             <div className="max-h-64 overflow-y-auto border rounded-md">
               {state.analysis.projects.map((project) => {
-                const alreadyImported =
-                  importedPathSet.has(project.relative_path);
+                const projectKey = projectKeyOf(project);
+                const alreadyImported = isAlreadyImported(project);
+                // Two projects in one directory would otherwise both read
+                // "Root directory", with nothing on screen telling them apart.
+                const sharesDirectory =
+                  (perDirectory.get(project.relative_path) ?? 0) > 1;
+                const location =
+                  project.relative_path === "." ? "Root directory" : project.relative_path;
                 return (
                 <div
-                  key={project.relative_path}
+                  key={projectKey}
                   className="flex items-center gap-3 p-3 border-b last:border-b-0 hover:bg-muted/50"
                 >
                   {state.analysis.import_type === "type2" && (
                     <Checkbox
-                      checked={
-                        alreadyImported || selectedPaths.has(project.relative_path)
-                      }
+                      checked={alreadyImported || selectedPaths.has(projectKey)}
                       disabled={alreadyImported}
                       aria-label={
                         alreadyImported
                           ? `${project.name} is already imported`
                           : `Select ${project.name}`
                       }
-                      onCheckedChange={() =>
-                        toggleProjectSelection(project.relative_path)
-                      }
+                      onCheckedChange={() => toggleProjectSelection(projectKey)}
                     />
                   )}
                   {state.analysis.import_type === "type1" && (
@@ -723,9 +787,9 @@ export function ImportDialog({
                   <div className="flex-1 min-w-0">
                     <p className="font-medium truncate">{project.name}</p>
                     <p className="text-sm text-muted-foreground truncate">
-                      {project.relative_path === "."
-                        ? "Root directory"
-                        : project.relative_path}
+                      {sharesDirectory && project.project_file
+                        ? `${location} / ${project.project_file}`
+                        : location}
                     </p>
                   </div>
                   <div className="flex gap-2 text-xs text-muted-foreground">


### PR DESCRIPTION
Fixes #193, plus a plaintext-remote bug found while reproducing it.

## The problem

KiCad allows several projects to share a directory, and teams use it — the reporter's repository keeps a test fixture's top and base plate side by side in its root. Prism identified a project by that directory alone, so all four reported symptoms follow from one cause:

| Symptom | Cause |
| --- | --- |
| Ticking one project ticks them all | Selection was a `Set<relative_path>`; both projects report `"."` |
| Only one project is registered | `selected_paths` collapsed to a single `"."` |
| Named after one board, renders another | `discovered_names` collapsed to the alphabetically **last** project; `find_kicad_project` returned `sorted(glob)[0]`, the **first**. Name and board came from opposite ends of one sorted list |
| Changing sch/PCB paths does nothing | `find_kicad_project` ignored `config.pcb`/`config.schematic`, and `.prism.json` was excluded from the bundle fingerprint, so nothing rebuilt |

## The change

A project now carries an **anchor** — its own `.kicad_pro`, or the board KiCad would regenerate one from — recorded in `ws_projects.project_file_rel` and threaded through discovery, path resolution, the viewer, thumbnails and the jobset runner. Without an anchor every resolver behaves exactly as before, so single-project repositories are untouched.

Resolution follows KiCad's own rule that a project owns the files sharing its name. The existing "first board in the directory" fallback stays, since plenty of repositories name the board something else, but it can no longer land on a file another project in that directory owns — that fallback is what rendered the neighbour's board.

`UNIQUE(repo_id, relative_path)` made the second project in a directory impossible to register at all. Migration 20 widens it to include the project file, which only admits rows the old constraint rejected, so it cannot fail on existing data. Per-project settings live under `projects.<anchor>` in `.prism.json`, with the flat shape kept as the directory's shared default.

### Second commit: plaintext remotes

`http://` is refused by default and enabled with `IMPORT_ALLOW_INSECURE_HTTP`, for an internal Git server without TLS. That switch only governed the URL the user types — the two places that read a remote *back* applied the default policy instead. On such a workspace a repository imported once and then failed every time it was returned to (`Existing checkout … belongs to a different remote`), which is precisely the incremental import that lets a monorepo's other boards be added later. Deduplication degraded more quietly, falling back to an exact string comparison that a trailing `.git` defeats.

## Verification

- **Backend: 1019 tests pass** against a real PostgreSQL with migration 20 applied (42 skipped). Both plaintext-remote tests were confirmed to fail without their fix.
- **Frontend:** lint clean, `scan:gate` at baseline, 502 tests, build succeeds.
- **End-to-end**, no mocks — a real git server, real `git clone`, real PostgreSQL and the real job handlers, against a fixture matching the reporter's layout. 29/29 checks, over **both** https and plain http: analyze finds two projects with distinct keys; importing one registers exactly one; the sibling is still offered and imports into the same repository row; re-importing is refused; each project resolves its own board, schematic and `.kicad_pro`; editing one project's PCB path moves that project, leaves its sibling alone, and invalidates the semantic bundle.

Migration 20 is additive and the constraint change is strictly widening, so this needs no backfill and can roll forward on a live workspace. Projects registered before the anchor existed keep their bare-directory identity and are backfilled opportunistically on the next asset refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)