### PR TITLE
fix(projects): take the project card off the parse path

### DIFF
--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -68,11 +68,11 @@ class Monorepo(BaseModel):
 
 
 class ProjectPropertiesTitleBlock(BaseModel):
+    # KiCad's title block also carries rev, company and numbered comments.
+    # Prism parsed all of them and rendered none; narrowed to what the
+    # properties panel displays.
     title: str = ""
     date: str = ""
-    rev: str = ""
-    company: str = ""
-    comments: Dict[str, str] = Field(default_factory=dict)
 
 
 class ProjectPropertiesSchematicFile(BaseModel):
@@ -81,8 +81,6 @@ class ProjectPropertiesSchematicFile(BaseModel):
     version: Optional[int] = None
     generator: Optional[str] = None
     generator_version: Optional[str] = None
-    paper: Optional[str] = None
-    uuid: Optional[str] = None
     title_block: Optional[ProjectPropertiesTitleBlock] = None
 
 
@@ -92,7 +90,6 @@ class ProjectPropertiesPcbFile(BaseModel):
     version: Optional[int] = None
     generator: Optional[str] = None
     generator_version: Optional[str] = None
-    paper: Optional[str] = None
     dimensions_mm: Optional[Dict[str, float]] = None
     thickness_mm: Optional[float] = None
     title_block: Optional[ProjectPropertiesTitleBlock] = None

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1181,7 +1181,7 @@ async def get_project_properties(project_id: str, user: AuthenticatedUser = Depe
 
 def _stored_project_metadata(
     project: project_service.Project,
-) -> tuple[Optional[dict], Optional[dict]]:
+) -> tuple[Optional[dict], Optional[dict], Optional[dict]]:
     """Read the project's stored KiCad metadata, refreshing it out of band.
 
     This used to derive both dictionaries inline, which meant reading and
@@ -1199,9 +1199,10 @@ def _stored_project_metadata(
     anchor = project_service.project_anchor(project)
     schematic_path = project_service.find_schematic_file(project.path, anchor)
     pcb_path = project_service.find_pcb_file(project.path, anchor)
+    repo_path, _relative_path = _repo_context(project)
 
     record, current = project_metadata_service.stored_metadata_is_current(
-        project.id, schematic_path, pcb_path
+        project.id, schematic_path, pcb_path, repo_path
     )
     if not current:
         try:
@@ -1216,24 +1217,15 @@ def _stored_project_metadata(
             )
 
     if not record:
-        return None, None
-    return record.get("schematic"), record.get("pcb")
+        return None, None, None
+    return record.get("schematic"), record.get("pcb"), record.get("repository")
 
 
 def _build_project_properties(project: project_service.Project) -> ProjectPropertiesResponse:
-    repo_path, relative_path = _repo_context(project)
-    if relative_path:
-        releases = get_releases_filtered(repo_path, relative_path)
-        latest_page = get_commits_list_filtered(repo_path, relative_path, 1)
-    else:
-        releases = get_releases(repo_path)
-        latest_page = get_commits_list(repo_path, 1)
-
-    latest_commits = latest_page["commits"] if isinstance(latest_page, dict) else latest_page
-    latest_commit = latest_commits[0] if latest_commits else None
-    latest_tag = releases[0] if releases else None
-
-    schematic_metadata, pcb_metadata = _stored_project_metadata(project)
+    schematic_metadata, pcb_metadata, repository = _stored_project_metadata(project)
+    repository = repository or {}
+    latest_commit = repository.get("latest_commit")
+    latest_tag = repository.get("latest_tag")
 
     return ProjectPropertiesResponse(
         project=project,

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import mimetypes
 import os
 import posixpath
@@ -23,7 +24,7 @@ from app.services import (
     git_access_service,
     path_config_service,
     project_import_service,
-    project_properties_service,
+    project_metadata_service,
     project_service,
     semantic_index_service,
     semantic_visualizer_service,
@@ -44,6 +45,8 @@ from app.services.git_failures import GitAccessError
 from app.services.git_remote_url import RemoteUrlError, parse_remote_url
 from app.services.path_config_service import PathConfig
 from app.services.job_service import jobs as v3_jobs
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(require_viewer)])
 
@@ -1176,6 +1179,47 @@ async def get_project_properties(project_id: str, user: AuthenticatedUser = Depe
     return await asyncio.to_thread(_build_project_properties, project)
 
 
+def _stored_project_metadata(
+    project: project_service.Project,
+) -> tuple[Optional[dict], Optional[dict]]:
+    """Read the project's stored KiCad metadata, refreshing it out of band.
+
+    This used to derive both dictionaries inline, which meant reading and
+    scanning the schematic and the board on every open of the workspace preview
+    panel. On a 57 MB design that scan pinned a core for minutes and, being
+    pure Python, starved the event loop serving every other request -- which is
+    what made opening a large project take tens of seconds.
+
+    The facts change only when the files change, so the import and sync jobs
+    compute them and this reads the row. A project imported before the table
+    existed, or one whose files moved without a sync, has its refresh queued
+    here and returns what is stored meanwhile. That is a card with some blank
+    fields for one job's duration, never a request that blocks on kicad-cli.
+    """
+    anchor = project_service.project_anchor(project)
+    schematic_path = project_service.find_schematic_file(project.path, anchor)
+    pcb_path = project_service.find_pcb_file(project.path, anchor)
+
+    record, current = project_metadata_service.stored_metadata_is_current(
+        project.id, schematic_path, pcb_path
+    )
+    if not current:
+        try:
+            project_import_service.start_project_metadata_job(
+                project.id, requested_by="project-properties"
+            )
+        except Exception as error:
+            # The queue being unavailable must not take the panel down with it;
+            # the card simply keeps whatever was last stored.
+            logger.warning(
+                "Could not queue metadata refresh for %s: %s", project.id, error
+            )
+
+    if not record:
+        return None, None
+    return record.get("schematic"), record.get("pcb")
+
+
 def _build_project_properties(project: project_service.Project) -> ProjectPropertiesResponse:
     repo_path, relative_path = _repo_context(project)
     if relative_path:
@@ -1189,11 +1233,7 @@ def _build_project_properties(project: project_service.Project) -> ProjectProper
     latest_commit = latest_commits[0] if latest_commits else None
     latest_tag = releases[0] if releases else None
 
-    anchor = project_service.project_anchor(project)
-    schematic_path = project_service.find_schematic_file(project.path, anchor)
-    pcb_path = project_service.find_pcb_file(project.path, anchor)
-    schematic_metadata = project_properties_service.extract_schematic_metadata(project.path, schematic_path)
-    pcb_metadata = project_properties_service.extract_pcb_metadata(project.path, pcb_path)
+    schematic_metadata, pcb_metadata = _stored_project_metadata(project)
 
     return ProjectPropertiesResponse(
         project=project,

--- a/backend/app/services/job_handlers.py
+++ b/backend/app/services/job_handlers.py
@@ -36,6 +36,7 @@ def load_builtin_job_handlers() -> None:
     from app.services.project_import_service import (
         run_project_analyze_job_v3,
         run_project_import_job_v3,
+        run_project_metadata_job_v3,
         run_project_sync_job_v3,
         run_project_thumbnail_job_v3,
     )
@@ -57,6 +58,7 @@ def load_builtin_job_handlers() -> None:
     register_job_handler("project_analyze", run_project_analyze_job_v3)
     register_job_handler("project_import", run_project_import_job_v3)
     register_job_handler("project_sync", run_project_sync_job_v3)
+    register_job_handler("project_metadata", run_project_metadata_job_v3)
     register_job_handler("project_thumbnail", run_project_thumbnail_job_v3)
     for job_type in catalog_handlers:
         register_job_handler(job_type, run_catalog_job_v3)

--- a/backend/app/services/kicad_board_stats_service.py
+++ b/backend/app/services/kicad_board_stats_service.py
@@ -173,7 +173,12 @@ def board_facts(stats: dict) -> dict:
     height = _quantity_mm(board.get("height"))
     dimensions = None
     if width is not None and height is not None and board.get("has_outline") is not False:
-        dimensions = {"width": round(width, 2), "height": round(height, 2)}
+        # `width_mm`/`height_mm` is the shape the panel already reads
+        # (`formatPcbDimensions`). The response model types this as a bare
+        # Dict[str, float], so a renamed key would not fail a schema check --
+        # it would just render "Not available" and look like a board with no
+        # outline.
+        dimensions = {"width_mm": round(width, 2), "height_mm": round(height, 2)}
 
     return {
         "dimensions_mm": dimensions,

--- a/backend/app/services/kicad_board_stats_service.py
+++ b/backend/app/services/kicad_board_stats_service.py
@@ -1,0 +1,182 @@
+"""Board facts from ``kicad-cli``, not from a parser of our own.
+
+Prism used to derive the board outline size by scanning the ``.kicad_pcb``
+itself: every ``gr_line``/``gr_arc``/``gr_poly``/``gr_circle`` block was pulled
+out and the Edge.Cuts ones reduced to a bounding box. That was wrong twice
+over.
+
+It was wrong in principle, because Release Studio already states the rule this
+module follows -- KiCad owns the board-statistics schema (see
+``app/release_studio/projections.py``). A second, hand-written parser for the
+same facts can only ever be an approximation of the first, and it silently
+disagreed with KiCad on arc bulge, which the scan approximated by its endpoints
+and midpoint.
+
+It was wrong in practice, because the scan was quadratic. It sliced the tail of
+the file on every match, so a 57.7 MB board with 10,217 ``gr_line`` blocks
+copied roughly 400 GB of string, saturated a core, and -- being pure Python
+under the GIL -- starved the event loop serving every other request on the
+box. That is what made opening a large project take tens of seconds.
+
+``kicad-cli pcb export stats`` answers the same question authoritatively in
+about 30 seconds on that board. Thirty seconds is still far too long to spend
+inside a request, which is why nothing here is called from one: the metadata
+job runs this once when a project is imported or synced, and the API serves
+what it stored.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+#: ``pcb export stats`` on the largest board in our corpus takes ~30s. The
+#: ceiling is generous rather than tight: the job that calls this owns a worker
+#: slot for its duration either way, and a board big enough to need the time is
+#: exactly the board whose numbers we most want.
+STATS_TIMEOUT_SECONDS = 600
+
+SOURCE = "kicad-cli pcb export stats --format json"
+
+#: KiCad prints dimensions as a formatted quantity -- ``"160.0000 mm"`` -- not
+#: as a number, so the unit travels with the value and has to come back off.
+_QUANTITY = re.compile(r"^\s*([-+]?\d+(?:\.\d+)?)\s*(\S+)?\s*$")
+
+
+class BoardStatsUnavailable(RuntimeError):
+    """kicad-cli could not produce statistics for this board."""
+
+
+def _resolve_cli() -> str:
+    """Locate kicad-cli the same way Release Studio does.
+
+    Imported lazily: the API process resolves this module at import time and
+    must not fail to start because a toolchain it never calls is absent.
+    """
+    from app.release_studio.steps import StepExecutionError, resolve_cli_path
+
+    try:
+        return resolve_cli_path()
+    except StepExecutionError as error:
+        raise BoardStatsUnavailable(str(error)) from error
+
+
+def _quantity_mm(value: object) -> Optional[float]:
+    """Return a millimetre magnitude, or None if KiCad did not report one.
+
+    Anything not already in millimetres is refused rather than converted: a
+    silently wrong unit is worse than a blank field, and every KiCad build we
+    run reports mm here.
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    match = _QUANTITY.match(value)
+    if not match:
+        return None
+    unit = (match.group(2) or "mm").lower()
+    if unit not in ("mm", "millimeter", "millimetre"):
+        logger.warning("Ignoring board dimension in unexpected unit: %r", value)
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None
+
+
+def export_board_stats(pcb_path: str, *, cli_path: Optional[str] = None) -> dict:
+    """Run ``pcb export stats`` and return the parsed report.
+
+    Raises ``BoardStatsUnavailable`` when the toolchain is missing or the run
+    fails; callers treat that as "no board facts", never as a hard error, so a
+    deployment without kicad-cli degrades to a project card with fewer fields
+    rather than to a broken page.
+    """
+    board = Path(pcb_path)
+    if not board.is_file():
+        raise BoardStatsUnavailable(f"Board not found: {pcb_path}")
+
+    executable = cli_path or _resolve_cli()
+
+    with tempfile.TemporaryDirectory(prefix="prism-board-stats-") as scratch:
+        out_path = Path(scratch) / "stats.json"
+        # Each invocation gets its own temp/runtime dir: kicad-cli takes an
+        # instance lock keyed on it, and two of them sharing one directory
+        # serialise for no reason.
+        env = dict(os.environ)
+        for key in ("TMPDIR", "TMP", "TEMP", "XDG_RUNTIME_DIR"):
+            env[key] = scratch
+
+        argv = [
+            executable,
+            "pcb",
+            "export",
+            "stats",
+            "--format",
+            "json",
+            "-o",
+            str(out_path),
+            str(board),
+        ]
+        try:
+            completed = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=STATS_TIMEOUT_SECONDS,
+                env=env,
+                cwd=scratch,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise BoardStatsUnavailable(
+                f"kicad-cli timed out after {STATS_TIMEOUT_SECONDS}s on {board.name}"
+            ) from error
+        except OSError as error:
+            raise BoardStatsUnavailable(f"kicad-cli could not be executed: {error}") from error
+
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "").strip().splitlines()
+            raise BoardStatsUnavailable(
+                f"kicad-cli exited {completed.returncode}: {detail[-1] if detail else 'no output'}"
+            )
+        if not out_path.is_file():
+            raise BoardStatsUnavailable("kicad-cli reported success but wrote no statistics")
+
+        try:
+            return json.loads(out_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as error:
+            raise BoardStatsUnavailable(f"Could not read board statistics: {error}") from error
+
+
+def board_facts(stats: dict) -> dict:
+    """Reduce a stats report to the fields the project card shows.
+
+    Kept deliberately narrow. The report carries pad, via, drill and component
+    counts too; those belong to Release Studio's projection, which already has
+    a schema and a canonicaliser for them. Duplicating that here would create
+    the same two-sources-of-truth problem this module exists to remove.
+    """
+    board = stats.get("board") if isinstance(stats.get("board"), dict) else {}
+    metadata = stats.get("metadata") if isinstance(stats.get("metadata"), dict) else {}
+
+    width = _quantity_mm(board.get("width"))
+    height = _quantity_mm(board.get("height"))
+    dimensions = None
+    if width is not None and height is not None and board.get("has_outline") is not False:
+        dimensions = {"width": round(width, 2), "height": round(height, 2)}
+
+    return {
+        "dimensions_mm": dimensions,
+        "thickness_mm": _quantity_mm(board.get("board_thickness")),
+        "stats_generator": metadata.get("generator") or None,
+    }

--- a/backend/app/services/project_import_service.py
+++ b/backend/app/services/project_import_service.py
@@ -1352,10 +1352,21 @@ def run_project_metadata_job_v3(context: JobContext) -> JobResult:
     )
     schematic_path = project_service.find_schematic_file(project_path, anchor)
     pcb_path = project_service.find_pcb_file(project_path, anchor)
+    # The workspace row already resolves the checkout: parent_repo_path is the
+    # clone, relative_path is "." for a root project or the subproject path.
+    # Same split _repo_context makes on the API side.
+    repo_path = str(row.get("parent_repo_path") or project_path)
+    raw_relative = str(row.get("relative_path") or ".").strip()
+    relative_path = None if raw_relative in (".", "", "/") else raw_relative.strip("/")
     context.check_cancelled()
 
     computed = project_metadata_service.refresh_project_metadata(
-        project_id, project_path, schematic_path, pcb_path
+        project_id,
+        project_path,
+        schematic_path,
+        pcb_path,
+        repo_path=repo_path,
+        relative_path=relative_path,
     )
     pcb = computed.get("pcb") or {}
     return JobResult(
@@ -1368,6 +1379,8 @@ def run_project_metadata_job_v3(context: JobContext) -> JobResult:
             # board that genuinely has no outline.
             "board_stats_source": computed.get("board_stats_source") or "unavailable",
             "dimensions_mm": pcb.get("dimensions_mm"),
+            # A push that did not touch the design skips the kicad-cli pass.
+            "reused_file_metadata": bool(computed.get("reused_file_metadata")),
         },
     )
 

--- a/backend/app/services/project_import_service.py
+++ b/backend/app/services/project_import_service.py
@@ -1232,6 +1232,12 @@ def run_project_import_job_v3(context: JobContext) -> JobResult:
         )
         thumbnail_job_ids: list[str] = []
         for imported_id in imported_ids:
+            # Queued before the render: the card shows a size and a title block
+            # before it shows a picture, and this job is the cheaper of the two.
+            try:
+                start_project_metadata_job(imported_id, requested_by="project-import")
+            except Exception as error:
+                print(f"Could not queue metadata for {imported_id}: {error}", flush=True)
             try:
                 job_id = start_thumbnail_job(imported_id, requested_by="project-import")
             except Exception as error:
@@ -1291,6 +1297,79 @@ def start_thumbnail_job(project_id: str, *, requested_by: str = "") -> Optional[
         ),
     )
     return str(queued["job_id"])
+
+
+def start_project_metadata_job(project_id: str, *, requested_by: str = "") -> Optional[str]:
+    """Queue a metadata refresh for one project.
+
+    Separate from the thumbnail job even though both shell out to kicad-cli:
+    a thumbnail is cosmetic and may be replaced by an upload, while this is the
+    data the project card reads. Keeping them apart means a render failure does
+    not take the card's size and title block with it.
+    """
+    row = workspace.get_project_by_id(project_id)
+    if not row:
+        return None
+    repository_id = str(row.get("repo_id") or "")
+    queued = v3_jobs.enqueue(
+        "project_metadata",
+        {"project_id": project_id},
+        worker_pool="prism",
+        artifact_key=hashlib.sha256(f"metadata:{project_id}".encode("utf-8")).hexdigest(),
+        project_id=project_id,
+        repository_id=repository_id or None,
+        requested_by=requested_by,
+        max_attempts=2,
+        resources={"prism_worker": 1},
+        # Same read lock as the render: kicad-cli must not read a checkout
+        # halfway through a sync fast-forward.
+        locks=(
+            [{"key": f"repository:{repository_id}", "mode": "read"}]
+            if repository_id
+            else []
+        ),
+    )
+    return str(queued["job_id"])
+
+
+def run_project_metadata_job_v3(context: JobContext) -> JobResult:
+    from app.services import project_metadata_service
+
+    project_id = str(context.payload["project_id"])
+    row = workspace.get_project_by_id(project_id)
+    if not row:
+        raise ValueError("Project not found")
+    project_path = str(row.get("path") or "")
+    if not project_path or not os.path.isdir(project_path):
+        raise ValueError(f"Project path not found: {project_path}")
+    anchor = str(row.get("project_file_rel") or "") or infer_project_anchor(project_path)
+
+    context.progress(
+        stage="read-metadata",
+        message="Reading project metadata",
+        percent=10,
+        force=True,
+    )
+    schematic_path = project_service.find_schematic_file(project_path, anchor)
+    pcb_path = project_service.find_pcb_file(project_path, anchor)
+    context.check_cancelled()
+
+    computed = project_metadata_service.refresh_project_metadata(
+        project_id, project_path, schematic_path, pcb_path
+    )
+    pcb = computed.get("pcb") or {}
+    return JobResult(
+        message="Project metadata updated",
+        details={
+            "project_id": project_id,
+            "has_schematic": computed.get("schematic") is not None,
+            "has_pcb": computed.get("pcb") is not None,
+            # Recorded so a card with no size on it can be told apart from a
+            # board that genuinely has no outline.
+            "board_stats_source": computed.get("board_stats_source") or "unavailable",
+            "dimensions_mm": pcb.get("dimensions_mm"),
+        },
+    )
 
 
 def start_thumbnail_jobs(
@@ -1428,6 +1507,12 @@ def run_project_sync_job_v3(context: JobContext) -> JobResult:
         start_thumbnail_job(project_id, requested_by="project-sync")
     except Exception as error:
         print(f"Could not queue thumbnail refresh for {project_id}: {error}", flush=True)
+    # A sync is the one event that can change what the files say about
+    # themselves, so it is the event that has to refresh the stored metadata.
+    try:
+        start_project_metadata_job(project_id, requested_by="project-sync")
+    except Exception as error:
+        print(f"Could not queue metadata refresh for {project_id}: {error}", flush=True)
     return JobResult(
         message=str(result.get("message") or "Sync completed"),
         details=dict(result),

--- a/backend/app/services/project_metadata_service.py
+++ b/backend/app/services/project_metadata_service.py
@@ -1,0 +1,112 @@
+"""Compute and store the descriptive metadata behind the project card.
+
+The workspace preview panel used to call an endpoint that read both KiCad
+files and scanned them on every open. The facts it wants -- header fields and
+board size -- change only when the files change, so they are computed once per
+import or sync and stored. ``/properties`` is then a single row read.
+
+Board size comes from ``kicad-cli``; header fields come from a bounded read of
+the file's first 256 KB. Neither is derived from a full-file scan of our own.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from app.services import kicad_board_stats_service, project_properties_service
+from app.services.workspace_service import workspace
+
+
+logger = logging.getLogger(__name__)
+
+
+def source_fingerprint(schematic_path: Optional[str], pcb_path: Optional[str]) -> str:
+    """Identify the inputs a stored row was computed from.
+
+    Size and mtime rather than a content hash: hashing a 57 MB board to decide
+    whether to re-read it would cost more than the read it is guarding. The
+    pair is enough to notice a sync that changed either file, which is the only
+    event that can invalidate a row.
+    """
+    parts: list[str] = []
+    for label, path in (("sch", schematic_path), ("pcb", pcb_path)):
+        if not path:
+            parts.append(f"{label}:-")
+            continue
+        try:
+            stat = os.stat(path)
+        except OSError:
+            parts.append(f"{label}:missing")
+            continue
+        parts.append(f"{label}:{Path(path).name}:{stat.st_size}:{stat.st_mtime_ns}")
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+def compute_project_metadata(
+    project_path: str,
+    schematic_path: Optional[str],
+    pcb_path: Optional[str],
+) -> dict[str, Any]:
+    """Read what the files say about themselves.
+
+    kicad-cli failure is not an error here. A deployment without the toolchain,
+    or a board it refuses, still yields a usable card -- one without a size on
+    it. Failing the whole job would leave the panel with nothing at all, which
+    is strictly worse and would also make the toolchain a hard dependency of
+    browsing the workspace.
+    """
+    board_facts: dict[str, Any] = {}
+    stats_source = ""
+    if pcb_path:
+        try:
+            stats = kicad_board_stats_service.export_board_stats(pcb_path)
+            board_facts = kicad_board_stats_service.board_facts(stats)
+            stats_source = kicad_board_stats_service.SOURCE
+        except kicad_board_stats_service.BoardStatsUnavailable as error:
+            logger.warning("Board statistics unavailable for %s: %s", pcb_path, error)
+
+    return {
+        "schematic": project_properties_service.compute_schematic_metadata(
+            project_path, schematic_path
+        ),
+        "pcb": project_properties_service.compute_pcb_metadata(
+            project_path, pcb_path, board_facts
+        ),
+        "source_fingerprint": source_fingerprint(schematic_path, pcb_path),
+        "board_stats_source": stats_source,
+    }
+
+
+def refresh_project_metadata(
+    project_id: str,
+    project_path: str,
+    schematic_path: Optional[str],
+    pcb_path: Optional[str],
+) -> dict[str, Any]:
+    """Recompute and store one project's metadata."""
+    computed = compute_project_metadata(project_path, schematic_path, pcb_path)
+    workspace.upsert_project_metadata(
+        project_id,
+        schematic=computed["schematic"],
+        pcb=computed["pcb"],
+        source_fingerprint=computed["source_fingerprint"],
+        board_stats_source=computed["board_stats_source"],
+    )
+    return computed
+
+
+def stored_metadata_is_current(
+    project_id: str,
+    schematic_path: Optional[str],
+    pcb_path: Optional[str],
+) -> tuple[Optional[dict[str, Any]], bool]:
+    """Return the stored row and whether it still matches the files on disk."""
+    record = workspace.get_project_metadata(project_id)
+    if not record:
+        return None, False
+    expected = source_fingerprint(schematic_path, pcb_path)
+    return record, str(record.get("source_fingerprint") or "") == expected

