### PR TITLE
Prepare v3.1.0-alpha release path

### DIFF
--- a/.github/workflows/dev-quality-gate.yml
+++ b/.github/workflows/dev-quality-gate.yml
@@ -98,6 +98,7 @@ jobs:
       # database, because it drops and rebuilds schema objects. Pointing both
       # names at one database silently skipped the entire suite.
       TEST_POSTGRES_URL: postgresql://postgres@127.0.0.1:5432/kicad_prism_catalog_test
+      LEGACY_SURVIVOR_TEST_POSTGRES_URL: postgresql://postgres@127.0.0.1:5432/kicad_prism_survivor_test
 
     steps:
       - name: Check out source
@@ -114,7 +115,9 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Create the isolated catalog test database
-        run: psql "$PRISM_DATABASE_URL" -c 'CREATE DATABASE kicad_prism_catalog_test'
+        run: |
+          psql "$PRISM_DATABASE_URL" -c 'CREATE DATABASE kicad_prism_catalog_test'
+          psql "$PRISM_DATABASE_URL" -c 'CREATE DATABASE kicad_prism_survivor_test'
 
       - name: Compile Python sources
         run: python -m compileall -q app
@@ -124,11 +127,23 @@ jobs:
 
       - name: Require the catalog integration suite to have run
         run: |
+          set -o pipefail
           # These tests skip themselves when TEST_POSTGRES_URL is missing or
           # points at the application database, so a silent skip looks green.
           python -m unittest tests.test_component_catalog_postgres_integration -v 2>&1 | tee result.log
           if grep -q "skipped" result.log; then
             echo "Catalog integration tests skipped; check TEST_POSTGRES_URL." >&2
+            exit 1
+          fi
+
+      - name: Require the legacy survivor integration suite to have run
+        run: |
+          set -o pipefail
+          # This is the destructive upgrade path: export a legacy catalog,
+          # initialize epoch 2, and restore every non-CERN survivor.
+          python -m unittest tests.test_legacy_catalog_survivor_postgres_integration -v 2>&1 | tee survivor-result.log
+          if grep -q "skipped" survivor-result.log; then
+            echo "Legacy survivor integration tests skipped; check LEGACY_SURVIVOR_TEST_POSTGRES_URL." >&2
             exit 1
           fi
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,9 @@ jobs:
           --tag "$GITHUB_REF_NAME"
           --github-output "$GITHUB_OUTPUT"
 
+      - name: Require checked-in release notes
+        run: test -f "docs/releases/${GITHUB_REF_NAME}.md"
+
       - name: Require tagged commit on main
         id: source
         run: |
@@ -257,7 +260,7 @@ jobs:
           name: KiCAD Prism ${{ github.ref_name }}
           prerelease: ${{ needs.validate.outputs.prerelease }}
           make_latest: ${{ needs.validate.outputs.prerelease == 'false' }}
-          generate_release_notes: true
+          body_path: docs/releases/${{ github.ref_name }}.md
           fail_on_unmatched_files: true
           files: |
             ${{ steps.bundle.outputs.archive }}

--- a/backend/app/api/release_studio.py
+++ b/backend/app/api/release_studio.py
@@ -111,7 +111,15 @@ async def get_source(
             repo_root, commit_sha, str(project.get("relative_path") or "")
         )
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.exception(
+            "Could not discover Release Studio source for project %s at %s",
+            project_id,
+            commit_sha,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Could not inspect this revision's Release Studio source.",
+        ) from exc
     try:
         source = apply_source_defaults(source, store.get_source_defaults(project_id))
     except Exception:
@@ -429,8 +437,13 @@ def _released_member_response(
                 )
             data = extracted.read()
     except tarfile.TarError as exc:
+        logger.exception(
+            "Could not read stored Release Studio dossier for build %s member %s",
+            build_id or build["id"],
+            member_path,
+        )
         raise HTTPException(
-            status_code=500, detail=f"The stored dossier could not be read: {exc}"
+            status_code=500, detail="The stored dossier could not be read."
         ) from exc
 
     actual = hashlib.sha256(data).hexdigest()
