### PR TITLE
feat(catalog): serve an asset's stored bytes to the browser

### DIFF
--- a/backend/app/api/catalog_admin.py
+++ b/backend/app/api/catalog_admin.py
@@ -946,6 +946,31 @@ def get_catalog_preview(preview_id: str, user: AuthenticatedUser = Depends(requi
     return FileResponse(path, media_type=content_type, headers={"Cache-Control": "private, max-age=300"})
 
 
+@router.get("/assets/{asset_id}/content")
+def get_catalog_asset_content(asset_id: str, user: AuthenticatedUser = Depends(require_catalog_reader)):
+    """Serve an asset's stored bytes so the browser can render it.
+
+    Deliberately not the placement payload from the remote-provider download:
+    that one rewrites a symbol's footprint reference and a footprint's
+    3D-model paths for KiCad. A renderer wants the library file itself.
+    """
+    _ = user
+    asset = catalog_service.catalog_asset_source(asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    path, content_type, filename = asset
+    return FileResponse(
+        path,
+        media_type=content_type,
+        # Assets are immutable once written -- a change produces a new asset
+        # row -- but they are catalog content, so keep the cache private.
+        headers={
+            "Cache-Control": "private, max-age=300",
+            "Content-Disposition": f'inline; filename="{filename}"',
+        },
+    )
+
+
 @router.patch("/components/{component_id}")
 def update_catalog_component(
     component_id: str,

--- a/backend/app/api/remote_provider.py
+++ b/backend/app/api/remote_provider.py
@@ -422,6 +422,32 @@ async def download_asset(
     )
 
 
+@router.get("/api/remote-provider/assets/{asset_id}/content")
+async def get_asset_content(
+    asset_id: str,
+    user: AuthenticatedUser = Depends(require_remote_symbol_reader),
+):
+    """Serve an asset's stored bytes to the panel so it can render them.
+
+    The signed `/assets/{asset_id}` download above is KiCad's placement path
+    and rewrites the payload for it. This one is the library file as stored,
+    and is gated by the panel's own reader dependency rather than a signature.
+    """
+    _ = user
+    asset = await asyncio.to_thread(catalog_service.catalog_asset_source, asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    path, content_type, filename = asset
+    return FileResponse(
+        path,
+        media_type=content_type,
+        headers={
+            "Cache-Control": "private, max-age=300",
+            "Content-Disposition": f'inline; filename="{filename}"',
+        },
+    )
+
+
 @router.get("/api/remote-provider/previews/{preview_id}")
 async def download_preview(
     preview_id: str,

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -2649,6 +2649,42 @@ class ComponentCatalogDomainService:
             return None
         return (path, str(row["content_type"] or "image/svg+xml")) if path.is_file() else None
 
+    def catalog_asset_source(self, asset_id: str) -> tuple[Path, str, str] | None:
+        """One asset's stored bytes, as written -- not the placement rewrite.
+
+        ``get_asset_by_id`` returns what KiCad places: a symbol carries an
+        injected footprint reference and the component's fields, a footprint
+        carries rewritten 3D-model paths. Those rewrites exist for placement.
+        A renderer wants the file as the library holds it, so this resolves the
+        canonical path instead of materialising a payload.
+
+        Returns ``(path, content_type, filename)``, or ``None`` when the asset
+        is unknown or its file is missing.
+        """
+        self.initialize()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT canonical_path, asset_type FROM assets WHERE id = %s",
+                (asset_id,),
+            ).fetchone()
+        if not row:
+            return None
+        path = Path(str(row["canonical_path"] or "")).resolve()
+        # Every asset root is a child of the store root. Confining the resolved
+        # path keeps a stored value that escaped the store -- or a row written
+        # by an older import -- from turning this into an arbitrary file read.
+        try:
+            path.relative_to(self._store_root.resolve())
+        except ValueError:
+            return None
+        if not path.is_file():
+            return None
+        return (
+            path,
+            _content_type_for_asset(str(row["asset_type"] or ""), path),
+            path.name,
+        )
+
     def create_project_import_session(
         self,
         *,

--- a/backend/tests/test_catalog_asset_content.py
+++ b/backend/tests/test_catalog_asset_content.py
@@ -1,0 +1,175 @@
+"""Serving an asset's stored bytes to the browser.
+
+The renderer that replaces stored SVG previews (issue #200) needs the library
+file itself. The existing download path returns the *placement* payload KiCad
+consumes, which is a different thing, so these tests pin the distinction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi import HTTPException  # noqa: E402
+
+from app.api import catalog_admin  # noqa: E402
+from app.api import remote_provider as rp  # noqa: E402
+from app.core.roles import CATALOG_READ_ROLES  # noqa: E402
+from app.core.security import AuthenticatedUser, require_catalog_reader  # noqa: E402
+
+
+SYMBOL = b'(kicad_symbol_lib (version 20231120) (symbol "R"))'
+
+
+class AssetSourceResolution(unittest.TestCase):
+    """`catalog_asset_source` on the domain service."""
+
+    def setUp(self) -> None:
+        from app.services.component_catalog_domain import (  # noqa: PLC0415
+            _content_type_for_asset,
+        )
+
+        self._content_type_for_asset = _content_type_for_asset
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.store = Path(tmp.name) / "components"
+        (self.store / "symbols").mkdir(parents=True)
+        self.asset = self.store / "symbols" / "R_Small.kicad_sym"
+        self.asset.write_bytes(SYMBOL)
+        self.outside = Path(tmp.name) / "elsewhere.kicad_sym"
+        self.outside.write_bytes(b"(kicad_symbol_lib)")
+
+    def _service(self, row: dict[str, object] | None):
+        """A stand-in for the domain service with one row in `assets`."""
+        from app.services.component_catalog_domain import (  # noqa: PLC0415
+            ComponentCatalogDomainService,
+        )
+
+        class _Cursor:
+            def fetchone(self_inner):
+                return row
+
+        class _Conn:
+            def execute(self_inner, *_args, **_kwargs):
+                return _Cursor()
+
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *_exc):
+                return False
+
+        service = ComponentCatalogDomainService.__new__(ComponentCatalogDomainService)
+        service._store_root = self.store
+        service.initialize = lambda: None
+        service._connect = lambda: _Conn()
+        return service
+
+    def test_returns_the_stored_file_not_a_placement_payload(self) -> None:
+        service = self._service(
+            {"canonical_path": str(self.asset), "asset_type": "symbol"}
+        )
+        resolved = service.catalog_asset_source("asset-1")
+        self.assertIsNotNone(resolved)
+        path, content_type, filename = resolved
+        self.assertEqual(path.read_bytes(), SYMBOL)
+        self.assertEqual(content_type, "application/x-kicad-symbol")
+        self.assertEqual(filename, "R_Small.kicad_sym")
+
+    def test_refuses_a_path_outside_the_store(self) -> None:
+        # A row whose canonical_path escaped the store must not become an
+        # arbitrary file read through an authenticated endpoint.
+        service = self._service(
+            {"canonical_path": str(self.outside), "asset_type": "symbol"}
+        )
+        self.assertIsNone(service.catalog_asset_source("asset-1"))
+
+    def test_refuses_a_traversal_through_the_store(self) -> None:
+        escape = self.store / "symbols" / ".." / ".." / "elsewhere.kicad_sym"
+        service = self._service(
+            {"canonical_path": str(escape), "asset_type": "symbol"}
+        )
+        self.assertIsNone(service.catalog_asset_source("asset-1"))
+
+    def test_missing_row_and_missing_file_both_resolve_to_nothing(self) -> None:
+        self.assertIsNone(self._service(None).catalog_asset_source("nope"))
+        gone = self.store / "symbols" / "absent.kicad_sym"
+        service = self._service(
+            {"canonical_path": str(gone), "asset_type": "symbol"}
+        )
+        self.assertIsNone(service.catalog_asset_source("asset-1"))
+
+
+class AssetContentRoutes(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.asset = Path(tmp.name) / "R_Small.kicad_sym"
+        self.asset.write_bytes(SYMBOL)
+        self.user = AuthenticatedUser(
+            email="designer@example.com", name="Designer", role="designer"
+        )
+
+    def test_admin_route_serves_the_file(self) -> None:
+        resolved = (self.asset, "application/x-kicad-symbol", self.asset.name)
+        with patch.object(
+            catalog_admin.catalog_service, "catalog_asset_source", return_value=resolved
+        ):
+            response = catalog_admin.get_catalog_asset_content("asset-1", user=self.user)
+        self.assertEqual(response.media_type, "application/x-kicad-symbol")
+        self.assertEqual(response.headers["cache-control"], "private, max-age=300")
+        self.assertIn("R_Small.kicad_sym", response.headers["content-disposition"])
+
+    def test_admin_route_404s_for_an_unknown_asset(self) -> None:
+        with patch.object(
+            catalog_admin.catalog_service, "catalog_asset_source", return_value=None
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                catalog_admin.get_catalog_asset_content("nope", user=self.user)
+        self.assertEqual(raised.exception.status_code, 404)
+
+    def test_panel_route_serves_the_file(self) -> None:
+        resolved = (self.asset, "application/x-kicad-symbol", self.asset.name)
+        with patch.object(
+            rp.catalog_service, "catalog_asset_source", return_value=resolved
+        ):
+            response = asyncio.run(rp.get_asset_content("asset-1", user=self.user))
+        self.assertEqual(response.media_type, "application/x-kicad-symbol")
+
+    def test_panel_route_404s_for_an_unknown_asset(self) -> None:
+        with patch.object(
+            rp.catalog_service, "catalog_asset_source", return_value=None
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                asyncio.run(rp.get_asset_content("nope", user=self.user))
+        self.assertEqual(raised.exception.status_code, 404)
+
+
+class AssetContentAuthorization(unittest.TestCase):
+    """The admin route is catalog-read; the panel route is remote-symbol-read."""
+
+    def test_every_catalog_reader_role_is_allowed(self) -> None:
+        for role in sorted(CATALOG_READ_ROLES):
+            user = AuthenticatedUser(email=f"{role}@example.com", name=role, role=role)
+            self.assertIs(asyncio.run(require_catalog_reader(user=user)), user)
+
+    def test_a_viewer_is_refused(self) -> None:
+        # `viewer` authenticates fine and reads projects, but the catalog is a
+        # separate grant -- authentication is not object authorization.
+        viewer = AuthenticatedUser(
+            email="viewer@example.com", name="Viewer", role="viewer"
+        )
+        self.assertNotIn("viewer", CATALOG_READ_ROLES)
+        with self.assertRaises(HTTPException) as raised:
+            asyncio.run(require_catalog_reader(user=viewer))
+        self.assertEqual(raised.exception.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 2 of #200. Backend only — no frontend consumer yet; that is Phase 3.

## Why a new endpoint

Nothing served asset bytes to a browser. The admin catalog API exposed preview
images and asset *metadata* (`assets/search`, `assets/browse`), and the only
route returning bytes is the signed `/api/remote-provider/assets/{asset_id}`
download meant for KiCad.

**That download is deliberately not reused.** `_materialize_asset` rewrites what
it returns — a symbol gains an injected footprint reference and the component's
fields, a footprint gains rewritten 3D-model paths — because that is what KiCad
needs in order to place the part. A renderer wants the file as the library holds
it, so `catalog_asset_source` resolves the canonical path rather than
materialising a payload.

## What this adds

| route | dependency | surface |
| --- | --- | --- |
| `GET /api/catalog/assets/{asset_id}/content` | `require_catalog_reader` | Component Database, Assets tab |
| `GET /api/remote-provider/assets/{asset_id}/content` | `require_remote_symbol_reader` | Remote Symbol Panel |

Neither shadows an existing path — verified against the generated OpenAPI
schema, since this FastAPI version keeps included routers unflattened and
`app.routes` does not show them.

`ComponentCatalogDomainService.catalog_asset_source(asset_id)` returns
`(path, content_type, filename)` or `None`.

## Path confinement

The resolved path is confined to the store root, matching the neighbouring
`catalog_preview_path`. Every asset root (`symbols/`, `footprints/`,
`3dmodels/`, `spice/`) is a child of it, so this costs nothing in the normal
case — including for linked library assets, which also live under the store.

It matters because the asset writer has a fallback that tolerates a
`canonical_path` outside the store (`_register_asset` falls back to
`Path(canonical_path.name)` when `relative_to` raises). Without the guard, such
a row would turn an authenticated endpoint into an arbitrary file read. Both
confinement tests were confirmed to fail with the guard removed.

The store root is resolved at comparison time rather than trusting the
constructor, again matching `catalog_preview_path`.

## Tests

10 new, in `backend/tests/test_catalog_asset_content.py`:

- stored bytes are returned, not a placement payload
- a path outside the store is refused
- a `..` traversal through the store is refused
- unknown row and missing file both resolve to `None`
- both routes serve the file, and both 404 on an unknown asset
- every `CATALOG_READ_ROLES` role is allowed; `viewer` is refused 403

## Checks

| | |
| --- | --- |
| `compileall` | clean |
| `unittest discover` | 1033 passed, 85 skipped (was 1023) |

The 85 skips are the PostgreSQL integration tests — `TEST_POSTGRES_URL` was not
set locally, so **those paths did not run here**. This change adds one `SELECT`
against `assets` and no schema change.

Frontend, semantic viewer and deployment suites were not run: nothing in those
areas changed.

## Next

Phase 3 swaps `LibraryPreviewViewport`'s `<img>` child for a renderer that
fetches from these routes. It depends on
[ecad-viewer#14](https://github.com/krishna-swaroop/ecad-viewer/pull/14), now
merged to `dev`, being bundled into Prism.