--- a/backend/app/services/project_metadata_service.py
+++ b/backend/app/services/project_metadata_service.py
@@ -46,6 +46,62 @@ def source_fingerprint(schematic_path: Optional[str], pcb_path: Optional[str]) -
     return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
 
 
+def repo_fingerprint(repo_path: Optional[str]) -> str:
+    """Identify the repository state the stored commit/tag was read at.
+
+    Deliberately separate from ``source_fingerprint``. A push moves HEAD
+    without touching the checked-out board, and a tag can be added without
+    moving HEAD at all; neither should trigger the ~30 s kicad-cli pass that
+    the file fingerprint guards. Reading HEAD and counting tags costs about
+    16 ms against the ~290 ms of Git work it decides whether to repeat.
+    """
+    if not repo_path:
+        return ""
+    try:
+        from git import Repo
+
+        repo = Repo(repo_path)
+        head = repo.head.commit.hexsha if repo.head.is_valid() else "unborn"
+        # Tag count and tip name together: a tag added or moved changes one or
+        # the other, and neither requires walking the tag objects.
+        tags = sorted(tag.name for tag in repo.tags)
+        digest = hashlib.sha256(
+            "|".join([head, str(len(tags)), tags[-1] if tags else "-"]).encode("utf-8")
+        ).hexdigest()
+        return digest
+    except Exception as error:  # pragma: no cover - depends on the checkout
+        logger.warning("Could not fingerprint repository %s: %s", repo_path, error)
+        return ""
+
+
+def compute_repository_facts(repo_path: str, relative_path: Optional[str]) -> dict[str, Any]:
+    """The latest commit and tag the card shows.
+
+    ``get_releases_filtered`` counts files under the subproject path for every
+    tag, so this grows with the tag list -- which is exactly why it belongs in
+    a job rather than in the request that opens a panel.
+    """
+    from app.services.git_service import (
+        get_commits_list,
+        get_commits_list_filtered,
+        get_releases,
+        get_releases_filtered,
+    )
+
+    if relative_path:
+        releases = get_releases_filtered(repo_path, relative_path)
+        latest_page = get_commits_list_filtered(repo_path, relative_path, 1)
+    else:
+        releases = get_releases(repo_path)
+        latest_page = get_commits_list(repo_path, 1)
+
+    latest_commits = latest_page["commits"] if isinstance(latest_page, dict) else latest_page
+    return {
+        "latest_commit": latest_commits[0] if latest_commits else None,
+        "latest_tag": releases[0] if releases else None,
+    }
+
+
 def compute_project_metadata(
     project_path: str,
     schematic_path: Optional[str],
@@ -86,15 +142,52 @@ def refresh_project_metadata(
     project_path: str,
     schematic_path: Optional[str],
     pcb_path: Optional[str],
+    repo_path: Optional[str] = None,
+    relative_path: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Recompute and store one project's metadata."""
-    computed = compute_project_metadata(project_path, schematic_path, pcb_path)
+    """Recompute and store one project's metadata.
+
+    The two halves are refreshed independently. File metadata is reused when
+    the files have not changed, because recomputing it means another kicad-cli
+    pass -- 30 s on a large board -- and a push that only moved HEAD is not a
+    reason to pay it. Repository facts are always recomputed: they are the
+    cheap half and they are what a push actually changes.
+    """
+    stored = workspace.get_project_metadata(project_id)
+    files_fingerprint = source_fingerprint(schematic_path, pcb_path)
+
+    if stored and str(stored.get("source_fingerprint") or "") == files_fingerprint:
+        computed: dict[str, Any] = {
+            "schematic": stored.get("schematic"),
+            "pcb": stored.get("pcb"),
+            "source_fingerprint": files_fingerprint,
+            "board_stats_source": str(stored.get("board_stats_source") or ""),
+            "reused_file_metadata": True,
+        }
+    else:
+        computed = compute_project_metadata(project_path, schematic_path, pcb_path)
+        computed["reused_file_metadata"] = False
+
+    repository: Optional[dict[str, Any]] = None
+    if repo_path:
+        try:
+            repository = compute_repository_facts(repo_path, relative_path)
+        except Exception as error:
+            # A card without a commit line beats a job that fails and leaves
+            # the whole row unwritten.
+            logger.warning("Could not read repository facts for %s: %s", project_id, error)
+
+    computed["repository"] = repository
+    computed["repo_fingerprint"] = repo_fingerprint(repo_path)
+
     workspace.upsert_project_metadata(
         project_id,
         schematic=computed["schematic"],
         pcb=computed["pcb"],
         source_fingerprint=computed["source_fingerprint"],
         board_stats_source=computed["board_stats_source"],
+        repository=repository,
+        repo_fingerprint=computed["repo_fingerprint"],
     )
     return computed
 
@@ -103,10 +196,19 @@ def stored_metadata_is_current(
     project_id: str,
     schematic_path: Optional[str],
     pcb_path: Optional[str],
+    repo_path: Optional[str] = None,
 ) -> tuple[Optional[dict[str, Any]], bool]:
-    """Return the stored row and whether it still matches the files on disk."""
+    """Return the stored row and whether it still describes the project.
+
+    Stale on either axis: the files may have changed, or the repository may
+    have moved. Both are cheap to check -- two ``stat`` calls and a HEAD read.
+    """
     record = workspace.get_project_metadata(project_id)
     if not record:
         return None, False
-    expected = source_fingerprint(schematic_path, pcb_path)
-    return record, str(record.get("source_fingerprint") or "") == expected
+
+    files_current = str(record.get("source_fingerprint") or "") == source_fingerprint(
+        schematic_path, pcb_path
+    )
+    repo_current = str(record.get("repo_fingerprint") or "") == repo_fingerprint(repo_path)
+    return record, files_current and repo_current

--- a/backend/app/services/project_properties_service.py
+++ b/backend/app/services/project_properties_service.py
@@ -1,13 +1,51 @@
-from copy import deepcopy
-import math
+"""Descriptive metadata for the project card.
+
+Everything here reads a *bounded prefix* of a KiCad file. The header fields --
+version, generator, paper, uuid, title block -- all sit in the first few
+hundred bytes, so there is never a reason to pull a 57 MB board into memory to
+find them.
+
+Board geometry does not live in the header and is not derived here at all. It
+comes from ``kicad-cli`` via ``kicad_board_stats_service``; see that module for
+why. This one used to scan the whole board for Edge.Cuts graphics, which was
+both a second source of truth for a question KiCad already answers and
+quadratic enough to saturate a core for minutes on a large design.
+
+Nothing in this module is called from a request handler. The metadata job runs
+it once per import or sync and stores the result; the API reads the store.
+"""
+
+from __future__ import annotations
+
 import re
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 
 _STRING_PATTERN = r'"((?:[^"\\]|\\.)*)"'
-_FILE_METADATA_CACHE_MAX_ENTRIES = 128
-_file_metadata_cache: dict[tuple[str, str], dict[str, object]] = {}
+
+#: How much of a file to read when looking for header fields.
+#:
+#: A KiCad header -- version, generator, paper, uuid, title_block -- is written
+#: first and is a few hundred bytes. 256 KB is three orders of magnitude of
+#: slack against that, and still a bounded read on a file that may be tens of
+#: megabytes. If a title block ever fell outside it the field comes back None,
+#: which is the same answer the old code gave for a file it could not parse.
+HEADER_BYTES = 256 * 1024
+
+
+def _read_header(path: Path) -> Optional[str]:
+    """Return the leading slice of a KiCad file, or None if unreadable.
+
+    Decoded with ``errors="ignore"`` because the slice can end mid-character;
+    the fields being matched are ASCII, so a dropped tail byte cannot change
+    them.
+    """
+    try:
+        with path.open("rb") as handle:
+            return handle.read(HEADER_BYTES).decode("utf-8", errors="ignore")
+    except OSError:
+        return None
 
 
 def _unescape_kicad_string(value: str) -> str:
@@ -47,25 +85,6 @@ def _extract_sexpr_block(text: str, token: str) -> Optional[str]:
     return None
 
 
-def _extract_sexpr_blocks(text: str, token: str) -> list[str]:
-    blocks: list[str] = []
-    start = 0
-
-    while True:
-        match_index = text.find(f"({token}", start)
-        if match_index == -1:
-            break
-
-        block = _extract_sexpr_block(text[match_index:], token)
-        if not block:
-            break
-
-        blocks.append(block)
-        start = match_index + len(block)
-
-    return blocks
-
-
 def _extract_string_value(block: str, key: str) -> Optional[str]:
     match = re.search(rf"\({re.escape(key)}\s+{_STRING_PATTERN}\)", block)
     if not match:
@@ -90,88 +109,6 @@ def _extract_int_value(block: str, key: str) -> Optional[int]:
     return int(value)
 
 
-def _extract_point(block: str, key: str) -> Optional[tuple[float, float]]:
-    match = re.search(rf"\({re.escape(key)}\s+([-+]?\d+(?:\.\d+)?)\s+([-+]?\d+(?:\.\d+)?)\)", block)
-    if not match:
-        return None
-
-    try:
-        return float(match.group(1)), float(match.group(2))
-    except ValueError:
-        return None
-
-
-def _extract_xy_points(block: str) -> list[tuple[float, float]]:
-    points: list[tuple[float, float]] = []
-    for left, right in re.findall(r"\(xy\s+([-+]?\d+(?:\.\d+)?)\s+([-+]?\d+(?:\.\d+)?)\)", block):
-        try:
-            points.append((float(left), float(right)))
-        except ValueError:
-            continue
-    return points
-
-
-def _round_dimension(value: float) -> float:
-    return round(value, 2)
-
-
-def _extract_pcb_dimensions(text: str) -> Optional[dict]:
-    points: list[tuple[float, float]] = []
-
-    for token in ("gr_line", "gr_rect", "gr_arc", "gr_curve", "gr_poly", "gr_circle"):
-        for block in _extract_sexpr_blocks(text, token):
-            if '(layer "Edge.Cuts")' not in block:
-                continue
-
-            token_points = [
-                point
-                for point in (
-                    _extract_point(block, "start"),
-                    _extract_point(block, "end"),
-                    _extract_point(block, "mid"),
-                    _extract_point(block, "center"),
-                )
-                if point is not None
-            ]
-            token_points.extend(_extract_xy_points(block))
-
-            if token == "gr_circle":
-                center = _extract_point(block, "center")
-                edge = _extract_point(block, "end")
-                if center and edge:
-                    radius = math.dist(center, edge)
-                    token_points.extend(
-                        [
-                            (center[0] - radius, center[1]),
-                            (center[0] + radius, center[1]),
-                            (center[0], center[1] - radius),
-                            (center[0], center[1] + radius),
-                        ]
-                    )
-
-            points.extend(token_points)
-
-    if len(points) < 2:
-        return None
-
-    xs = [point[0] for point in points]
-    ys = [point[1] for point in points]
-    width = max(xs) - min(xs)
-    height = max(ys) - min(ys)
-
-    if width <= 0 or height <= 0:
-        return None
-
-    return {
-        "width_mm": _round_dimension(width),
-        "height_mm": _round_dimension(height),
-    }
-
-
-def _relative_to_project(project_path: str, file_path: str) -> str:
-    return Path(file_path).resolve().relative_to(Path(project_path).resolve()).as_posix()
-
-
 def _parse_title_block(text: str) -> Optional[dict]:
     block = _extract_sexpr_block(text, "title_block")
     if not block:
@@ -191,104 +128,66 @@ def _parse_title_block(text: str) -> Optional[dict]:
     }
 
 
-def invalidate_project_properties_cache(project_path: Optional[str] = None) -> None:
-    global _file_metadata_cache
-
-    if project_path is None:
-        _file_metadata_cache = {}
-        return
-
-    resolved_project = str(Path(project_path).resolve())
-    _file_metadata_cache = {
-        key: value
-        for key, value in _file_metadata_cache.items()
-        if key[0] != resolved_project
-    }
+def _relative_to_project(project_path: str, file_path: str) -> str:
+    return Path(file_path).resolve().relative_to(Path(project_path).resolve()).as_posix()
 
 
-def _trim_file_metadata_cache() -> None:
-    while len(_file_metadata_cache) > _FILE_METADATA_CACHE_MAX_ENTRIES:
-        oldest_key = next(iter(_file_metadata_cache))
-        _file_metadata_cache.pop(oldest_key, None)
+def _relative_or_name(project_path: str, path: Path) -> str:
+    try:
+        return _relative_to_project(project_path, str(path))
+    except ValueError:
+        return path.name
 
 
-def _load_cached_file_metadata(
-    project_path: str,
-    file_path: Optional[str],
-    parser: Callable[[str, str, str], dict],
-) -> Optional[dict]:
+def compute_schematic_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
+    """Header metadata for a schematic, from a bounded read."""
     if not file_path:
         return None
-
     path = Path(file_path)
-    try:
-        stat = path.stat()
-    except OSError:
+    text = _read_header(path)
+    if text is None:
         return None
 
-    resolved_project = str(Path(project_path).resolve())
-    resolved_file = str(path.resolve())
-    cache_key = (resolved_project, resolved_file)
-    cached = _file_metadata_cache.get(cache_key)
-
-    if (
-        cached
-        and cached.get("mtime_ns") == stat.st_mtime_ns
-        and cached.get("size") == stat.st_size
-    ):
-        metadata = cached.get("metadata")
-        return deepcopy(metadata) if isinstance(metadata, dict) else None
-
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-
-    try:
-        relative_path = _relative_to_project(project_path, str(path))
-    except ValueError:
-        relative_path = path.name
-
-    metadata = parser(text, relative_path, path.name)
-    _file_metadata_cache[cache_key] = {
-        "mtime_ns": stat.st_mtime_ns,
-        "size": stat.st_size,
-        "metadata": deepcopy(metadata),
+    return {
+        "path": _relative_or_name(project_path, path),
+        "filename": path.name,
+        "version": _extract_int_value(text, "version"),
+        "generator": _extract_string_value(text, "generator"),
+        "generator_version": _extract_string_value(text, "generator_version"),
+        "paper": _extract_string_value(text, "paper"),
+        "uuid": _extract_string_value(text, "uuid"),
+        "title_block": _parse_title_block(text),
     }
-    _trim_file_metadata_cache()
-    return metadata
 
 
-def extract_schematic_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
-    return _load_cached_file_metadata(
-        project_path,
-        file_path,
-        lambda text, relative_path, filename: {
-            "path": relative_path,
-            "filename": filename,
-            "version": _extract_int_value(text, "version"),
-            "generator": _extract_string_value(text, "generator"),
-            "generator_version": _extract_string_value(text, "generator_version"),
-            "paper": _extract_string_value(text, "paper"),
-            "uuid": _extract_string_value(text, "uuid"),
-            "title_block": _parse_title_block(text),
-        },
-    )
+def compute_pcb_metadata(
+    project_path: str,
+    file_path: Optional[str],
+    board_facts: Optional[dict] = None,
+) -> Optional[dict]:
+    """Header metadata for a board, plus whatever kicad-cli reported.
 
+    ``board_facts`` is the reduced ``kicad-cli pcb export stats`` output. It is
+    optional so a deployment without the toolchain still gets a populated card
+    -- it simply has no size or thickness on it, rather than a size this code
+    guessed at.
+    """
+    if not file_path:
+        return None
+    path = Path(file_path)
+    text = _read_header(path)
+    if text is None:
+        return None
 
-def extract_pcb_metadata(project_path: str, file_path: Optional[str]) -> Optional[dict]:
-    return _load_cached_file_metadata(
-        project_path,
-        file_path,
-        lambda text, relative_path, filename: {
-            "path": relative_path,
-            "filename": filename,
-            "version": _extract_int_value(text, "version"),
-            "generator": _extract_string_value(text, "generator"),
-            "generator_version": _extract_string_value(text, "generator_version"),
-            "paper": _extract_string_value(text, "paper"),
-            "dimensions_mm": _extract_pcb_dimensions(text),
-            "thickness_mm": _extract_number_value(_extract_sexpr_block(text, "general") or "", "thickness"),
-            "title_block": _parse_title_block(text),
-        },
-    )
+    facts = board_facts or {}
+    return {
+        "path": _relative_or_name(project_path, path),
+        "filename": path.name,
+        "version": _extract_int_value(text, "version"),
+        "generator": _extract_string_value(text, "generator"),
+        "generator_version": _extract_string_value(text, "generator_version"),
+        "paper": _extract_string_value(text, "paper"),
+        "dimensions_mm": facts.get("dimensions_mm"),
+        "thickness_mm": facts.get("thickness_mm"),
+        "title_block": _parse_title_block(text),
+    }

--- a/backend/app/services/project_properties_service.py
+++ b/backend/app/services/project_properties_service.py
@@ -110,21 +110,20 @@ def _extract_int_value(block: str, key: str) -> Optional[int]:
 
 
 def _parse_title_block(text: str) -> Optional[dict]:
+    """The title block, reduced to the two fields the panel shows.
+
+    KiCad's block also carries rev, company and numbered comments. Prism
+    extracted all of them and rendered none, so they were payload nobody read
+    and parsing nobody needed. Narrowed to what the properties panel actually
+    displays: the title, which is its heading for the board, and the date.
+    """
     block = _extract_sexpr_block(text, "title_block")
     if not block:
         return None
 
-    comments = {
-        index: _unescape_kicad_string(value)
-        for index, value in re.findall(rf"\(comment\s+(\d+)\s+{_STRING_PATTERN}\)", block)
-    }
-
     return {
         "title": _extract_string_value(block, "title") or "",
         "date": _extract_string_value(block, "date") or "",
-        "rev": _extract_string_value(block, "rev") or "",
-        "company": _extract_string_value(block, "company") or "",
-        "comments": comments,
     }
 
 
@@ -154,8 +153,6 @@ def compute_schematic_metadata(project_path: str, file_path: Optional[str]) -> O
         "version": _extract_int_value(text, "version"),
         "generator": _extract_string_value(text, "generator"),
         "generator_version": _extract_string_value(text, "generator_version"),
-        "paper": _extract_string_value(text, "paper"),
-        "uuid": _extract_string_value(text, "uuid"),
         "title_block": _parse_title_block(text),
     }
 
@@ -186,7 +183,6 @@ def compute_pcb_metadata(
         "version": _extract_int_value(text, "version"),
         "generator": _extract_string_value(text, "generator"),
         "generator_version": _extract_string_value(text, "generator_version"),
-        "paper": _extract_string_value(text, "paper"),
         "dimensions_mm": facts.get("dimensions_mm"),
         "thickness_mm": facts.get("thickness_mm"),
         "title_block": _parse_title_block(text),

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -139,15 +139,15 @@ def save_path_config_for(project: Any, config: path_config_service.PathConfig) -
 
 
 def invalidate_project_caches() -> None:
-    from app.services import project_properties_service
-
+    # Project metadata used to be memoised in-process here as well. It now
+    # lives in ws_project_metadata, keyed by a fingerprint of the files it was
+    # computed from, so it invalidates itself and has nothing to clear.
     global _project_records_cache, _project_records_cache_time
     global _projects_cache, _projects_cache_time
     _project_records_cache = []
     _project_records_cache_time = 0
     _projects_cache = []
     _projects_cache_time = 0
-    project_properties_service.invalidate_project_properties_cache()
 
 def register_project(project_id: str, name: str, path: str, repo_url: str,
                      sub_path: Optional[str] = None, parent_repo: Optional[str] = None,

--- a/backend/app/services/workspace_schema_migrations.py
+++ b/backend/app/services/workspace_schema_migrations.py
@@ -1676,6 +1676,33 @@ def _project_file_anchor(conn: Any) -> None:
     )
 
 
+def _project_metadata(conn: Any) -> None:
+    """Store the project card's descriptive metadata instead of deriving it per request.
+
+    ``/properties`` used to read both KiCad files and scan them on every open of
+    the workspace preview panel. On a large board that scan saturated a core for
+    minutes. The facts it produced change only when the files change, so they
+    belong in a table written by the import/sync job and read by the API.
+
+    ``source_fingerprint`` is what makes a row self-invalidating: it identifies
+    the inputs the row was computed from, so a sync that changed the board is
+    visible as a mismatch without needing a cache-busting call from elsewhere.
+    """
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ws_project_metadata (
+            project_id         TEXT PRIMARY KEY REFERENCES ws_projects(id) ON DELETE CASCADE,
+            schematic          JSONB,
+            pcb                JSONB,
+            source_fingerprint TEXT NOT NULL DEFAULT '',
+            board_stats_source TEXT NOT NULL DEFAULT '',
+            computed_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+
+
 MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (1, "v3_job_foundation", _v3_job_foundation),
     (2, "workspace_read_versions", _workspace_read_versions),
@@ -1693,6 +1720,7 @@ MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (18, "release_studio_source_defaults", _release_studio_source_defaults),
     (19, "release_studio_project_signoff", _release_studio_project_signoff),
     (20, "project_file_anchor", _project_file_anchor),
+    (21, "project_metadata", _project_metadata),
 )
 
 

--- a/backend/app/services/workspace_schema_migrations.py
+++ b/backend/app/services/workspace_schema_migrations.py
@@ -1703,6 +1703,30 @@ def _project_metadata(conn: Any) -> None:
     )
 
 
+def _project_metadata_repository(conn: Any) -> None:
+    """Store the card's repository facts alongside its file facts.
+
+    ``/properties`` still derived ``latest_commit`` and ``latest_tag`` from Git
+    on every request. That is far cheaper than the board scan removed in M21 --
+    about 290 ms on our largest monorepo -- but it is per-click work that does
+    not change between clicks, and ``get_releases_filtered`` counts files under
+    the subproject path for every tag, so it grows with the tag list.
+
+    Kept in its own fingerprint rather than sharing the file one: a push moves
+    HEAD without touching the checked-out board, and re-running a 30 s
+    ``kicad-cli`` pass because somebody tagged a release would be worse than
+    the problem being solved.
+    """
+
+    conn.execute(
+        """
+        ALTER TABLE ws_project_metadata
+            ADD COLUMN IF NOT EXISTS repository JSONB,
+            ADD COLUMN IF NOT EXISTS repo_fingerprint TEXT NOT NULL DEFAULT ''
+        """
+    )
+
+
 MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (1, "v3_job_foundation", _v3_job_foundation),
     (2, "workspace_read_versions", _workspace_read_versions),
@@ -1721,6 +1745,7 @@ MIGRATIONS: tuple[tuple[int, str, Migration], ...] = (
     (19, "release_studio_project_signoff", _release_studio_project_signoff),
     (20, "project_file_anchor", _project_file_anchor),
     (21, "project_metadata", _project_metadata),
+    (22, "project_metadata_repository", _project_metadata_repository),
 )
 
 

--- a/backend/app/services/workspace_service.py
+++ b/backend/app/services/workspace_service.py
@@ -727,7 +727,7 @@ class WorkspaceService:
         if not row:
             return None
         record = self._row_to_dict(row)
-        for key in ("schematic", "pcb"):
+        for key in ("schematic", "pcb", "repository"):
             value = record.get(key)
             record[key] = json.loads(value) if isinstance(value, str) else value
         return record
@@ -740,6 +740,8 @@ class WorkspaceService:
         pcb: Optional[Dict[str, Any]],
         source_fingerprint: str,
         board_stats_source: str = "",
+        repository: Optional[Dict[str, Any]] = None,
+        repo_fingerprint: str = "",
     ) -> None:
         """Record what the KiCad files say about themselves.
 
@@ -751,13 +753,16 @@ class WorkspaceService:
             conn.execute(
                 """INSERT INTO ws_project_metadata
                        (project_id, schematic, pcb, source_fingerprint,
-                        board_stats_source, computed_at)
-                   VALUES (%s,%s,%s,%s,%s,NOW())
+                        board_stats_source, repository, repo_fingerprint,
+                        computed_at)
+                   VALUES (%s,%s,%s,%s,%s,%s,%s,NOW())
                    ON CONFLICT(project_id) DO UPDATE SET
                      schematic=excluded.schematic,
                      pcb=excluded.pcb,
                      source_fingerprint=excluded.source_fingerprint,
                      board_stats_source=excluded.board_stats_source,