@@ -945,4 +958,3 @@ def _artifact_bytes(artifact_id: str | None) -> bytes:
             ),
         )
     return payload
-

--- a/backend/app/release_studio/documents/fonts/geist-1.7.0/OFL.txt
+++ b/backend/app/release_studio/documents/fonts/geist-1.7.0/OFL.txt
@@ -18,7 +18,7 @@ with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+fonts, including any derivative works, can be bundled, embedded,
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The

--- a/backend/tests/test_release_studio_api.py
+++ b/backend/tests/test_release_studio_api.py
@@ -97,6 +97,33 @@ class ReleaseStudioRequestAndCoverageTests(unittest.TestCase):
         request = self.api.PublishRequest(tag="v1.0.0", title="Board", notes="notes")
         self.assertEqual(request.tag, "v1.0.0")
 
+    def test_source_discovery_hides_internal_exception_details(self) -> None:
+        with (
+            patch.object(self.api, "get_project_for_role_or_404"),
+            patch.object(
+                self.api.workspace,
+                "get_project_by_id",
+                return_value={"path": "/srv/private/board", "relative_path": "board"},
+            ),
+            patch(
+                "app.release_studio.source.discover_source",
+                side_effect=RuntimeError("failed at /srv/private/board/secret.kicad_pro"),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                _run(
+                    self.api.get_source(
+                        "project", "a" * 40, _User("viewer", role="viewer")
+                    )
+                )
+
+        self.assertEqual(caught.exception.status_code, 400)
+        self.assertEqual(
+            caught.exception.detail,
+            "Could not inspect this revision's Release Studio source.",
+        )
+        self.assertNotIn("/srv/private", str(caught.exception.detail))
+
     def test_publish_zips_the_dossier_and_creates_a_forge_release(self) -> None:
         user = _User("designer@example.com")
         build = {
@@ -402,6 +429,18 @@ class ReleaseStudioDocumentSheetApiTests(unittest.TestCase):
                 )
             )
         self.assertEqual(caught.exception.status_code, 404)
+
+    def test_sheet_preview_hides_corrupt_archive_details(self) -> None:
+        with patch.object(self.api, "_artifact_bytes", return_value=b"not a tar archive"):
+            with self.assertRaises(HTTPException) as caught:
+                _run(
+                    self.api.preview_document_sheet(
+                        "proj", "build", "fabrication", user=self.user
+                    )
+                )
+
+        self.assertEqual(caught.exception.status_code, 500)
+        self.assertEqual(caught.exception.detail, "The stored dossier could not be read.")
 
 
 class ReleaseStudioVendorApiTests(unittest.TestCase):

--- a/deploy/release/README.md
+++ b/deploy/release/README.md
@@ -4,6 +4,24 @@ This is the pull-only Linux AMD64 deployment bundle for the release recorded in
 `VERSION`. Its generated `.env.example` pins the exact Prism backend and
 frontend image digests tested by the release workflow.
 
+## Before upgrading
+
+Read `RELEASE_NOTES.md` and `UPGRADES.md` from this archive before replacing a
+running installation. A populated pre-epoch-2 V3 catalog cannot be started by
+v3.1.0-alpha until its backup, survivor export, CERN preflight, catalog-only
+reset, and survivor restore have completed.
+
+The bundle includes the host-side backup tool. Extract the new bundle to a
+staging directory and back up the active deployment before replacing its files:
+
+```bash
+python3 /path/to/staged-bundle/scripts/prism_backup.py \
+  --root /path/to/active-prism create
+```
+
+Verify the resulting archive before continuing. `UPGRADES.md` gives the exact
+cutover order and the one-off backend-container commands for the catalog tools.
+
 ## Configure
 
 ```bash
@@ -84,5 +102,7 @@ from the next release's `.env.example` and migrate site values; copying the old
 
 Full guides:
 
+- `RELEASE_NOTES.md` in this archive
+- `UPGRADES.md` in this archive
 - <https://github.com/krishna-swaroop/KiCAD-Prism/blob/main/docs/DEPLOYMENT.md>
 - <https://github.com/krishna-swaroop/KiCAD-Prism/blob/main/docs/OPERATIONS.md>

--- a/docs/PUBLIC_DEMO_PLAN.md
+++ b/docs/PUBLIC_DEMO_PLAN.md
@@ -522,13 +522,12 @@ anonymous-admin configuration when the public origin is not local. Startup
 also logs a prominent guest-mode warning. An administrator guest is appropriate
 only for a private local seed/evaluation machine.
 
-### 4.2 `viewer` breaks two features you probably want in the demo
+### 4.2 `viewer` keeps the public demo read-only
 
 Audited guards on the mutating endpoints:
 
 | Feature | Endpoint | Guard | Works as guest viewer? |
 |---|---|---|---|
-| Visual SCH/PCB/BOM diff | `POST /api/projects/{id}/diff` | `require_designer` | **No** |
 | Design comparison | `POST /api/projects/{id}/design-compare` | `require_viewer` | Yes |
 | Trigger jobset workflow | `POST /api/projects/{id}/workflows` | `require_designer` | No (good) |
 | Generate semantic index | `POST /api/projects/{id}/semantic-index/generate` | `require_designer` | No (good) |
@@ -538,20 +537,10 @@ Audited guards on the mutating endpoints:
 | Delete project | `DELETE /api/projects/{id}` | `require_designer` | No (good) |
 | Folder create/move/delete | `folders.py` | `require_designer` | No (good) |
 
-The problem: **visual diff is designer-gated**, and it's one of the most
-compelling things Prism does. Two ways to handle it:
-
-- **Simplest (do this first):** pre-compute diffs locally for a few interesting
-  commit pairs so the cached results render, and deep-link to them from your demo
-  landing copy. Your own USB-PD board already has a tag (`A.1.0.0`) and a commit
-  history to diff against.
-- **Better long-term:** introduce an explicit `PRISM_DEMO_MODE=true` flag that
-  relaxes *read-only-but-expensive* operations for viewers while keeping all
-  destructive operations designer-gated. Implement it as a dedicated dependency
-  (e.g. `require_designer_or_demo`) applied only to `POST .../diff`, so the
-  permission widening is visible at each call site rather than hidden in role
-  resolution. Do **not** solve this by promoting guests to `designer` — that
-  would hand them project deletion, repo import, and jobset execution.
+The current Design Comparison path is viewer-accessible and is the supported
+SCH/PCB/BOM comparison experience. The older raster-diff endpoint at
+`POST /api/projects/{id}/diff` has been removed; do not build demo setup or role
+exceptions around it.
 
 The comments UI is shipped, but guest viewers cannot create or reply to
 comments. That keeps a public demo read-only while preserving discussion review;

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -68,6 +68,10 @@ out.
 Run everything from the deployment directory: the one holding `compose.yml`
 (release bundle) or `docker-compose.yml` (source build).
 
+Release-bundle users should first extract the next bundle into a separate
+staging directory. Do not replace the active deployment or start the new images
+yet. The staged bundle contains this runbook and the backup tool used below.
+
 ## 1. Record what you are running
 
 ```bash
@@ -79,6 +83,15 @@ build. Keep this with the backup — a rollback needs to know what to roll back
 *to*, and "the previous one" is not an answer at 6pm.
 
 ## 2. Take a backup
+
+Release bundle, before replacing the active files:
+
+```bash
+python3 /path/to/staged-bundle/scripts/prism_backup.py \
+  --root /path/to/active-prism create
+```
+
+Source checkout:
 
 ```bash
 python3 scripts/prism_backup.py create
@@ -100,6 +113,16 @@ of every payload.
 > plus the `.env` verbatim. Encrypt it and store it off this host.
 
 ## 3. Check that the backup is real
+
+Use the same copy of `prism_backup.py` that created the archive. For a release
+bundle staged outside the active deployment, that is:
+
+```bash
+python3 /path/to/staged-bundle/scripts/prism_backup.py verify \
+  /path/to/active-prism/prism-backup-<timestamp>.tar.gz
+```
+
+For a source checkout:
 
 ```bash
 python3 scripts/prism_backup.py verify prism-backup-<timestamp>.tar.gz
@@ -295,6 +318,43 @@ non-catalog PostgreSQL schema untouched. Use this rollout order:
 10. Rebuild project usage if the deployment requires it.
 11. Run catalog acceptance queries and default/non-default KiCad placement smoke tests before reopening access.
 
+### Run the catalog tools from the release bundle
+
+The release bundle deliberately keeps backend dependencies inside the
+digest-pinned backend image. After the verified backup, replace the deployment
+files with the new bundle, carry site values into its `.env`, pull the new
+backend image, and stop every catalog writer while leaving PostgreSQL running:
+
+```bash
+docker compose pull backend
+docker compose stop frontend backend prism-worker catalog-worker
+```
+
+Choose an absolute host directory outside `data/projects` for migration
+archives and reports, then define the command used by the examples below:
+
+```bash
+mkdir -p /absolute/host/migration
+run_catalog_tool() {
+  docker compose run --rm --no-deps \
+    --volume /absolute/host/migration:/migration \
+    backend python "$@"
+}
+```
+
+This one-off container uses the active deployment's PostgreSQL network and
+`data/projects` mount without starting the backend service. Source checkouts
+with the backend dependencies installed can use the same examples with:
+
+```bash
+run_catalog_tool() { python3 "$@"; }
+```
+
+After the catalog-only reset, initialize epoch 2 once with
+`docker compose up -d backend`, wait for it to become healthy, then stop it
+again before restoring survivors. Do not start the workers until restoration
+and the CERN import have completed.
+
 ### Preserving non-CERN work from a legacy catalog
 
 Pre-epoch-2 CERN imports did not carry the newer `external_source` marker. Their
@@ -309,13 +369,13 @@ a hard stop. Write the archive outside
 component store:
 
 ```bash
-python3 scripts/migrate_legacy_catalog_survivors.py export \
+run_catalog_tool scripts/migrate_legacy_catalog_survivors.py export \
   --output /migration/prism-legacy-survivors.zip \
   --expect-survivors <survivor-count> \
   --expect-librarian <librarian-impacted-count> \
   --expect-excluded-cern <legacy-cern-count>
 
-python3 scripts/migrate_legacy_catalog_survivors.py verify \
+run_catalog_tool scripts/migrate_legacy_catalog_survivors.py verify \
   /migration/prism-legacy-survivors.zip
 ```
 
@@ -331,7 +391,7 @@ After producing the CERN importer dry-run report, require a clean identity
 comparison:
 
 ```bash
-python3 scripts/migrate_legacy_catalog_survivors.py check-cern-report \
+run_catalog_tool scripts/migrate_legacy_catalog_survivors.py check-cern-report \
   /migration/prism-legacy-survivors.zip \
   /migration/cern-preflight.json
 ```
@@ -341,13 +401,13 @@ check all pass should the full reset run. Start the new backend once to create
 epoch 2, stop catalog writers again, and preflight then execute restoration:
 
 ```bash
-python3 scripts/migrate_legacy_catalog_survivors.py restore \
+run_catalog_tool scripts/migrate_legacy_catalog_survivors.py restore \
   /migration/prism-legacy-survivors.zip \
   --expect-components <survivor-count> \
   --confirm RESTORE-PRISM-LEGACY-SURVIVORS-EPOCH-2 \
   --dry-run
 
-python3 scripts/migrate_legacy_catalog_survivors.py restore \
+run_catalog_tool scripts/migrate_legacy_catalog_survivors.py restore \
   /migration/prism-legacy-survivors.zip \
   --expect-components <survivor-count> \
   --confirm RESTORE-PRISM-LEGACY-SURVIVORS-EPOCH-2
@@ -363,7 +423,7 @@ the other.
 The reset command is:
 
 ```bash
-python3 scripts/reset_prism_catalog.py \
+run_catalog_tool scripts/reset_prism_catalog.py \
   --confirm RESET-PRISM-CATALOG-EPOCH-2
 ```
 
@@ -372,7 +432,7 @@ the importer's explicit CERN origin marker. Non-CERN components and assets still
 referenced by them are preserved:
 
 ```bash
-python3 scripts/reset_prism_catalog.py \
+run_catalog_tool scripts/reset_prism_catalog.py \
   --cern-only \
   --confirm RESET-PRISM-CERN-IMPORTS
 ```

--- a/docs/releases/v3.1.0-alpha.md
+++ b/docs/releases/v3.1.0-alpha.md
@@ -11,7 +11,7 @@ the KiCad Remote Symbol Provider.
 > component-as-part model is an intentional destructive catalog boundary. Do
 > not start this release against a populated pre-epoch-2 catalog until you have
 > completed the backup, survivor export, CERN preflight, catalog-only reset,
-> and restore sequence in [Upgrades and backups](../UPGRADES.md#catalog-epoch-2-cutover).
+> and restore sequence in [Upgrades and backups](https://github.com/krishna-swaroop/KiCAD-Prism/blob/v3.1.0-alpha/docs/UPGRADES.md#catalog-epoch-2-cutover).
 > Project repositories and non-catalog PostgreSQL schemas are not part of the
 > reset, but rolling an epoch-2 catalog back without restoring its matching
 > backup is unsupported.
@@ -33,8 +33,8 @@ release with representative projects and libraries before reopening access.
 - Publishes approved dossiers to GitHub or GitLab Releases while keeping
   historical revisions buildable but non-publishable.
 
-See the [Release Studio guide](../release-studio/README.md) for configuration,
-operation, artifacts, and recovery details.
+See the [Release Studio guide](https://github.com/krishna-swaroop/KiCAD-Prism/blob/v3.1.0-alpha/docs/release-studio/README.md)
+for configuration, operation, artifacts, and recovery details.
 
 ### Component catalog and imports
 
@@ -49,6 +49,22 @@ operation, artifacts, and recovery details.
 - Separates Import Center sources into **KiCad libraries** and **Project
   components**, with clear local-folder, server-folder, selected-project, and
   all-project actions.
+- Correctly treats multiple KiCad projects in one directory as independent
+  catalog entries, build anchors, and thumbnail sources.
+- Repaints schematic text-variable values after project metadata arrives, so
+  library and project previews no longer retain unresolved placeholders.
+
+### Library QA and Remote Symbol Provider
+
+- Adds paired pin-to-pad inspection to the component workspace, quick view,
+  Remote Symbol Provider panel, and expanded QA dialog.
+- Hover previews a mapping in both views, click latches it, and duplicate pin or
+  pad numbers highlight every matching terminal. Unmatched items keep their
+  source-side highlight without presenting a false warning.
+- Replaces scaled SVG-style interaction for live library previews with crisp
+  camera rendering, mouse and trackpad pan, wheel/pinch zoom, and reset controls.
+- Keeps stored SVG previews and revision comparisons on their existing static
+  viewport path; the camera-driven renderer is used only for live previews.
 
 ### Design review and visualizer
 
@@ -60,6 +76,9 @@ operation, artifacts, and recovery details.
   eviction, skipped unnecessary parses, and adaptive job polling.
 - Improves long-list, resizable-panel, project-gallery, history, and selection
   inspector behavior across common laptop and desktop layouts.
+- Preserves the supported Design Comparison API at
+  `POST /api/projects/{id}/design-compare`. The obsolete raster-diff API at
+  `POST /api/projects/{id}/diff` has been removed.
 
 ### Platform reliability
 
@@ -71,13 +90,17 @@ operation, artifacts, and recovery details.
   tested upstream bundle.
 - Hardens gzip responses, asynchronous UI state, error boundaries, and large
   catalog workflows.
+- Removes the deprecated external renderer `interactive` alias. Bundle
+  consumers must use the typed `selectable`, `navigation`, `onProbe`, and
+  renderer-controller contract. Prism itself has fully migrated; there are no
+  known external consumers today.
 
 ## Upgrade requirements
 
 1. Record the current release and image digests.
 2. Create and verify a complete Prism backup.
 3. For a populated pre-epoch-2 catalog, complete every gate in the
-   [catalog epoch-2 cutover](../UPGRADES.md#catalog-epoch-2-cutover) before
+   [catalog epoch-2 cutover](https://github.com/krishna-swaroop/KiCAD-Prism/blob/v3.1.0-alpha/docs/UPGRADES.md#catalog-epoch-2-cutover) before
    starting the new application.
 4. Carry site-specific values into the new release environment; do not copy an
    older release file over the new digest pins.
@@ -87,4 +110,5 @@ operation, artifacts, and recovery details.
 
 The public release bundle remains Linux AMD64 and is published only after the
 tag points to a successful `main` Quality Gate commit and the complete release
-stack passes its image smoke test.
+stack passes its image smoke test. The archive includes this release note, the
+upgrade runbook, and the host-side backup tool needed before the epoch-2 cutover.

--- a/frontend/src/lib/diff-grouping.ts
+++ b/frontend/src/lib/diff-grouping.ts
@@ -59,5 +59,3 @@ export function mergedKind(kinds: Iterable<DiffKind>): DiffKind {
     if (set.size === 1) return set.values().next().value as DiffKind;
     return "changed";
 }
-
-

--- a/scripts/release_bundle.py
+++ b/scripts/release_bundle.py
@@ -30,6 +30,12 @@ TEMPLATE_FILES = (
     "Dockerfile.caddy-dns",
     "README.md",
 )
+REPOSITORY_FILES = (
+    ("docs/UPGRADES.md", "UPGRADES.md"),
+    ("scripts/prism_backup.py", "scripts/prism_backup.py"),
+    ("scripts/prism_deploy/__init__.py", "scripts/prism_deploy/__init__.py"),
+    ("scripts/prism_deploy/tui.py", "scripts/prism_deploy/tui.py"),
+)
 
 
 @dataclass(frozen=True)
@@ -135,7 +141,14 @@ def build_release_bundle(
     build_date: str,
 ) -> tuple[Path, Path, Path]:
     metadata = parse_release_tag(tag)
-    missing = [name for name in TEMPLATE_FILES if not (template_dir / name).is_file()]
+    repository_root = template_dir.resolve().parents[1]
+    release_notes_source = repository_root / "docs" / "releases" / f"{metadata.tag}.md"
+    source_files = [
+        *((template_dir / name, name) for name in TEMPLATE_FILES),
+        *((repository_root / source, destination) for source, destination in REPOSITORY_FILES),
+        (release_notes_source, "RELEASE_NOTES.md"),
+    ]
+    missing = [str(source) for source, _destination in source_files if not source.is_file()]
     if missing:
         raise FileNotFoundError(
             f"release template is missing required files: {', '.join(missing)}"
@@ -150,8 +163,10 @@ def build_release_bundle(
 
     output_root.mkdir(parents=True, exist_ok=True)
     bundle_dir.mkdir()
-    for name in TEMPLATE_FILES:
-        shutil.copy2(template_dir / name, bundle_dir / name)
+    for source, destination in source_files:
+        target = bundle_dir / destination
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
 
     replace_release_tokens(
         bundle_dir / ".env.example",
@@ -163,7 +178,7 @@ def build_release_bundle(
     )
     (bundle_dir / "VERSION").write_text(f"{tag}\n", encoding="utf-8")
 
-    checksum_names = (*TEMPLATE_FILES, "VERSION")
+    checksum_names = tuple(destination for _source, destination in source_files) + ("VERSION",)
     checksum_lines = [
         f"{sha256(bundle_dir / name)}  {name}" for name in checksum_names
     ]

--- a/scripts/test_release_bundle.py
+++ b/scripts/test_release_bundle.py
@@ -44,6 +44,15 @@ class ReleaseMetadataTests(unittest.TestCase):
 
 
 class ReleaseBundleTests(unittest.TestCase):
+    def test_release_workflow_publishes_the_checked_in_notes(self) -> None:
+        workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "docker-publish.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('test -f "docs/releases/${GITHUB_REF_NAME}.md"', workflow)
+        self.assertIn("body_path: docs/releases/${{ github.ref_name }}.md", workflow)
+        self.assertNotIn("generate_release_notes:", workflow)
+
     def test_bundle_contains_digest_pins_and_valid_checksums(self) -> None:
         backend_image = (
             "ghcr.io/krishna-swaroop/kicad-prism-backend@"
@@ -58,7 +67,7 @@ class ReleaseBundleTests(unittest.TestCase):
             bundle_dir, archive, archive_checksum = build_release_bundle(
                 template_dir=TEMPLATE_DIR,
                 output_root=Path(output),
-                tag="v3.1.2-alpha.1",
+                tag="v3.1.0-alpha",
                 backend_image=backend_image,
                 frontend_image=frontend_image,
                 revision="abc123",
@@ -80,15 +89,36 @@ class ReleaseBundleTests(unittest.TestCase):
 
             with tarfile.open(archive, mode="r:gz") as packaged:
                 packaged_names = set(packaged.getnames())
-            archive_root = "kicad-prism-v3.1.2-alpha.1-linux-amd64"
+            archive_root = "kicad-prism-v3.1.0-alpha-linux-amd64"
             self.assertIn(f"{archive_root}/compose.yml", packaged_names)
             self.assertIn(f"{archive_root}/SHA256SUMS", packaged_names)
+            self.assertIn(f"{archive_root}/RELEASE_NOTES.md", packaged_names)
+            self.assertIn(f"{archive_root}/UPGRADES.md", packaged_names)
+            self.assertIn(f"{archive_root}/scripts/prism_backup.py", packaged_names)
+            self.assertIn(f"{archive_root}/scripts/prism_deploy/tui.py", packaged_names)
+
+            release_notes = (bundle_dir / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+            self.assertIn("epoch-2 cutover", release_notes)
+            self.assertIn("paired pin", release_notes.lower())
 
             expected_archive_hash = hashlib.sha256(archive.read_bytes()).hexdigest()
             self.assertEqual(
                 archive_checksum.read_text(encoding="utf-8"),
                 f"{expected_archive_hash}  {archive.name}\n",
             )
+
+    def test_bundle_refuses_a_tag_without_checked_in_release_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as output:
+            with self.assertRaises(FileNotFoundError):
+                build_release_bundle(
+                    template_dir=TEMPLATE_DIR,
+                    output_root=Path(output),
+                    tag="v99.0.0-alpha",
+                    backend_image="backend@sha256:" + "a" * 64,
+                    frontend_image="frontend@sha256:" + "b" * 64,
+                    revision="abc123",
+                    build_date="2026-08-30T00:00:00Z",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the destructive legacy-survivor PostgreSQL migration test an explicit no-skip CI gate
- publish checked-in tag-specific release notes and include release notes, the upgrade runbook, and backup tooling in the verified release bundle
- document an executable epoch-2 cutover path for release-bundle operators
- sanitize Release Studio source and dossier errors while retaining server-side diagnostics
- update stale Design Comparison guidance and the v3.1.0-alpha release-note draft

## Verification

- frontend: lint, React Doctor (0 findings), 69 test files / 522 tests, main build, panel build
- backend: 1,067 tests passed (3 unrelated environment-dependent skips)
- Release Studio API: 18 tests passed
- legacy survivor migration: export/reset/epoch-2 initialization/restore passed against isolated PostgreSQL
- release bundle: 6 tests, archive checksum verification, bundled backup-tool smoke test, generated Compose validation
- deployment installer: 79 tests
- backup tool: 19 tests
- default, proxy, load-test, local-toolchain, and release Compose configurations validated
- agent docs, Python compilation, YAML parsing, and diff cleanliness passed
