### PR TITLE
chore(workspace): drop the decorative Properties badge

### DIFF
--- a/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
+++ b/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
@@ -16,7 +16,6 @@ import {
 import { fetchJson } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { FolderTreeItem, Project, ProjectPropertiesResponse } from "@/types/project";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -316,10 +315,7 @@ export function WorkspaceProjectPropertiesSheet({
       <div className="flex min-h-full flex-col overflow-hidden">
         <div className="space-y-3 border-b px-6 py-5 text-left">
           <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="outline">Properties</Badge>
-              </div>
+            <div className="min-w-0">
               <div className="space-y-1">
                 <h2 className="truncate text-2xl font-semibold leading-tight">{displayName}</h2>
                 <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
The `Properties` badge in the project properties panel header was static text: not interactive, no state, always the same word, sitting alone in a `flex flex-wrap` row that never held anything else.

It also restated what two other things already said — the panel carries `aria-label="Project properties panel"`, and the project name sits directly beneath it — while costing a row of header height in a panel that has to fit a board render plus its metadata.

Removed, along with its empty wrapper and the now-unused `Badge` import.

`tsc -b`, `eslint`, 512 tests, react-doctor gate at baseline (0 warnings).

---