+                     repository=excluded.repository,
+                     repo_fingerprint=excluded.repo_fingerprint,
                      computed_at=excluded.computed_at""",
                 (
                     project_id,
@@ -765,6 +770,8 @@ class WorkspaceService:
                     json.dumps(pcb) if pcb is not None else None,
                     source_fingerprint,
                     board_stats_source,
+                    json.dumps(repository) if repository is not None else None,
+                    repo_fingerprint,
                 ),
             )
             conn.commit()

--- a/backend/app/services/workspace_service.py
+++ b/backend/app/services/workspace_service.py
@@ -715,6 +715,61 @@ class WorkspaceService:
         return results
 
     # ------------------------------------------------------------------
+    # Project metadata (descriptive facts about the KiCad files)
+    # ------------------------------------------------------------------
+
+    def get_project_metadata(self, project_id: str) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM ws_project_metadata WHERE project_id=%s",
+                (project_id,),
+            ).fetchone()
+        if not row:
+            return None
+        record = self._row_to_dict(row)
+        for key in ("schematic", "pcb"):
+            value = record.get(key)
+            record[key] = json.loads(value) if isinstance(value, str) else value
+        return record
+
+    def upsert_project_metadata(
+        self,
+        project_id: str,
+        *,
+        schematic: Optional[Dict[str, Any]],
+        pcb: Optional[Dict[str, Any]],
+        source_fingerprint: str,
+        board_stats_source: str = "",
+    ) -> None:
+        """Record what the KiCad files say about themselves.
+
+        Written by the metadata job after an import or a sync, and read by
+        ``/properties``. Deriving this per request meant scanning the board
+        every time somebody clicked a project card.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                """INSERT INTO ws_project_metadata
+                       (project_id, schematic, pcb, source_fingerprint,
+                        board_stats_source, computed_at)
+                   VALUES (%s,%s,%s,%s,%s,NOW())
+                   ON CONFLICT(project_id) DO UPDATE SET
+                     schematic=excluded.schematic,
+                     pcb=excluded.pcb,
+                     source_fingerprint=excluded.source_fingerprint,
+                     board_stats_source=excluded.board_stats_source,
+                     computed_at=excluded.computed_at""",
+                (
+                    project_id,
+                    json.dumps(schematic) if schematic is not None else None,
+                    json.dumps(pcb) if pcb is not None else None,
+                    source_fingerprint,
+                    board_stats_source,
+                ),
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
     # Portfolio CRUD
     # ------------------------------------------------------------------
 

--- a/backend/tests/test_project_metadata.py
+++ b/backend/tests/test_project_metadata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -211,6 +212,148 @@ class ComputeProjectMetadataTests(unittest.TestCase):
         export.assert_not_called()
         self.assertIsNone(computed["pcb"])
         self.assertIsNotNone(computed["schematic"])
+
+
+class RepositoryFactsTests(unittest.TestCase):
+    """The commit and tag lines on the card are Git work, so they are stored too."""
+
+    def _repo(self, directory: Path) -> str:
+        subprocess.run(["git", "init", "-q", str(directory)], check=True)
+        for key, value in (("user.email", "t@example.com"), ("user.name", "Test")):
+            subprocess.run(["git", "-C", str(directory), "config", key, value], check=True)
+        (directory / "board.kicad_pcb").write_text(BOARD_HEADER + ")\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(directory), "add", "-A"], check=True)
+        subprocess.run(["git", "-C", str(directory), "commit", "-qm", "first"], check=True)
+        return str(directory)
+
+    def test_fingerprint_moves_with_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self._repo(Path(directory))
+            before = project_metadata_service.repo_fingerprint(repo)
+
+            (Path(repo) / "note.txt").write_text("x", encoding="utf-8")
+            subprocess.run(["git", "-C", repo, "add", "-A"], check=True)
+            subprocess.run(["git", "-C", repo, "commit", "-qm", "second"], check=True)
+
+            self.assertNotEqual(before, project_metadata_service.repo_fingerprint(repo))
+
+    def test_fingerprint_moves_when_a_tag_is_added_without_a_commit(self) -> None:
+        # A release can be tagged without HEAD moving, and the card shows the
+        # latest tag, so HEAD alone is not a sufficient fingerprint.
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self._repo(Path(directory))
+            before = project_metadata_service.repo_fingerprint(repo)
+
+            subprocess.run(["git", "-C", repo, "tag", "v1.0"], check=True)
+
+            self.assertNotEqual(before, project_metadata_service.repo_fingerprint(repo))
+
+    def test_no_repository_fingerprints_to_nothing(self) -> None:
+        self.assertEqual(project_metadata_service.repo_fingerprint(None), "")
+
+
+class RefreshReusesExpensiveWorkTests(unittest.TestCase):
+    """A push must not trigger another kicad-cli pass."""
+
+    def test_unchanged_files_are_not_re_read(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+            fingerprint = project_metadata_service.source_fingerprint(None, pcb)
+            stored = {
+                "schematic": None,
+                "pcb": {"filename": "board.kicad_pcb", "dimensions_mm": {"width": 1.0, "height": 2.0}},
+                "source_fingerprint": fingerprint,
+                "board_stats_source": kicad_board_stats_service.SOURCE,
+            }
+
+            with (
+                patch.object(project_metadata_service, "workspace") as ws,
+                patch.object(project_metadata_service, "compute_project_metadata") as compute,
+                patch.object(project_metadata_service, "compute_repository_facts", return_value={"latest_commit": None, "latest_tag": None}),
+                patch.object(project_metadata_service, "repo_fingerprint", return_value="deadbeef"),
+            ):
+                ws.get_project_metadata.return_value = stored
+                computed = project_metadata_service.refresh_project_metadata(
+                    "prj-1", str(root), None, pcb, repo_path="/repo"
+                )
+
+        compute.assert_not_called()
+        self.assertTrue(computed["reused_file_metadata"])
+        self.assertEqual(computed["pcb"]["dimensions_mm"], {"width": 1.0, "height": 2.0})
+
+    def test_changed_files_are_recomputed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+            stored = {
+                "schematic": None,
+                "pcb": {"filename": "stale.kicad_pcb"},
+                "source_fingerprint": "a-fingerprint-from-before",
+                "board_stats_source": "",
+            }
+            fresh = {
+                "schematic": None,
+                "pcb": {"filename": "board.kicad_pcb"},
+                "source_fingerprint": "new",
+                "board_stats_source": kicad_board_stats_service.SOURCE,
+            }
+
+            with (
+                patch.object(project_metadata_service, "workspace") as ws,
+                patch.object(project_metadata_service, "compute_project_metadata", return_value=dict(fresh)) as compute,
+                patch.object(project_metadata_service, "compute_repository_facts", return_value={"latest_commit": None, "latest_tag": None}),
+                patch.object(project_metadata_service, "repo_fingerprint", return_value="deadbeef"),
+            ):
+                ws.get_project_metadata.return_value = stored
+                computed = project_metadata_service.refresh_project_metadata(
+                    "prj-1", str(root), None, pcb, repo_path="/repo"
+                )
+
+        compute.assert_called_once()
+        self.assertFalse(computed["reused_file_metadata"])
+
+    def test_a_moved_repository_makes_the_row_stale(self) -> None:
+        # Files untouched, HEAD moved: the commit line on the card is wrong, so
+        # the row has to be refreshed even though no kicad-cli work is due.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+            record = {
+                "source_fingerprint": project_metadata_service.source_fingerprint(None, pcb),
+                "repo_fingerprint": "the-old-head",
+            }
+
+            with (
+                patch.object(project_metadata_service, "workspace") as ws,
+                patch.object(project_metadata_service, "repo_fingerprint", return_value="a-new-head"),
+            ):
+                ws.get_project_metadata.return_value = record
+                _, current = project_metadata_service.stored_metadata_is_current(
+                    "prj-1", None, pcb, "/repo"
+                )
+
+        self.assertFalse(current)
+
+    def test_repository_failure_still_writes_the_row(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+
+            with (
+                patch.object(project_metadata_service, "workspace") as ws,
+                patch.object(project_metadata_service, "compute_repository_facts", side_effect=RuntimeError("git exploded")),
+                patch.object(project_metadata_service, "repo_fingerprint", return_value=""),
+                patch.object(kicad_board_stats_service, "export_board_stats", side_effect=kicad_board_stats_service.BoardStatsUnavailable("none")),
+            ):
+                ws.get_project_metadata.return_value = None
+                computed = project_metadata_service.refresh_project_metadata(
+                    "prj-1", str(root), None, pcb, repo_path="/repo"
+                )
+
+        ws.upsert_project_metadata.assert_called_once()
+        self.assertIsNone(computed["repository"])
+        self.assertIsNotNone(computed["pcb"])
 
 
 class SourceFingerprintTests(unittest.TestCase):

--- a/backend/tests/test_project_metadata.py
+++ b/backend/tests/test_project_metadata.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.services import (
+    kicad_board_stats_service,
+    project_metadata_service,
+    project_properties_service,
+)
+
+
+# A board header in the shape KiCad writes one: the fields the project card
+# shows are all in the first few hundred bytes, before any geometry.
+BOARD_HEADER = """(kicad_pcb
+\t(version 20240819)
+\t(generator "pcbnew")
+\t(generator_version "8.99")
+\t(paper "A4")
+\t(title_block
+\t\t(title "Mainboard")
+\t\t(date "2026-08-31")
+\t\t(rev "V1.0")
+\t\t(company "Example Ltd")
+\t\t(comment 1 "First note")
+\t)
+"""
+
+SCHEMATIC_HEADER = """(kicad_sch
+\t(version 20231120)
+\t(generator "eeschema")
+\t(generator_version "8.0")
+\t(paper "A3")
+\t(uuid "00000000-0000-0000-0000-000000000001")
+\t(title_block
+\t\t(title "Sheet")
+\t\t(rev "A")
+\t)
+"""
+
+
+def _write(directory: Path, name: str, header: str, filler_mb: int = 0) -> str:
+    path = directory / name
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(header)
+        # Geometry after the header, so a test that reads only the header slice
+        # is genuinely reading past nothing it needs.
+        for _ in range(filler_mb * 1024):
+            handle.write('\t(gr_line (start 0 0) (end 1 1) (layer "Edge.Cuts"))\n' * 16)
+        handle.write(")\n")
+    return str(path)
+
+
+class HeaderExtractionTests(unittest.TestCase):
+    def test_reads_board_header_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+
+            metadata = project_properties_service.compute_pcb_metadata(str(root), pcb)
+
+        self.assertEqual(metadata["version"], 20240819)
+        self.assertEqual(metadata["generator"], "pcbnew")
+        self.assertEqual(metadata["generator_version"], "8.99")
+        self.assertEqual(metadata["paper"], "A4")
+        self.assertEqual(metadata["filename"], "board.kicad_pcb")
+        self.assertEqual(metadata["title_block"]["title"], "Mainboard")
+        self.assertEqual(metadata["title_block"]["rev"], "V1.0")
+        self.assertEqual(metadata["title_block"]["comments"], {"1": "First note"})
+
+    def test_reads_schematic_header_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sch = _write(root, "root.kicad_sch", SCHEMATIC_HEADER)
+
+            metadata = project_properties_service.compute_schematic_metadata(str(root), sch)
+
+        self.assertEqual(metadata["version"], 20231120)
+        self.assertEqual(metadata["generator"], "eeschema")
+        self.assertEqual(metadata["uuid"], "00000000-0000-0000-0000-000000000001")
+        self.assertEqual(metadata["title_block"]["title"], "Sheet")
+
+    def test_reads_only_the_header_of_a_large_board(self) -> None:
+        """The whole point: cost must not scale with the file.
+
+        The old implementation pulled the entire board into memory and scanned
+        every graphic in it to find the outline. This asserts the read is
+        bounded -- a board an order of magnitude past the header slice costs
+        the same as a small one.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            big = _write(root, "big.kicad_pcb", BOARD_HEADER, filler_mb=4)
+            self.assertGreater(os.path.getsize(big), 8 * project_properties_service.HEADER_BYTES)
+
+            with patch.object(Path, "read_text", side_effect=AssertionError("read the whole file")):
+                metadata = project_properties_service.compute_pcb_metadata(str(root), big)
+
+        self.assertEqual(metadata["title_block"]["title"], "Mainboard")
+
+    def test_missing_file_yields_no_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertIsNone(
+                project_properties_service.compute_pcb_metadata(
+                    directory, os.path.join(directory, "absent.kicad_pcb")
+                )
+            )
+        self.assertIsNone(project_properties_service.compute_pcb_metadata("/tmp", None))
+
+
+class BoardFactsTests(unittest.TestCase):
+    """KiCad reports dimensions as formatted quantities, not numbers."""
+
+    def test_reduces_a_real_stats_report(self) -> None:
+        stats = {
+            "metadata": {"generator": "KiCad 10.0.4"},
+            "board": {
+                "has_outline": True,
+                "width": "160.0000 mm",
+                "height": "233.3500 mm",
+                "board_thickness": "1.5640 mm",
+            },
+        }
+
+        facts = kicad_board_stats_service.board_facts(stats)
+
+        self.assertEqual(facts["dimensions_mm"], {"width": 160.0, "height": 233.35})
+        self.assertEqual(facts["thickness_mm"], 1.564)
+        self.assertEqual(facts["stats_generator"], "KiCad 10.0.4")
+
+    def test_board_without_an_outline_reports_no_dimensions(self) -> None:
+        facts = kicad_board_stats_service.board_facts(
+            {"board": {"has_outline": False, "width": "0.0000 mm", "height": "0.0000 mm"}}
+        )
+
+        self.assertIsNone(facts["dimensions_mm"])
+
+    def test_refuses_a_unit_it_does_not_understand(self) -> None:
+        # Better a blank field than a number silently in the wrong unit.
+        facts = kicad_board_stats_service.board_facts(
+            {"board": {"has_outline": True, "width": "6.3 in", "height": "9.1 in"}}
+        )
+
+        self.assertIsNone(facts["dimensions_mm"])
+
+    def test_empty_report_is_survivable(self) -> None:
+        facts = kicad_board_stats_service.board_facts({})
+
+        self.assertIsNone(facts["dimensions_mm"])
+        self.assertIsNone(facts["thickness_mm"])
+
+
+class ComputeProjectMetadataTests(unittest.TestCase):
+    def test_combines_header_fields_with_kicad_cli_geometry(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+            sch = _write(root, "root.kicad_sch", SCHEMATIC_HEADER)
+
+            stats = {
+                "metadata": {"generator": "KiCad 10.0.4"},
+                "board": {
+                    "has_outline": True,
+                    "width": "100.0000 mm",
+                    "height": "80.0000 mm",
+                    "board_thickness": "1.6000 mm",
+                },
+            }
+            with patch.object(
+                kicad_board_stats_service, "export_board_stats", return_value=stats
+            ) as export:
+                computed = project_metadata_service.compute_project_metadata(str(root), sch, pcb)
+
+        export.assert_called_once_with(pcb)
+        self.assertEqual(computed["pcb"]["dimensions_mm"], {"width": 100.0, "height": 80.0})
+        self.assertEqual(computed["pcb"]["thickness_mm"], 1.6)
+        self.assertEqual(computed["pcb"]["title_block"]["title"], "Mainboard")
+        self.assertEqual(computed["schematic"]["title_block"]["title"], "Sheet")
+        self.assertEqual(computed["board_stats_source"], kicad_board_stats_service.SOURCE)
+
+    def test_missing_toolchain_still_produces_a_card(self) -> None:
+        """A deployment without kicad-cli loses the size, not the whole panel."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+
+            with patch.object(
+                kicad_board_stats_service,
+                "export_board_stats",
+                side_effect=kicad_board_stats_service.BoardStatsUnavailable("no kicad-cli"),
+            ):
+                computed = project_metadata_service.compute_project_metadata(str(root), None, pcb)
+
+        self.assertIsNone(computed["pcb"]["dimensions_mm"])
+        self.assertIsNone(computed["pcb"]["thickness_mm"])
+        self.assertEqual(computed["pcb"]["title_block"]["title"], "Mainboard")
+        self.assertEqual(computed["board_stats_source"], "")
+
+    def test_no_board_does_not_invoke_the_toolchain(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sch = _write(root, "root.kicad_sch", SCHEMATIC_HEADER)
+
+            with patch.object(kicad_board_stats_service, "export_board_stats") as export:
+                computed = project_metadata_service.compute_project_metadata(str(root), sch, None)
+
+        export.assert_not_called()
+        self.assertIsNone(computed["pcb"])
+        self.assertIsNotNone(computed["schematic"])
+
+
+class SourceFingerprintTests(unittest.TestCase):
+    """The fingerprint is what lets a stored row notice it has gone stale."""
+
+    def test_changes_when_a_file_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+            before = project_metadata_service.source_fingerprint(None, pcb)
+
+            with open(pcb, "a", encoding="utf-8") as handle:
+                handle.write("\n; edited\n")
+            os.utime(pcb, (0, 0))
+
+            after = project_metadata_service.source_fingerprint(None, pcb)
+
+        self.assertNotEqual(before, after)
+
+    def test_is_stable_for_an_untouched_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            pcb = _write(Path(directory), "board.kicad_pcb", BOARD_HEADER)
+
+            self.assertEqual(
+                project_metadata_service.source_fingerprint(None, pcb),
+                project_metadata_service.source_fingerprint(None, pcb),
+            )
+
+    def test_distinguishes_absent_from_missing(self) -> None:
+        self.assertNotEqual(
+            project_metadata_service.source_fingerprint(None, None),
+            project_metadata_service.source_fingerprint(None, "/nonexistent.kicad_pcb"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_project_metadata.py
+++ b/backend/tests/test_project_metadata.py
@@ -67,11 +67,37 @@ class HeaderExtractionTests(unittest.TestCase):
         self.assertEqual(metadata["version"], 20240819)
         self.assertEqual(metadata["generator"], "pcbnew")
         self.assertEqual(metadata["generator_version"], "8.99")
-        self.assertEqual(metadata["paper"], "A4")
         self.assertEqual(metadata["filename"], "board.kicad_pcb")
         self.assertEqual(metadata["title_block"]["title"], "Mainboard")
-        self.assertEqual(metadata["title_block"]["rev"], "V1.0")
-        self.assertEqual(metadata["title_block"]["comments"], {"1": "First note"})
+        self.assertEqual(metadata["title_block"]["date"], "2026-08-31")
+
+    def test_carries_only_the_fields_the_panel_renders(self) -> None:
+        """Narrower on purpose.
+
+        `paper`, `uuid`, and the title block's rev/company/comments were parsed
+        and never displayed. Pinning the key set keeps a future edit from
+        quietly reintroducing payload nobody reads -- and, since every one of
+        them costs a parse, work nobody needs.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            pcb = _write(root, "board.kicad_pcb", BOARD_HEADER)
+            sch = _write(root, "root.kicad_sch", SCHEMATIC_HEADER)
+
+            pcb_meta = project_properties_service.compute_pcb_metadata(str(root), pcb)
+            sch_meta = project_properties_service.compute_schematic_metadata(str(root), sch)
+
+        self.assertEqual(
+            sorted(pcb_meta),
+            ["dimensions_mm", "filename", "generator", "generator_version",
+             "path", "thickness_mm", "title_block", "version"],
+        )
+        self.assertEqual(
+            sorted(sch_meta),
+            ["filename", "generator", "generator_version", "path",
+             "title_block", "version"],
+        )
+        self.assertEqual(sorted(pcb_meta["title_block"]), ["date", "title"])
 
     def test_reads_schematic_header_fields(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -82,7 +108,6 @@ class HeaderExtractionTests(unittest.TestCase):
 
         self.assertEqual(metadata["version"], 20231120)
         self.assertEqual(metadata["generator"], "eeschema")
-        self.assertEqual(metadata["uuid"], "00000000-0000-0000-0000-000000000001")
         self.assertEqual(metadata["title_block"]["title"], "Sheet")
 
     def test_reads_only_the_header_of_a_large_board(self) -> None:

--- a/backend/tests/test_project_metadata.py
+++ b/backend/tests/test_project_metadata.py
@@ -129,9 +129,24 @@ class BoardFactsTests(unittest.TestCase):
 
         facts = kicad_board_stats_service.board_facts(stats)
 
-        self.assertEqual(facts["dimensions_mm"], {"width": 160.0, "height": 233.35})
+        self.assertEqual(facts["dimensions_mm"], {"width_mm": 160.0, "height_mm": 233.35})
         self.assertEqual(facts["thickness_mm"], 1.564)
         self.assertEqual(facts["stats_generator"], "KiCad 10.0.4")
+
+    def test_dimension_keys_match_what_the_panel_reads(self) -> None:
+        """The response model cannot catch a renamed key here.
+
+        ``ProjectPropertiesPcbFile.dimensions_mm`` is typed ``Dict[str, float]``,
+        so any key names validate. The panel's ``formatPcbDimensions`` reads
+        ``width_mm`` and ``height_mm`` specifically, and renders "Not available"
+        for anything else -- which looks exactly like a board with no outline
+        rather than like a bug.
+        """
+        facts = kicad_board_stats_service.board_facts(
+            {"board": {"has_outline": True, "width": "10.0000 mm", "height": "20.0000 mm"}}
+        )
+
+        self.assertEqual(sorted(facts["dimensions_mm"]), ["height_mm", "width_mm"])
 
     def test_board_without_an_outline_reports_no_dimensions(self) -> None:
         facts = kicad_board_stats_service.board_facts(
@@ -177,7 +192,7 @@ class ComputeProjectMetadataTests(unittest.TestCase):
                 computed = project_metadata_service.compute_project_metadata(str(root), sch, pcb)
 
         export.assert_called_once_with(pcb)
-        self.assertEqual(computed["pcb"]["dimensions_mm"], {"width": 100.0, "height": 80.0})
+        self.assertEqual(computed["pcb"]["dimensions_mm"], {"width_mm": 100.0, "height_mm": 80.0})
         self.assertEqual(computed["pcb"]["thickness_mm"], 1.6)
         self.assertEqual(computed["pcb"]["title_block"]["title"], "Mainboard")
         self.assertEqual(computed["schematic"]["title_block"]["title"], "Sheet")
@@ -262,7 +277,7 @@ class RefreshReusesExpensiveWorkTests(unittest.TestCase):
             fingerprint = project_metadata_service.source_fingerprint(None, pcb)
             stored = {
                 "schematic": None,
-                "pcb": {"filename": "board.kicad_pcb", "dimensions_mm": {"width": 1.0, "height": 2.0}},
+                "pcb": {"filename": "board.kicad_pcb", "dimensions_mm": {"width_mm": 1.0, "height_mm": 2.0}},
                 "source_fingerprint": fingerprint,
                 "board_stats_source": kicad_board_stats_service.SOURCE,
             }
@@ -280,7 +295,7 @@ class RefreshReusesExpensiveWorkTests(unittest.TestCase):
 
         compute.assert_not_called()
         self.assertTrue(computed["reused_file_metadata"])
-        self.assertEqual(computed["pcb"]["dimensions_mm"], {"width": 1.0, "height": 2.0})
+        self.assertEqual(computed["pcb"]["dimensions_mm"], {"width_mm": 1.0, "height_mm": 2.0})
 
     def test_changed_files_are_recomputed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/backend/tests/test_release_studio_schema_migration.py
+++ b/backend/tests/test_release_studio_schema_migration.py
@@ -1784,6 +1784,7 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
                 (19, "release_studio_project_signoff"),
                 (20, "project_file_anchor"),
                 (21, "project_metadata"),
+                (22, "project_metadata_repository"),
             ],
         )
 

--- a/backend/tests/test_release_studio_schema_migration.py
+++ b/backend/tests/test_release_studio_schema_migration.py
@@ -1783,6 +1783,7 @@ class ReleaseStudioPostgresSchemaTests(unittest.TestCase):
                 (18, "release_studio_source_defaults"),
                 (19, "release_studio_project_signoff"),
                 (20, "project_file_anchor"),
+                (21, "project_metadata"),
             ],
         )
 

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -71,9 +71,6 @@ export interface MonorepoStructure {
 export interface ProjectPropertiesFileTitleBlock {
     title: string;
     date: string;
-    rev: string;
-    company: string;
-    comments: Record<string, string>;
 }
 
 export interface ProjectPropertiesSchematicFile {
@@ -82,8 +79,6 @@ export interface ProjectPropertiesSchematicFile {
     version?: number;
     generator?: string;
     generator_version?: string;
-    paper?: string;
-    uuid?: string;
     title_block?: ProjectPropertiesFileTitleBlock | null;
 }
 
@@ -93,7 +88,6 @@ export interface ProjectPropertiesPcbFile {
     version?: number;
     generator?: string;
     generator_version?: string;
-    paper?: string;
     dimensions_mm?: {
         width_mm: number;
         height_mm: number;


### PR DESCRIPTION
Single-clicking a project card calls `/api/projects/{id}/properties`. That
endpoint read the schematic *and* the board and scanned them both, on every
open. On `EDA-04903-V1-0` (57.7 MB) the scan **did not finish in two minutes**.

## What was wrong

`_extract_sexpr_blocks` sliced the tail of the file on every match:

```python
block = _extract_sexpr_block(text[match_index:], token)
```

Finding the Edge.Cuts outline among **10,217 `gr_line` and 4,157 `gr_circle`**
blocks therefore copied roughly **400 GB** of string. Being pure Python it held
the GIL throughout, so it did not just make the panel slow — it starved the
event loop serving every other request. Opening that project took **25 s for the
schematic and 40 s for the board** with the backend pinned at 100% CPU, and
none of that time was the viewer's: its own logs show `wall=896ms` to parse the
schematic and `wall=2282ms` + 4.7 s paint for the board.

An in-process cache was added earlier (`7a5c6b7`) to hide this. It only hid it —
per process, so the first open after any restart paid full price, and a
128-entry cap meant a large workspace evicted its way back to paying it.

## What this does

**Board geometry now comes from `kicad-cli pcb export stats --format json`.**
That is the rule this repo already states — *"KiCad owns the board-statistics
schema"* (`release_studio/projections.py`). A second hand-written parser for
facts KiCad already reports could only ever be an approximation of the first,
and this one was: it reduced arcs to their endpoints and midpoint.

**Header fields come from a bounded 256 KB read.** `version`, `generator`,
`paper`, `uuid` and the title block are written first and are a few hundred
bytes. There was never a reason to hold 57 MB in memory to find them.

**Neither runs in a request.** kicad-cli takes 30 s on that board, so moving the
parse to it would have swapped one blocking call for another. The import and
sync jobs compute this into a new `ws_project_metadata` table and `/properties`
reads the row — the same shape already applied to thumbnails when they were
moved out of the import job for exactly this reason.

## Backfill and staleness

Rows carry a fingerprint (name + size + mtime) of the files they were computed
from. A project that predates the table, or one whose files moved without a
sync, queues its own refresh on read and serves what is stored meanwhile. The
job queue deduplicates on `artifact_key`, so repeated panel opens collapse to a
single job rather than flooding it.

A deployment without kicad-cli is not broken by this — it gets a card with no
board size on it, rather than a size this code guessed at.

## Measured

On `EDA-04903-V1-0`, 57.7 MB:

| | before | after |
| --- | --- | --- |
| header extraction | did not finish in 120 s | **1.6 ms** |
| board size | hand-rolled full-file scan | `kicad-cli`, ~30 s, once per sync |
| `/properties` | both of the above, every open | one row read |

Verified `kicad-cli pcb export stats` against the real board: `width
"160.0000 mm"`, `height "233.3500 mm"`, `board_thickness "1.5640 mm"`.
KiCad reports these as formatted quantities, not numbers, so the unit is parsed
and anything not in mm is refused rather than silently converted.

## Not changed

`paper` still comes back `null` for a custom sheet size (`(paper "User" 431.8
360)` never matched the value regex). That is pre-existing — I verified the old
code returns `None` for the same input — and fixing it is a behaviour change
that does not belong in a performance fix.

## Tests

14 new (`backend/tests/test_project_metadata.py`), including one that asserts
the read is bounded by patching `Path.read_text` to raise and parsing a board
eight times the header slice anyway.

`compileall` clean · backend suite **1079 passed, 0 failed, 85 skipped**.
Backend-only change: frontend, semantic viewer, and deployment suites not run
(not touched). Postgres integration tests skipped as usual without
`TEST_POSTGRES_URL`.