### PR TITLE
refactor(catalog): extract validation, release workflow, and health

### DIFF
--- a/backend/app/services/catalog/health.py
+++ b/backend/app/services/catalog/health.py
@@ -1,0 +1,90 @@
+"""Catalog health: validation, availability, and preview counters for operators."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.config import settings
+from app.services.catalog.component_queries import CatalogComponentQueries
+from app.services.catalog.component_read_models import (
+    STATE_PLACE_READY,
+    VALIDATION_STATUS_FAILED,
+    VALIDATION_STATUS_NOT_RUN,
+    VALIDATION_STATUS_PASSED,
+    VALIDATION_STATUS_SKIPPED,
+    VALIDATION_STATUS_WARNING,
+)
+from app.services.catalog.klc_validation import CatalogKlcValidation
+from app.services.catalog.preview_renderer import PREVIEW_STATUS_FAILED
+
+
+HEALTH_PAGE_SIZE = 10000
+
+
+class CatalogHealth:
+    """Aggregate one health snapshot over every active component."""
+
+    def __init__(self, component_queries: CatalogComponentQueries, klc: CatalogKlcValidation) -> None:
+        self._component_queries = component_queries
+        self._klc = klc
+
+    def report(self, conn: Any) -> dict[str, Any]:
+        validation_counts = {
+            status: 0
+            for status in (
+                VALIDATION_STATUS_PASSED,
+                VALIDATION_STATUS_WARNING,
+                VALIDATION_STATUS_FAILED,
+                VALIDATION_STATUS_SKIPPED,
+                VALIDATION_STATUS_NOT_RUN,
+            )
+        }
+        place_ready = 0
+        released = 0
+        missing_files = 0
+        total_components = 0
+        page = 1
+        while True:
+            # Lightweight payloads avoid hydrating preview graphs for every component.
+            plan = self._component_queries.prepare_list_components(
+                include_inactive=False, page=page, page_size=HEALTH_PAGE_SIZE, lightweight=True
+            )
+            result = self._component_queries.execute_list_components(conn, plan)
+            total_components = int(result["total"])
+            for component in result["items"]:
+                status = component["validation"]["status"]
+                validation_counts[status] = validation_counts.get(status, 0) + 1
+                if component["availability_state"] == STATE_PLACE_READY:
+                    place_ready += 1
+                else:
+                    missing_files += 1
+                if component["release_status"] == "released":
+                    released += 1
+            if page >= int(result["pages"]):
+                break
+            page += 1
+        preview_failed_row = conn.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM revision_preview_outputs rpo
+            JOIN components c ON c.current_revision_id = rpo.revision_id
+            JOIN asset_preview_versions apv ON apv.id = rpo.preview_id
+            WHERE c.is_active = 1 AND apv.status = %s
+            """,
+            (PREVIEW_STATUS_FAILED,),
+        ).fetchone()
+        return {
+            "enabled": bool(settings.CATALOG_KLC_ENABLED),
+            "checker_available": self._klc.checker_available(),
+            "checker_path": str(self._klc.utils_root()),
+            "release_gate": self._klc.release_gate(),
+            "total_components": total_components,
+            "released": released,
+            "place_ready": place_ready,
+            "missing_files": missing_files,
+            "preview_failed": int(preview_failed_row["count"] if preview_failed_row else 0),
+            "validation": validation_counts,
+        }
+
+
+__all__ = ["HEALTH_PAGE_SIZE", "CatalogHealth"]

--- a/backend/app/services/catalog/klc_validation.py
+++ b/backend/app/services/catalog/klc_validation.py
@@ -1,0 +1,519 @@
+"""KLC validation: run the KiCad library checkers and persist their evidence.
+
+Every run writes an immutable report directory under the runtime's validation
+root and one ``asset_validation_runs`` row with its findings. Nothing here
+commits; the facade owns the transaction.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+from typing import Any
+import uuid
+from xml.etree import ElementTree
+
+from app.core.config import settings
+from app.services.catalog.component_read_models import (
+    KLC_RELEASE_GATE_VALUES,
+    VALIDATION_STATUS_FAILED,
+    VALIDATION_STATUS_PASSED,
+    VALIDATION_STATUS_SKIPPED,
+    VALIDATION_STATUS_WARNING,
+    CatalogComponentReadModels,
+)
+from app.services.catalog.normalization import utc_now_iso
+from app.services.catalog.revision_kernel import CatalogRevisionKernel
+from app.services.catalog.runtime import CatalogRuntime
+
+
+VALIDATION_SEVERITY_ERROR = "error"
+VALIDATION_SEVERITY_WARNING = "warning"
+VALIDATION_SEVERITY_INFO = "info"
+
+KLC_ASSET_TYPES = frozenset({"symbol", "footprint"})
+KLC_TOOL_VERSION_TIMEOUT_SECONDS = 5
+
+# Report files a caller may download, keyed by the public name and the column
+# that stores the path.
+VALIDATION_REPORT_COLUMNS: dict[str, str] = {
+    "report.json": "json_path",
+    "report.junit.xml": "junit_path",
+    "stdout": "stdout_path",
+    "stderr": "stderr_path",
+}
+
+
+class CatalogKlcValidation:
+    """Execute KLC checkers for revision assets and read back their runs."""
+
+    def __init__(
+        self,
+        revision_kernel: CatalogRevisionKernel,
+        read_models: CatalogComponentReadModels,
+    ) -> None:
+        self._revision_kernel = revision_kernel
+        self._read_models = read_models
+
+    # -- configuration ------------------------------------------------------
+
+    @staticmethod
+    def release_gate() -> str:
+        gate = settings.CATALOG_KLC_RELEASE_GATE.strip().lower()
+        return gate if gate in KLC_RELEASE_GATE_VALUES else "warn"
+
+    @staticmethod
+    def utils_root() -> Path:
+        return Path(settings.CATALOG_KLC_UTILS_PATH).expanduser().resolve()
+
+    @classmethod
+    def checker_path(cls, asset_type: str) -> Path | None:
+        script = (
+            "check_symbol.py"
+            if asset_type == "symbol"
+            else "check_footprint.py"
+            if asset_type == "footprint"
+            else ""
+        )
+        if not script:
+            return None
+        path = cls.utils_root() / "klc-check" / script
+        return path if path.is_file() else None
+
+    @classmethod
+    def checker_available(cls) -> bool:
+        return bool(cls.checker_path("symbol") and cls.checker_path("footprint"))
+
+    @classmethod
+    def tool_version(cls) -> str:
+        root = cls.utils_root()
+        if not root.exists():
+            return ""
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=KLC_TOOL_VERSION_TIMEOUT_SECONDS,
+                check=False,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        return ""
+
+    @staticmethod
+    def rule_args(asset_type: str) -> list[str]:
+        if asset_type == "symbol":
+            rules = settings.CATALOG_KLC_SYMBOL_RULES.strip()
+            excludes = settings.CATALOG_KLC_SYMBOL_EXCLUDE_RULES.strip()
+        else:
+            rules = settings.CATALOG_KLC_FOOTPRINT_RULES.strip()
+            excludes = settings.CATALOG_KLC_FOOTPRINT_EXCLUDE_RULES.strip()
+        args: list[str] = []
+        if rules:
+            args.extend(["--rule", rules])
+        if excludes:
+            args.extend(["--exclude", excludes])
+        return args
+
+    # -- report shaping -----------------------------------------------------
+
+    @staticmethod
+    def parse_klc_junit(junit_path: Path) -> list[dict[str, Any]]:
+        if not junit_path.is_file():
+            return []
+        root = ElementTree.parse(junit_path).getroot()
+        findings: list[dict[str, Any]] = []
+        for testcase in root.iter("testcase"):
+            object_name = (
+                str(testcase.attrib.get("name", "")).removesuffix(" - Errors").removesuffix(" - Warnings")
+            )
+            testcase_type = str(testcase.attrib.get("type", ""))
+            for failure in testcase.findall("failure"):
+                raw_type = str(failure.attrib.get("type", testcase_type)).upper()
+                if raw_type == "WARNING" or testcase_type == "Warnings":
+                    severity = VALIDATION_SEVERITY_WARNING
+                elif raw_type == "INFO" or testcase_type == "Info":
+                    severity = VALIDATION_SEVERITY_INFO
+                else:
+                    severity = VALIDATION_SEVERITY_ERROR
+                message = str(failure.attrib.get("message") or "").strip()
+                rule_code = message.split(":", 1)[0].strip() if ":" in message else ""
+                text = (failure.text or "").strip()
+                lines = [line.strip() for line in text.splitlines() if line.strip()]
+                rule_url = next(
+                    (line for line in lines if line.startswith("http://") or line.startswith("https://")),
+                    "",
+                )
+                details = [line for line in lines if line != message and line != rule_url]
+                findings.append(
+                    {
+                        "severity": severity,
+                        "rule_code": rule_code,
+                        "rule_url": rule_url,
+                        "message": message or text or "KLC finding",
+                        "details": details,
+                        "object_name": object_name,
+                    }
+                )
+        return findings
+
+    @staticmethod
+    def write_validation_report_json(
+        path: Path,
+        *,
+        run_id: str,
+        asset: dict[str, Any],
+        status: str,
+        exit_code: int | None,
+        findings: list[dict[str, Any]],
+        stdout: str,
+        stderr: str,
+        tool_version: str,
+        created_at: str,
+        finished_at: str,
+    ) -> None:
+        payload = {
+            "run_id": run_id,
+            "asset_id": str(asset["id"]),
+            "asset_type": str(asset["asset_type"]),
+            "asset_name": str(asset["name"]),
+            "target_library": str(asset["target_library"]),
+            "target_name": str(asset["target_name"]),
+            "status": status,
+            "exit_code": exit_code,
+            "error_count": sum(1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_ERROR),
+            "warning_count": sum(
+                1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_WARNING
+            ),
+            "tool_version": tool_version,
+            "created_at": created_at,
+            "finished_at": finished_at,
+            "stdout": stdout,
+            "stderr": stderr,
+            "findings": findings,
+        }
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    # -- persistence --------------------------------------------------------
+
+    def store_validation_run(
+        self,
+        conn: Any,
+        *,
+        run_id: str,
+        component_id: str,
+        revision_id: str,
+        asset: dict[str, Any],
+        status: str,
+        exit_code: int | None,
+        findings: list[dict[str, Any]],
+        report_dir: Path,
+        stdout_path: Path,
+        stderr_path: Path,
+        junit_path: Path,
+        json_path: Path,
+        raw_output: str,
+        tool_version: str,
+        created_at: str,
+        finished_at: str,
+    ) -> dict[str, Any]:
+        error_count = sum(1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_ERROR)
+        warning_count = sum(1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_WARNING)
+        conn.execute("DELETE FROM asset_validation_findings WHERE run_id = %s", (run_id,))
+        conn.execute(
+            """
+            INSERT INTO asset_validation_runs (
+                id, component_id, revision_id, asset_id, asset_type, checker_type, status,
+                error_count, warning_count, exit_code, tool_version, report_dir, stdout_path,
+                stderr_path, junit_path, json_path, raw_output, created_at, finished_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                run_id,
+                component_id,
+                revision_id,
+                asset["id"],
+                asset["asset_type"],
+                f"klc_{asset['asset_type']}",
+                status,
+                error_count,
+                warning_count,
+                exit_code,
+                tool_version,
+                str(report_dir),
+                str(stdout_path),
+                str(stderr_path),
+                str(junit_path),
+                str(json_path),
+                raw_output[-20000:],
+                created_at,
+                finished_at,
+            ),
+        )
+        for finding in findings:
+            conn.execute(
+                """
+                INSERT INTO asset_validation_findings (
+                    id, run_id, severity, rule_code, rule_url, message, details_json, object_name, created_at
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    str(uuid.uuid4()),
+                    run_id,
+                    finding["severity"],
+                    finding.get("rule_code", ""),
+                    finding.get("rule_url", ""),
+                    finding["message"],
+                    json.dumps(finding.get("details", [])),
+                    finding.get("object_name", ""),
+                    finished_at,
+                ),
+            )
+        row = conn.execute("SELECT * FROM asset_validation_runs WHERE id = %s", (run_id,)).fetchone()
+        return self._read_models.validation_run_payload(dict(row), include_findings=True, conn=conn) if row else {}
+
+    # -- execution ----------------------------------------------------------
+
+    def run_klc_for_asset(
+        self,
+        conn: Any,
+        runtime: CatalogRuntime,
+        *,
+        component_id: str,
+        revision_id: str,
+        asset: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Run the checker for one asset and persist the evidence.
+
+        A missing checker records a ``skipped`` run instead of raising so the
+        release gate can still see that validation did not happen.
+        """
+        asset_type = str(asset["asset_type"])
+        if asset_type not in KLC_ASSET_TYPES:
+            raise ValueError("KLC validation only supports symbol and footprint assets")
+        run_id = str(uuid.uuid4())
+        created_at = utc_now_iso()
+        report_dir = runtime.validation_root / run_id
+        report_dir.mkdir(parents=True, exist_ok=True)
+        stdout_path = report_dir / "stdout.txt"
+        stderr_path = report_dir / "stderr.txt"
+        junit_path = report_dir / "report.junit.xml"
+        json_path = report_dir / "report.json"
+        checker = self.checker_path(asset_type)
+        tool_version = self.tool_version()
+        findings: list[dict[str, Any]] = []
+        stdout = ""
+        stderr = ""
+        exit_code: int | None = None
+
+        if checker is None:
+            status = VALIDATION_STATUS_SKIPPED
+            stderr = f"KLC checker unavailable under {self.utils_root()}"
+        else:
+            cmd = [
+                "python3",
+                str(checker),
+                str(asset["canonical_path"]),
+                "-vv",
+                "--nocolor",
+                "--junit",
+                str(junit_path),
+            ]
+            cmd.extend(self.rule_args(asset_type))
+            if asset_type == "symbol" and settings.CATALOG_KLC_FOOTPRINT_LIB_DIR.strip():
+                cmd.extend(["--footprints", settings.CATALOG_KLC_FOOTPRINT_LIB_DIR.strip()])
+            try:
+                result = subprocess.run(
+                    cmd,
+                    cwd=str(checker.parent),
+                    capture_output=True,
+                    text=True,
+                    timeout=settings.CATALOG_KLC_TIMEOUT_SECONDS,
+                    check=False,
+                )
+                stdout = result.stdout or ""
+                stderr = result.stderr or ""
+                exit_code = result.returncode
+                try:
+                    findings = self.parse_klc_junit(junit_path)
+                except ElementTree.ParseError as exc:
+                    findings = [
+                        {
+                            "severity": VALIDATION_SEVERITY_ERROR,
+                            "rule_code": "",
+                            "rule_url": "",
+                            "message": f"Could not parse KLC JUnit report: {exc}",
+                            "details": [],
+                            "object_name": str(asset["target_name"] or asset["name"]),
+                        }
+                    ]
+                if (
+                    any(finding["severity"] == VALIDATION_SEVERITY_ERROR for finding in findings)
+                    or result.returncode not in {0, 2, 3}
+                ):
+                    status = VALIDATION_STATUS_FAILED
+                elif (
+                    any(finding["severity"] == VALIDATION_SEVERITY_WARNING for finding in findings)
+                    or result.returncode == 2
+                ):
+                    status = VALIDATION_STATUS_WARNING
+                else:
+                    status = VALIDATION_STATUS_PASSED
+            except subprocess.TimeoutExpired as exc:
+                status = VALIDATION_STATUS_FAILED
+                stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+                stderr = f"KLC validation timed out after {settings.CATALOG_KLC_TIMEOUT_SECONDS}s"
+                exit_code = None
+            except OSError as exc:
+                status = VALIDATION_STATUS_FAILED
+                stderr = str(exc)
+                exit_code = None
+
+        finished_at = utc_now_iso()
+        stdout_path.write_text(stdout, encoding="utf-8")
+        stderr_path.write_text(stderr, encoding="utf-8")
+        if not junit_path.exists():
+            junit_path.write_text("<testsuites />\n", encoding="utf-8")
+        self.write_validation_report_json(
+            json_path,
+            run_id=run_id,
+            asset=asset,
+            status=status,
+            exit_code=exit_code,
+            findings=findings,
+            stdout=stdout,
+            stderr=stderr,
+            tool_version=tool_version,
+            created_at=created_at,
+            finished_at=finished_at,
+        )
+        return self.store_validation_run(
+            conn,
+            run_id=run_id,
+            component_id=component_id,
+            revision_id=revision_id,
+            asset=asset,
+            status=status,
+            exit_code=exit_code,
+            findings=findings,
+            report_dir=report_dir,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            junit_path=junit_path,
+            json_path=json_path,
+            raw_output=f"{stdout}\n{stderr}",
+            tool_version=tool_version,
+            created_at=created_at,
+            finished_at=finished_at,
+        )
+
+    def validate_component(
+        self,
+        conn: Any,
+        runtime: CatalogRuntime,
+        component_id: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+        """Run KLC for every placement asset on the current revision.
+
+        Returns ``(component_row, revision_row, runs)`` so the facade can shape
+        the payload after committing.
+        """
+        if not settings.CATALOG_KLC_ENABLED:
+            raise ValueError("KLC validation is disabled")
+        component = self._revision_kernel.component_row(conn, component_id)
+        if not component:
+            raise ValueError("Component not found")
+        revision = self._revision_kernel.revision_row(conn, str(component["current_revision_id"]))
+        if not revision:
+            raise ValueError("Component revision not found")
+        assets = [
+            asset
+            for asset in self._revision_kernel.load_assets_for_revision(conn, str(revision["id"]))
+            if str(asset["asset_type"]) in KLC_ASSET_TYPES
+        ]
+        if not assets:
+            raise ValueError("No symbol or footprint assets are attached")
+        runs = [
+            self.run_klc_for_asset(
+                conn,
+                runtime,
+                component_id=component_id,
+                revision_id=str(revision["id"]),
+                asset=asset,
+            )
+            for asset in assets
+        ]
+        return component, revision, runs
+
+    # -- reads --------------------------------------------------------------
+
+    def component_validation(self, conn: Any, component_id: str) -> dict[str, Any]:
+        component = self._revision_kernel.component_row(conn, component_id)
+        if not component:
+            raise ValueError("Component not found")
+        revision = self._revision_kernel.revision_row(conn, str(component["current_revision_id"]))
+        if not revision:
+            raise ValueError("Component revision not found")
+        revision_id = str(revision["id"])
+        assets = self._revision_kernel.load_assets_for_revision(conn, revision_id)
+        summary = self._read_models.component_validation_summary(conn, revision_id, assets)
+        run_ids = [str(asset["latest_run"]["id"]) for asset in summary["assets"] if asset.get("latest_run")]
+        inherited_by_run = {
+            str(asset["latest_run"]["id"]): dict(asset["latest_run"])
+            for asset in summary["assets"]
+            if asset.get("latest_run") and asset["latest_run"].get("inherited")
+        }
+        runs: list[dict[str, Any]] = []
+        if run_ids:
+            placeholders = ",".join("%s" for _ in run_ids)
+            rows = conn.execute(
+                f"SELECT * FROM asset_validation_runs WHERE id IN ({placeholders})",
+                tuple(run_ids),
+            ).fetchall()
+            for row in rows:
+                payload = self._read_models.validation_run_payload(dict(row), include_findings=True, conn=conn)
+                inherited = inherited_by_run.get(payload["id"])
+                if inherited:
+                    payload["inherited"] = True
+                    payload["inherited_from_revision_id"] = inherited.get("inherited_from_revision_id", "")
+                runs.append(payload)
+        return {"summary": summary, "runs": runs}
+
+    def validation_run(self, conn: Any, run_id: str) -> dict[str, Any] | None:
+        row = conn.execute("SELECT * FROM asset_validation_runs WHERE id = %s", (run_id,)).fetchone()
+        if not row:
+            return None
+        return self._read_models.validation_run_payload(dict(row), include_findings=True, conn=conn)
+
+    @staticmethod
+    def report_path(conn: Any, runtime: CatalogRuntime, run_id: str, report_name: str) -> Path | None:
+        """Resolve a stored report file, confined to the validation root."""
+        column = VALIDATION_REPORT_COLUMNS.get(report_name)
+        if not column:
+            return None
+        row = conn.execute("SELECT * FROM asset_validation_runs WHERE id = %s", (run_id,)).fetchone()
+        if not row:
+            return None
+        path = Path(str(row[column])).resolve()
+        try:
+            path.relative_to(runtime.validation_root)
+        except ValueError:
+            return None
+        return path if path.is_file() else None
+
+
+__all__ = [
+    "CatalogKlcValidation",
+    "KLC_ASSET_TYPES",
+    "KLC_TOOL_VERSION_TIMEOUT_SECONDS",
+    "VALIDATION_REPORT_COLUMNS",
+    "VALIDATION_SEVERITY_ERROR",
+    "VALIDATION_SEVERITY_INFO",
+    "VALIDATION_SEVERITY_WARNING",
+]

--- a/backend/app/services/catalog/release_workflow.py
+++ b/backend/app/services/catalog/release_workflow.py
@@ -1,0 +1,323 @@
+"""Workflow transitions, release gates, and component retirement.
+
+Release is fail-closed: every gate that cannot be proven satisfied raises
+before any row changes. Review decisions and release records are written once
+per transition and never rewritten. Nothing here commits.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+import uuid
+
+from app.services.catalog.component_read_models import (
+    VALIDATION_STATUS_FAILED,
+    VALIDATION_STATUS_NOT_RUN,
+    VALIDATION_STATUS_SKIPPED,
+    CatalogComponentReadModels,
+)
+from app.services.catalog.klc_validation import CatalogKlcValidation
+from app.services.catalog.locking import CatalogLockOperations
+from app.services.catalog.metadata_normalization import IDENTITY_KIND_MPN
+from app.services.catalog.normalization import utc_now_iso
+from app.services.catalog.revision_finalization import CatalogRevisionFinalizer
+from app.services.catalog.revision_kernel import (
+    WORKFLOW_STAGES,
+    CatalogRevisionKernel,
+    normalize_workflow_stage,
+)
+from app.services.catalog.runtime import CatalogRuntime
+
+
+WORKFLOW_TRANSITIONS: dict[str, frozenset[str]] = {
+    "open": frozenset({"in_progress", "archived"}),
+    "in_progress": frozenset({"qa_review", "open", "archived"}),
+    "qa_review": frozenset({"done", "in_progress", "archived"}),
+    "done": frozenset({"released", "qa_review", "archived"}),
+    "released": frozenset({"archived", "open"}),
+    "archived": frozenset({"open"}),
+}
+
+_RELEASE_BLOCKING_VALIDATION = frozenset(
+    {VALIDATION_STATUS_FAILED, VALIDATION_STATUS_SKIPPED, VALIDATION_STATUS_NOT_RUN}
+)
+
+
+def _compact_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def review_decision_for(
+    current_status: str,
+    release_status: str,
+    *,
+    self_approval_override: bool,
+) -> str:
+    """Name the review decision a transition records, or ``""`` for none."""
+    if current_status == "qa_review" and release_status == "done":
+        return "emergency_override" if self_approval_override else "approved"
+    if current_status == "qa_review" and release_status == "in_progress":
+        return "changes_requested"
+    if current_status == "done" and release_status == "released":
+        return "released"
+    if release_status == "archived":
+        return "archived"
+    return ""
+
+
+class CatalogReleaseWorkflow:
+    """Move a component's current revision between workflow stages."""
+
+    def __init__(
+        self,
+        catalog_locks: CatalogLockOperations,
+        revision_kernel: CatalogRevisionKernel,
+        read_models: CatalogComponentReadModels,
+        finalizer: CatalogRevisionFinalizer,
+        klc: CatalogKlcValidation,
+    ) -> None:
+        self._catalog_locks = catalog_locks
+        self._revision_kernel = revision_kernel
+        self._read_models = read_models
+        self._finalizer = finalizer
+        self._klc = klc
+
+    def set_release_status(
+        self,
+        conn: Any,
+        runtime: CatalogRuntime,
+        component_id: str,
+        release_status: str,
+        *,
+        actor: str = "",
+        self_approval_override_reason: str = "",
+        review_note: str = "",
+        actor_role: str = "",
+        expected_revision_id: str = "",
+        expected_manifest_hash: str = "",
+    ) -> None:
+        release_status = normalize_workflow_stage(release_status)
+        if release_status not in WORKFLOW_STAGES:
+            raise ValueError("Unsupported release status")
+        self._catalog_locks.lock_component_for_mutation(conn, component_id)
+        component = self._revision_kernel.component_row(conn, component_id)
+        if not component:
+            raise ValueError("Component not found")
+        revision = self._revision_kernel.revision_row(conn, str(component["current_revision_id"]))
+        if not revision:
+            raise ValueError("Component revision not found")
+        if expected_revision_id and str(revision["id"]) != expected_revision_id:
+            raise ValueError("Component revision conflict: refresh the component before changing workflow")
+        if expected_manifest_hash and str(revision.get("manifest_hash") or "") != expected_manifest_hash:
+            raise ValueError("Component manifest conflict: refresh the component before changing workflow")
+        current_status = normalize_workflow_stage(str(revision["release_status"]))
+        if current_status == "released" and release_status == "open":
+            revision = self._open_draft_from_release(conn, runtime, component_id, actor)
+            current_status = normalize_workflow_stage(str(revision["release_status"]))
+
+        if release_status != current_status and release_status not in WORKFLOW_TRANSITIONS.get(
+            current_status, frozenset()
+        ):
+            raise ValueError(f"Cannot transition revision from {current_status} to {release_status}")
+        if actor and current_status == "qa_review" and release_status == "in_progress" and not review_note.strip():
+            raise ValueError("A review note is required when requesting changes")
+        if (
+            actor
+            and release_status == "done"
+            and str(revision.get("created_by") or "").casefold() == actor.casefold()
+            and not self_approval_override_reason.strip()
+        ):
+            raise ValueError("Two-person approval required: revision authors cannot approve their own revision")
+        if (
+            release_status in {"done", "released"}
+            and str(component.get("identity_kind") or IDENTITY_KIND_MPN) != IDENTITY_KIND_MPN
+        ):
+            raise ValueError("Provisional components require a manufacturer part number before approval or release")
+
+        revision_id = str(revision["id"])
+        manifest_hash = str(revision.get("manifest_hash") or "")
+        assets = self._revision_kernel.load_assets_for_revision(conn, revision["id"])
+        validation = self._read_models.component_validation_summary(conn, revision_id, assets)
+        policy_snapshot = {
+            "two_person_approval": True,
+            "klc_release_gate": self._klc.release_gate(),
+        }
+        if release_status == "released":
+            self._assert_release_allowed(conn, revision_id, validation)
+
+        approval_decision = None
+        if release_status == "released":
+            approval_decision = conn.execute(
+                """
+                SELECT *
+                FROM component_review_decisions
+                WHERE component_id = %s AND revision_id = %s AND manifest_hash = %s
+                  AND decision IN ('approved', 'emergency_override')
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1
+                """,
+                (component_id, revision_id, manifest_hash),
+            ).fetchone()
+            if actor and not approval_decision:
+                raise ValueError("Cannot release component without approval evidence for this exact revision")
+
+        now = utc_now_iso()
+        conn.execute(
+            "UPDATE component_revisions SET release_status = %s, updated_at = %s WHERE id = %s",
+            (release_status, now, revision["id"]),
+        )
+        if release_status == "released":
+            conn.execute(
+                "UPDATE components SET released_revision_id = %s, updated_at = %s WHERE id = %s",
+                (revision["id"], now, component_id),
+            )
+        elif release_status == "archived" and str(component.get("released_revision_id") or "") == revision_id:
+            conn.execute(
+                "UPDATE components SET released_revision_id = '', updated_at = %s WHERE id = %s",
+                (now, component_id),
+            )
+        else:
+            conn.execute("UPDATE components SET updated_at = %s WHERE id = %s", (now, component_id))
+        if release_status == current_status:
+            return
+
+        decision = review_decision_for(
+            current_status,
+            release_status,
+            self_approval_override=bool(self_approval_override_reason.strip()),
+        )
+        if decision:
+            conn.execute(
+                """
+                INSERT INTO component_review_decisions (
+                    id, component_id, revision_id, reviewer, reviewer_role, decision, note,
+                    manifest_hash, validation_json, policy_json, created_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    str(uuid.uuid4()),
+                    component_id,
+                    revision_id,
+                    actor,
+                    actor_role,
+                    decision,
+                    self_approval_override_reason.strip() or review_note.strip(),
+                    manifest_hash,
+                    _compact_json(validation),
+                    _compact_json(policy_snapshot),
+                    now,
+                ),
+            )
+        if release_status == "released":
+            conn.execute(
+                """
+                INSERT INTO component_release_records (
+                    id, component_id, revision_id, release_label, manifest_hash, released_by,
+                    approval_decision_id, validation_json, policy_json, created_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT(component_id, revision_id, manifest_hash) DO NOTHING
+                """,
+                (
+                    str(uuid.uuid4()),
+                    component_id,
+                    revision_id,
+                    f"r{int(revision['version'])}",
+                    manifest_hash,
+                    actor,
+                    str(approval_decision["id"]) if approval_decision else "",
+                    _compact_json(validation),
+                    _compact_json(policy_snapshot),
+                    now,
+                ),
+            )
+        self._revision_kernel.append_audit_event(
+            conn,
+            component_id=component_id,
+            revision_id=revision_id,
+            event_type="workflow.transitioned",
+            actor=actor,
+            details={
+                "from": current_status,
+                "to": release_status,
+                "self_approval_override_reason": self_approval_override_reason.strip(),
+                "review_note": review_note.strip(),
+            },
+        )
+
+    def _open_draft_from_release(
+        self,
+        conn: Any,
+        runtime: CatalogRuntime,
+        component_id: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        """Reopening a released revision clones it; the release itself is immutable."""
+        summary = "Create draft from released revision"
+        revision = self._revision_kernel.clone_revision(
+            conn,
+            component_id,
+            actor=actor,
+            change_kind="new_draft",
+            change_summary=summary,
+        )
+        self._finalizer.finalize_revision(
+            conn,
+            runtime,
+            component_id=component_id,
+            revision_id=str(revision["id"]),
+            event_type="revision.created",
+            actor=actor,
+            details={"change_kind": "new_draft", "change_summary": summary},
+        )
+        return self._revision_kernel.revision_row(conn, str(revision["id"])) or revision
+
+    def _assert_release_allowed(self, conn: Any, revision_id: str, validation: dict[str, Any]) -> None:
+        default_representation = conn.execute(
+            """
+            SELECT symbol_asset_id, footprint_asset_id
+            FROM revision_representations
+            WHERE revision_id = %s AND is_default = 1
+            LIMIT 1
+            """,
+            (revision_id,),
+        ).fetchone()
+        if (
+            not default_representation
+            or not default_representation["symbol_asset_id"]
+            or not default_representation["footprint_asset_id"]
+        ):
+            raise ValueError("Cannot release component without one complete default representation")
+        if self._klc.release_gate() == "block" and validation["status"] in _RELEASE_BLOCKING_VALIDATION:
+            raise ValueError("Cannot release component until required symbol and footprint assets pass KLC validation")
+
+    def deactivate_component(
+        self,
+        conn: Any,
+        component_id: str,
+        *,
+        actor: str = "",
+        reason: str = "",
+    ) -> bool:
+        """Tombstone a component; identity and evidence are never hard-deleted."""
+        component = self._revision_kernel.component_row(conn, component_id)
+        if not component:
+            return False
+        if not bool(component["is_active"]):
+            return True
+        result = conn.execute(
+            "UPDATE components SET is_active = 0, updated_at = %s WHERE id = %s",
+            (utc_now_iso(), component_id),
+        )
+        self._revision_kernel.append_audit_event(
+            conn,
+            component_id=component_id,
+            revision_id=str(component.get("current_revision_id") or ""),
+            event_type="component.retired",
+            actor=actor,
+            details={"reason": reason.strip() or "Removed from the active component catalog"},
+        )
+        return result.rowcount > 0
+
+
+__all__ = ["CatalogReleaseWorkflow", "WORKFLOW_TRANSITIONS", "review_decision_for"]

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -7,14 +7,12 @@ import json
 import logging
 import re
 import shutil
-import subprocess
 import time
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterator
-from xml.etree import ElementTree
 
 from app.core.config import settings
 from app.services.catalog.component_history import CatalogComponentHistoryReads
@@ -27,6 +25,13 @@ from app.services.catalog.component_read_models import (
     supply_source_payload as _supply_source_payload,
 )
 from app.services.catalog.component_queries import CatalogComponentQueries
+from app.services.catalog.health import CatalogHealth
+from app.services.catalog.klc_validation import (
+    VALIDATION_SEVERITY_ERROR,
+    VALIDATION_SEVERITY_INFO,
+    VALIDATION_SEVERITY_WARNING,
+    CatalogKlcValidation,
+)
 from app.services.catalog.asset_browser import CatalogAssetBrowser
 from app.services.catalog.asset_files import (
     CatalogAssetFiles,
@@ -102,6 +107,7 @@ from app.services.catalog.preview_renderer import (
     PREVIEW_STATUS_READY,
 )
 from app.services.catalog.preview_store import CatalogPreviewStore
+from app.services.catalog.release_workflow import CatalogReleaseWorkflow
 from app.services.catalog.representations import CatalogRepresentations
 from app.services.catalog.revision_comparison import CatalogRevisionComparison
 from app.services.catalog.revision_finalization import CatalogRevisionFinalizer
@@ -135,9 +141,6 @@ VALIDATION_STATUS_WARNING = "warning"
 VALIDATION_STATUS_FAILED = "failed"
 VALIDATION_STATUS_SKIPPED = "skipped"
 VALIDATION_STATUS_NOT_RUN = "not_run"
-VALIDATION_SEVERITY_ERROR = "error"
-VALIDATION_SEVERITY_WARNING = "warning"
-VALIDATION_SEVERITY_INFO = "info"
 KLC_RELEASE_GATE_VALUES = {"off", "warn", "block"}
 
 SYMBOL_METADATA_FIELD_ORDER: tuple[str, ...] = (
@@ -377,6 +380,11 @@ class ComponentCatalogDomainService:
     _representations: CatalogRepresentations = CatalogRepresentations(
         _revision_kernel, _revision_finalizer
     )
+    _klc_validation: CatalogKlcValidation = CatalogKlcValidation(_revision_kernel, _component_read_models)
+    _release_workflow: CatalogReleaseWorkflow = CatalogReleaseWorkflow(
+        _catalog_locks, _revision_kernel, _component_read_models, _revision_finalizer, _klc_validation
+    )
+    _catalog_health: CatalogHealth = CatalogHealth(_component_queries, _klc_validation)
     _project_import_sessions: CatalogProjectImportSessions = CatalogProjectImportSessions()
     _project_import_matching: CatalogProjectImportMatching = CatalogProjectImportMatching()
     _project_import_assets: CatalogProjectImportAssets = CatalogProjectImportAssets(_revision_kernel)
@@ -446,6 +454,15 @@ class ComponentCatalogDomainService:
             self._asset_registry,
         )
         self._representations = CatalogRepresentations(self._revision_kernel, self._revision_finalizer)
+        self._klc_validation = CatalogKlcValidation(self._revision_kernel, self._component_read_models)
+        self._release_workflow = CatalogReleaseWorkflow(
+            self._catalog_locks,
+            self._revision_kernel,
+            self._component_read_models,
+            self._revision_finalizer,
+            self._klc_validation,
+        )
+        self._catalog_health = CatalogHealth(self._component_queries, self._klc_validation)
 
     def _runtime_for_compat(self) -> CatalogRuntime:
         """Lazily support legacy ``__new__``-constructed test doubles."""
@@ -2843,197 +2860,28 @@ class ComponentCatalogDomainService:
         return {"component": self.get_component(component_id)}
 
     def _klc_release_gate(self) -> str:
-        gate = settings.CATALOG_KLC_RELEASE_GATE.strip().lower()
-        return gate if gate in KLC_RELEASE_GATE_VALUES else "warn"
+        return self._klc_validation.release_gate()
 
     def _klc_utils_root(self) -> Path:
-        return Path(settings.CATALOG_KLC_UTILS_PATH).expanduser().resolve()
+        return self._klc_validation.utils_root()
 
     def _klc_checker_path(self, asset_type: str) -> Path | None:
-        script = "check_symbol.py" if asset_type == "symbol" else "check_footprint.py" if asset_type == "footprint" else ""
-        if not script:
-            return None
-        path = self._klc_utils_root() / "klc-check" / script
-        return path if path.is_file() else None
+        return self._klc_validation.checker_path(asset_type)
 
     def _klc_tool_version(self) -> str:
-        root = self._klc_utils_root()
-        if not root.exists():
-            return ""
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-            )
-            if result.returncode == 0:
-                return result.stdout.strip()
-        except (OSError, subprocess.SubprocessError):
-            return ""
-        return ""
+        return self._klc_validation.tool_version()
 
     def _klc_rule_args(self, asset_type: str) -> list[str]:
-        if asset_type == "symbol":
-            rules = settings.CATALOG_KLC_SYMBOL_RULES.strip()
-            excludes = settings.CATALOG_KLC_SYMBOL_EXCLUDE_RULES.strip()
-        else:
-            rules = settings.CATALOG_KLC_FOOTPRINT_RULES.strip()
-            excludes = settings.CATALOG_KLC_FOOTPRINT_EXCLUDE_RULES.strip()
-        args: list[str] = []
-        if rules:
-            args.extend(["--rule", rules])
-        if excludes:
-            args.extend(["--exclude", excludes])
-        return args
+        return self._klc_validation.rule_args(asset_type)
 
     def _parse_klc_junit(self, junit_path: Path) -> list[dict[str, Any]]:
-        if not junit_path.is_file():
-            return []
-        root = ElementTree.parse(junit_path).getroot()
-        findings: list[dict[str, Any]] = []
-        for testcase in root.iter("testcase"):
-            object_name = str(testcase.attrib.get("name", "")).removesuffix(" - Errors").removesuffix(" - Warnings")
-            testcase_type = str(testcase.attrib.get("type", ""))
-            for failure in testcase.findall("failure"):
-                raw_type = str(failure.attrib.get("type", testcase_type)).upper()
-                if raw_type == "WARNING" or testcase_type == "Warnings":
-                    severity = VALIDATION_SEVERITY_WARNING
-                elif raw_type == "INFO" or testcase_type == "Info":
-                    severity = VALIDATION_SEVERITY_INFO
-                else:
-                    severity = VALIDATION_SEVERITY_ERROR
-                message = str(failure.attrib.get("message") or "").strip()
-                rule_code = message.split(":", 1)[0].strip() if ":" in message else ""
-                text = (failure.text or "").strip()
-                lines = [line.strip() for line in text.splitlines() if line.strip()]
-                rule_url = next((line for line in lines if line.startswith("http://") or line.startswith("https://")), "")
-                details = [line for line in lines if line != message and line != rule_url]
-                findings.append(
-                    {
-                        "severity": severity,
-                        "rule_code": rule_code,
-                        "rule_url": rule_url,
-                        "message": message or text or "KLC finding",
-                        "details": details,
-                        "object_name": object_name,
-                    }
-                )
-        return findings
+        return self._klc_validation.parse_klc_junit(junit_path)
 
-    def _write_validation_report_json(
-        self,
-        path: Path,
-        *,
-        run_id: str,
-        asset: dict[str, Any],
-        status: str,
-        exit_code: int | None,
-        findings: list[dict[str, Any]],
-        stdout: str,
-        stderr: str,
-        tool_version: str,
-        created_at: str,
-        finished_at: str,
-    ) -> None:
-        payload = {
-            "run_id": run_id,
-            "asset_id": str(asset["id"]),
-            "asset_type": str(asset["asset_type"]),
-            "asset_name": str(asset["name"]),
-            "target_library": str(asset["target_library"]),
-            "target_name": str(asset["target_name"]),
-            "status": status,
-            "exit_code": exit_code,
-            "error_count": sum(1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_ERROR),
-            "warning_count": sum(1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_WARNING),
-            "tool_version": tool_version,
-            "created_at": created_at,
-            "finished_at": finished_at,
-            "stdout": stdout,
-            "stderr": stderr,
-            "findings": findings,
-        }
-        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    def _write_validation_report_json(self, path: Path, **report: Any) -> None:
+        self._klc_validation.write_validation_report_json(path, **report)
 
-    def _store_validation_run(
-        self,
-        conn: Any,
-        *,
-        run_id: str,
-        component_id: str,
-        revision_id: str,
-        asset: dict[str, Any],
-        status: str,
-        exit_code: int | None,
-        findings: list[dict[str, Any]],
-        report_dir: Path,
-        stdout_path: Path,
-        stderr_path: Path,
-        junit_path: Path,
-        json_path: Path,
-        raw_output: str,
-        tool_version: str,
-        created_at: str,
-        finished_at: str,
-    ) -> dict[str, Any]:
-        error_count = sum(1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_ERROR)
-        warning_count = sum(1 for finding in findings if finding["severity"] == VALIDATION_SEVERITY_WARNING)
-        conn.execute("DELETE FROM asset_validation_findings WHERE run_id = %s", (run_id,))
-        conn.execute(
-            """
-            INSERT INTO asset_validation_runs (
-                id, component_id, revision_id, asset_id, asset_type, checker_type, status,
-                error_count, warning_count, exit_code, tool_version, report_dir, stdout_path,
-                stderr_path, junit_path, json_path, raw_output, created_at, finished_at
-            )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-            """,
-            (
-                run_id,
-                component_id,
-                revision_id,
-                asset["id"],
-                asset["asset_type"],
-                f"klc_{asset['asset_type']}",
-                status,
-                error_count,
-                warning_count,
-                exit_code,
-                tool_version,
-                str(report_dir),
-                str(stdout_path),
-                str(stderr_path),
-                str(junit_path),
-                str(json_path),
-                raw_output[-20000:],
-                created_at,
-                finished_at,
-            ),
-        )
-        for finding in findings:
-            conn.execute(
-                """
-                INSERT INTO asset_validation_findings (
-                    id, run_id, severity, rule_code, rule_url, message, details_json, object_name, created_at
-                )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-                """,
-                (
-                    str(uuid.uuid4()),
-                    run_id,
-                    finding["severity"],
-                    finding.get("rule_code", ""),
-                    finding.get("rule_url", ""),
-                    finding["message"],
-                    json.dumps(finding.get("details", [])),
-                    finding.get("object_name", ""),
-                    finished_at,
-                ),
-            )
-        row = conn.execute("SELECT * FROM asset_validation_runs WHERE id = %s", (run_id,)).fetchone()
-        return self._validation_run_payload(dict(row), include_findings=True, conn=conn) if row else {}
+    def _store_validation_run(self, conn: Any, **run: Any) -> dict[str, Any]:
+        return self._klc_validation.store_validation_run(conn, **run)
 
     def _run_klc_for_asset(
         self,
@@ -3043,138 +2891,20 @@ class ComponentCatalogDomainService:
         revision_id: str,
         asset: dict[str, Any],
     ) -> dict[str, Any]:
-        asset_type = str(asset["asset_type"])
-        if asset_type not in {"symbol", "footprint"}:
-            raise ValueError("KLC validation only supports symbol and footprint assets")
-        run_id = str(uuid.uuid4())
-        created_at = _utc_now_iso()
-        report_dir = self.validation_root / run_id
-        report_dir.mkdir(parents=True, exist_ok=True)
-        stdout_path = report_dir / "stdout.txt"
-        stderr_path = report_dir / "stderr.txt"
-        junit_path = report_dir / "report.junit.xml"
-        json_path = report_dir / "report.json"
-        checker = self._klc_checker_path(asset_type)
-        tool_version = self._klc_tool_version()
-        findings: list[dict[str, Any]] = []
-        stdout = ""
-        stderr = ""
-        exit_code: int | None = None
-
-        if checker is None:
-            status = VALIDATION_STATUS_SKIPPED
-            stderr = f"KLC checker unavailable under {self._klc_utils_root()}"
-        else:
-            cmd = ["python3", str(checker), str(asset["canonical_path"]), "-vv", "--nocolor", "--junit", str(junit_path)]
-            cmd.extend(self._klc_rule_args(asset_type))
-            if asset_type == "symbol" and settings.CATALOG_KLC_FOOTPRINT_LIB_DIR.strip():
-                cmd.extend(["--footprints", settings.CATALOG_KLC_FOOTPRINT_LIB_DIR.strip()])
-            try:
-                result = subprocess.run(
-                    cmd,
-                    cwd=str(checker.parent),
-                    capture_output=True,
-                    text=True,
-                    timeout=settings.CATALOG_KLC_TIMEOUT_SECONDS,
-                    check=False,
-                )
-                stdout = result.stdout or ""
-                stderr = result.stderr or ""
-                exit_code = result.returncode
-                try:
-                    findings = self._parse_klc_junit(junit_path)
-                except ElementTree.ParseError as exc:
-                    findings = [
-                        {
-                            "severity": VALIDATION_SEVERITY_ERROR,
-                            "rule_code": "",
-                            "rule_url": "",
-                            "message": f"Could not parse KLC JUnit report: {exc}",
-                            "details": [],
-                            "object_name": str(asset["target_name"] or asset["name"]),
-                        }
-                    ]
-                if any(finding["severity"] == VALIDATION_SEVERITY_ERROR for finding in findings) or result.returncode not in {0, 2, 3}:
-                    status = VALIDATION_STATUS_FAILED
-                elif any(finding["severity"] == VALIDATION_SEVERITY_WARNING for finding in findings) or result.returncode == 2:
-                    status = VALIDATION_STATUS_WARNING
-                else:
-                    status = VALIDATION_STATUS_PASSED
-            except subprocess.TimeoutExpired as exc:
-                status = VALIDATION_STATUS_FAILED
-                stdout = exc.stdout if isinstance(exc.stdout, str) else ""
-                stderr = f"KLC validation timed out after {settings.CATALOG_KLC_TIMEOUT_SECONDS}s"
-                exit_code = None
-            except OSError as exc:
-                status = VALIDATION_STATUS_FAILED
-                stderr = str(exc)
-                exit_code = None
-
-        finished_at = _utc_now_iso()
-        stdout_path.write_text(stdout, encoding="utf-8")
-        stderr_path.write_text(stderr, encoding="utf-8")
-        if not junit_path.exists():
-            junit_path.write_text("<testsuites />\n", encoding="utf-8")
-        self._write_validation_report_json(
-            json_path,
-            run_id=run_id,
-            asset=asset,
-            status=status,
-            exit_code=exit_code,
-            findings=findings,
-            stdout=stdout,
-            stderr=stderr,
-            tool_version=tool_version,
-            created_at=created_at,
-            finished_at=finished_at,
-        )
-        return self._store_validation_run(
+        return self._klc_validation.run_klc_for_asset(
             conn,
-            run_id=run_id,
+            self._runtime_for_compat(),
             component_id=component_id,
             revision_id=revision_id,
             asset=asset,
-            status=status,
-            exit_code=exit_code,
-            findings=findings,
-            report_dir=report_dir,
-            stdout_path=stdout_path,
-            stderr_path=stderr_path,
-            junit_path=junit_path,
-            json_path=json_path,
-            raw_output=f"{stdout}\n{stderr}",
-            tool_version=tool_version,
-            created_at=created_at,
-            finished_at=finished_at,
         )
 
     def validate_component_klc(self, component_id: str) -> dict[str, Any]:
         self.initialize()
-        if not settings.CATALOG_KLC_ENABLED:
-            raise ValueError("KLC validation is disabled")
         with self._connect() as conn:
-            component = self._component_row(conn, component_id)
-            if not component:
-                raise ValueError("Component not found")
-            revision = self._revision_row(conn, str(component["current_revision_id"]))
-            if not revision:
-                raise ValueError("Component revision not found")
-            assets = [
-                asset
-                for asset in self._load_assets_for_revision(conn, str(revision["id"]))
-                if str(asset["asset_type"]) in {"symbol", "footprint"}
-            ]
-            if not assets:
-                raise ValueError("No symbol or footprint assets are attached")
-            runs = [
-                self._run_klc_for_asset(
-                    conn,
-                    component_id=component_id,
-                    revision_id=str(revision["id"]),
-                    asset=asset,
-                )
-                for asset in assets
-            ]
+            component, revision, runs = self._klc_validation.validate_component(
+                conn, self._runtime_for_compat(), component_id
+            )
             conn.commit()
             component_payload = self._component_payload(conn, component, revision)
         return {"component": component_payload, "runs": runs}
@@ -3182,120 +2912,22 @@ class ComponentCatalogDomainService:
     def get_component_validation(self, component_id: str) -> dict[str, Any]:
         self.initialize()
         with self._connect() as conn:
-            component = self._component_row(conn, component_id)
-            if not component:
-                raise ValueError("Component not found")
-            revision = self._revision_row(conn, str(component["current_revision_id"]))
-            if not revision:
-                raise ValueError("Component revision not found")
-            assets = self._load_assets_for_revision(conn, str(revision["id"]))
-            summary = self._component_validation_summary(conn, str(revision["id"]), assets)
-            run_ids = [
-                str(asset["latest_run"]["id"])
-                for asset in summary["assets"]
-                if asset.get("latest_run")
-            ]
-            inherited_by_run = {
-                str(asset["latest_run"]["id"]): dict(asset["latest_run"])
-                for asset in summary["assets"]
-                if asset.get("latest_run") and asset["latest_run"].get("inherited")
-            }
-            runs = []
-            if run_ids:
-                placeholders = ",".join("%s" for _ in run_ids)
-                rows = conn.execute(
-                    f"SELECT * FROM asset_validation_runs WHERE id IN ({placeholders})",
-                    tuple(run_ids),
-                ).fetchall()
-                for row in rows:
-                    payload = self._validation_run_payload(dict(row), include_findings=True, conn=conn)
-                    inherited = inherited_by_run.get(payload["id"])
-                    if inherited:
-                        payload["inherited"] = True
-                        payload["inherited_from_revision_id"] = inherited.get("inherited_from_revision_id", "")
-                    runs.append(payload)
-        return {"summary": summary, "runs": runs}
+            return self._klc_validation.component_validation(conn, component_id)
 
     def get_validation_run(self, run_id: str) -> dict[str, Any] | None:
         self.initialize()
         with self._connect() as conn:
-            row = conn.execute("SELECT * FROM asset_validation_runs WHERE id = %s", (run_id,)).fetchone()
-            if not row:
-                return None
-            return self._validation_run_payload(dict(row), include_findings=True, conn=conn)
+            return self._klc_validation.validation_run(conn, run_id)
 
     def validation_report_path(self, run_id: str, report_name: str) -> Path | None:
-        allowed = {
-            "report.json": "json_path",
-            "report.junit.xml": "junit_path",
-            "stdout": "stdout_path",
-            "stderr": "stderr_path",
-        }
-        column = allowed.get(report_name)
-        if not column:
-            return None
         self.initialize()
         with self._connect() as conn:
-            row = conn.execute("SELECT * FROM asset_validation_runs WHERE id = %s", (run_id,)).fetchone()
-            if not row:
-                return None
-            path = Path(str(row[column])).resolve()
-        try:
-            path.relative_to(self.validation_root)
-        except ValueError:
-            return None
-        return path if path.is_file() else None
+            return self._klc_validation.report_path(conn, self._runtime_for_compat(), run_id, report_name)
 
     def catalog_health(self) -> dict[str, Any]:
         self.initialize()
-        validation_counts = {status: 0 for status in (VALIDATION_STATUS_PASSED, VALIDATION_STATUS_WARNING, VALIDATION_STATUS_FAILED, VALIDATION_STATUS_SKIPPED, VALIDATION_STATUS_NOT_RUN)}
-        place_ready = 0
-        released = 0
-        missing_files = 0
-        total_components = 0
-        page = 1
-        page_size = 10000
-        while True:
-            # Lightweight payloads avoid hydrating preview graphs for every component.
-            result = self.list_components(include_inactive=False, page=page, page_size=page_size, lightweight=True)
-            components = result["items"]
-            total_components = int(result["total"])
-            for component in components:
-                validation_counts[component["validation"]["status"]] = validation_counts.get(component["validation"]["status"], 0) + 1
-                if component["availability_state"] == STATE_PLACE_READY:
-                    place_ready += 1
-                else:
-                    missing_files += 1
-                if component["release_status"] == "released":
-                    released += 1
-            if page >= int(result["pages"]):
-                break
-            page += 1
         with self._connect() as conn:
-            preview_failed_row = conn.execute(
-                """
-                SELECT COUNT(*) AS count
-                FROM revision_preview_outputs rpo
-                JOIN components c ON c.current_revision_id = rpo.revision_id
-                JOIN asset_preview_versions apv ON apv.id = rpo.preview_id
-                WHERE c.is_active = 1 AND apv.status = %s
-                """,
-                (PREVIEW_STATUS_FAILED,),
-            ).fetchone()
-            preview_failed = int(preview_failed_row["count"] if preview_failed_row else 0)
-        checker_available = bool(self._klc_checker_path("symbol") and self._klc_checker_path("footprint"))
-        return {
-            "enabled": bool(settings.CATALOG_KLC_ENABLED),
-            "checker_available": checker_available,
-            "checker_path": str(self._klc_utils_root()),
-            "release_gate": self._klc_release_gate(),
-            "total_components": total_components,
-            "released": released,
-            "place_ready": place_ready,
-            "missing_files": missing_files,
-            "preview_failed": preview_failed,
-            "validation": validation_counts,
-        }
+            return self._catalog_health.report(conn)
 
     def regenerate_component_previews(self, component_id: str, *, actor: str = "") -> dict[str, Any]:
         self.initialize()
@@ -3320,225 +2952,31 @@ class ComponentCatalogDomainService:
         expected_revision_id: str = "",
         expected_manifest_hash: str = "",
     ) -> dict[str, Any]:
-        release_status = _normalize_workflow_stage(release_status)
-        if release_status not in WORKFLOW_STAGES:
-            raise ValueError("Unsupported release status")
         self.initialize()
         with self._connect() as conn:
-            self._lock_component_for_mutation(conn, component_id)
-            component = self._component_row(conn, component_id)
-            if not component:
-                raise ValueError("Component not found")
-            revision = self._revision_row(conn, str(component["current_revision_id"]))
-            if not revision:
-                raise ValueError("Component revision not found")
-            if expected_revision_id and str(revision["id"]) != expected_revision_id:
-                raise ValueError("Component revision conflict: refresh the component before changing workflow")
-            if expected_manifest_hash and str(revision.get("manifest_hash") or "") != expected_manifest_hash:
-                raise ValueError("Component manifest conflict: refresh the component before changing workflow")
-            current_status = _normalize_workflow_stage(str(revision["release_status"]))
-            if current_status == "released" and release_status == "open":
-                revision = self._clone_revision(
-                    conn,
-                    component_id,
-                    actor=actor,
-                    change_kind="new_draft",
-                    change_summary="Create draft from released revision",
-                )
-                self._finalize_revision(
-                    conn,
-                    component_id=component_id,
-                    revision_id=str(revision["id"]),
-                    event_type="revision.created",
-                    actor=actor,
-                    details={
-                        "change_kind": "new_draft",
-                        "change_summary": "Create draft from released revision",
-                    },
-                )
-                revision = self._revision_row(conn, str(revision["id"])) or revision
-                current_status = _normalize_workflow_stage(str(revision["release_status"]))
-
-            allowed = {
-                "open": {"in_progress", "archived"},
-                "in_progress": {"qa_review", "open", "archived"},
-                "qa_review": {"done", "in_progress", "archived"},
-                "done": {"released", "qa_review", "archived"},
-                "released": {"archived", "open"},
-                "archived": {"open"},
-            }
-            if release_status != current_status and release_status not in allowed.get(current_status, set()):
-                raise ValueError(f"Cannot transition revision from {current_status} to {release_status}")
-            if actor and current_status == "qa_review" and release_status == "in_progress" and not review_note.strip():
-                raise ValueError("A review note is required when requesting changes")
-            if (
-                actor
-                and release_status == "done"
-                and str(revision.get("created_by") or "").casefold() == actor.casefold()
-                and not self_approval_override_reason.strip()
-            ):
-                raise ValueError("Two-person approval required: revision authors cannot approve their own revision")
-            if (
-                release_status in {"done", "released"}
-                and str(component.get("identity_kind") or IDENTITY_KIND_MPN) != IDENTITY_KIND_MPN
-            ):
-                raise ValueError("Provisional components require a manufacturer part number before approval or release")
-
-            assets = self._load_assets_for_revision(conn, revision["id"])
-            validation = self._component_validation_summary(conn, str(revision["id"]), assets)
-            policy_snapshot = {
-                "two_person_approval": True,
-                "klc_release_gate": self._klc_release_gate(),
-            }
-            default_representation = conn.execute(
-                """
-                SELECT symbol_asset_id, footprint_asset_id
-                FROM revision_representations
-                WHERE revision_id = %s AND is_default = 1
-                LIMIT 1
-                """,
-                (revision["id"],),
-            ).fetchone()
-            if release_status == "released" and (
-                not default_representation
-                or not default_representation["symbol_asset_id"]
-                or not default_representation["footprint_asset_id"]
-            ):
-                raise ValueError("Cannot release component without one complete default representation")
-            if release_status == "released" and self._klc_release_gate() == "block":
-                if validation["status"] in {VALIDATION_STATUS_FAILED, VALIDATION_STATUS_SKIPPED, VALIDATION_STATUS_NOT_RUN}:
-                    raise ValueError(
-                        "Cannot release component until required symbol and footprint assets pass KLC validation"
-                    )
-
-            approval_decision = None
-            if release_status == "released":
-                approval_decision = conn.execute(
-                    """
-                    SELECT *
-                    FROM component_review_decisions
-                    WHERE component_id = %s AND revision_id = %s AND manifest_hash = %s
-                      AND decision IN ('approved', 'emergency_override')
-                    ORDER BY created_at DESC, id DESC
-                    LIMIT 1
-                    """,
-                    (component_id, str(revision["id"]), str(revision.get("manifest_hash") or "")),
-                ).fetchone()
-                if actor and not approval_decision:
-                    raise ValueError("Cannot release component without approval evidence for this exact revision")
-
-            now = _utc_now_iso()
-            conn.execute(
-                "UPDATE component_revisions SET release_status = %s, updated_at = %s WHERE id = %s",
-                (release_status, now, revision["id"]),
+            self._release_workflow.set_release_status(
+                conn,
+                self._runtime_for_compat(),
+                component_id,
+                release_status,
+                actor=actor,
+                self_approval_override_reason=self_approval_override_reason,
+                review_note=review_note,
+                actor_role=actor_role,
+                expected_revision_id=expected_revision_id,
+                expected_manifest_hash=expected_manifest_hash,
             )
-            if release_status == "released":
-                conn.execute(
-                    "UPDATE components SET released_revision_id = %s, updated_at = %s WHERE id = %s",
-                    (revision["id"], now, component_id),
-                )
-            elif release_status == "archived":
-                if str(component.get("released_revision_id") or "") == str(revision["id"]):
-                    conn.execute(
-                        "UPDATE components SET released_revision_id = '', updated_at = %s WHERE id = %s",
-                        (now, component_id),
-                    )
-                else:
-                    conn.execute("UPDATE components SET updated_at = %s WHERE id = %s", (now, component_id))
-            else:
-                conn.execute("UPDATE components SET updated_at = %s WHERE id = %s", (now, component_id))
-            if release_status != current_status:
-                decision = ""
-                if current_status == "qa_review" and release_status == "done":
-                    decision = "emergency_override" if self_approval_override_reason.strip() else "approved"
-                elif current_status == "qa_review" and release_status == "in_progress":
-                    decision = "changes_requested"
-                elif current_status == "done" and release_status == "released":
-                    decision = "released"
-                elif release_status == "archived":
-                    decision = "archived"
-                if decision:
-                    conn.execute(
-                        """
-                        INSERT INTO component_review_decisions (
-                            id, component_id, revision_id, reviewer, reviewer_role, decision, note,
-                            manifest_hash, validation_json, policy_json, created_at
-                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                        """,
-                        (
-                            str(uuid.uuid4()),
-                            component_id,
-                            str(revision["id"]),
-                            actor,
-                            actor_role,
-                            decision,
-                            self_approval_override_reason.strip() or review_note.strip(),
-                            str(revision.get("manifest_hash") or ""),
-                            json.dumps(validation, sort_keys=True, separators=(",", ":")),
-                            json.dumps(policy_snapshot, sort_keys=True, separators=(",", ":")),
-                            now,
-                        ),
-                    )
-                if release_status == "released":
-                    conn.execute(
-                        """
-                        INSERT INTO component_release_records (
-                            id, component_id, revision_id, release_label, manifest_hash, released_by,
-                            approval_decision_id, validation_json, policy_json, created_at
-                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                        ON CONFLICT(component_id, revision_id, manifest_hash) DO NOTHING
-                        """,
-                        (
-                            str(uuid.uuid4()),
-                            component_id,
-                            str(revision["id"]),
-                            f"r{int(revision['version'])}",
-                            str(revision.get("manifest_hash") or ""),
-                            actor,
-                            str(approval_decision["id"]) if approval_decision else "",
-                            json.dumps(validation, sort_keys=True, separators=(",", ":")),
-                            json.dumps(policy_snapshot, sort_keys=True, separators=(",", ":")),
-                            now,
-                        ),
-                    )
-                self._append_audit_event(
-                    conn,
-                    component_id=component_id,
-                    revision_id=str(revision["id"]),
-                    event_type="workflow.transitioned",
-                    actor=actor,
-                    details={
-                        "from": current_status,
-                        "to": release_status,
-                        "self_approval_override_reason": self_approval_override_reason.strip(),
-                        "review_note": review_note.strip(),
-                    },
-                )
             conn.commit()
         return self.get_component(component_id) or {}
 
     def deactivate_component(self, component_id: str, *, actor: str = "", reason: str = "") -> bool:
         self.initialize()
         with self._connect() as conn:
-            component = self._component_row(conn, component_id)
-            if not component:
-                return False
-            if not bool(component["is_active"]):
-                return True
-            result = conn.execute(
-                "UPDATE components SET is_active = 0, updated_at = %s WHERE id = %s",
-                (_utc_now_iso(), component_id),
-            )
-            self._append_audit_event(
-                conn,
-                component_id=component_id,
-                revision_id=str(component.get("current_revision_id") or ""),
-                event_type="component.retired",
-                actor=actor,
-                details={"reason": reason.strip() or "Removed from the active component catalog"},
+            deactivated = self._release_workflow.deactivate_component(
+                conn, component_id, actor=actor, reason=reason
             )
             conn.commit()
-            return result.rowcount > 0
+            return deactivated
 
     def delete_component(self, component_id: str, *, actor: str = "", reason: str = "") -> bool:
         # Component identity, revisions, releases, usage, and audit evidence are never

--- a/backend/app/services/component_catalog_service_postgres.py
+++ b/backend/app/services/component_catalog_service_postgres.py
@@ -10,9 +10,12 @@ from app.services.catalog.asset_links import CatalogAssetLinks
 from app.services.catalog.component_history import CatalogComponentHistoryReads
 from app.services.catalog.component_read_models import CatalogComponentReadModels
 from app.services.catalog.component_queries import CatalogComponentQueries
+from app.services.catalog.health import CatalogHealth
+from app.services.catalog.klc_validation import CatalogKlcValidation
 from app.services.catalog.locking import CatalogLockOperations, PostgresCatalogLocks
 from app.services.catalog.preview_pipeline import CatalogPreviewPipeline
 from app.services.catalog.project_import_assets import CatalogProjectImportAssets
+from app.services.catalog.release_workflow import CatalogReleaseWorkflow
 from app.services.catalog.representations import CatalogRepresentations
 from app.services.catalog.revision_comparison import CatalogRevisionComparison
 from app.services.catalog.revision_finalization import CatalogRevisionFinalizer
@@ -75,6 +78,11 @@ class ComponentCatalogPostgresService(ComponentCatalogDomainService):
     _representations: CatalogRepresentations = CatalogRepresentations(
         _revision_kernel, _revision_finalizer
     )
+    _klc_validation: CatalogKlcValidation = CatalogKlcValidation(_revision_kernel, _component_read_models)
+    _release_workflow: CatalogReleaseWorkflow = CatalogReleaseWorkflow(
+        _catalog_locks, _revision_kernel, _component_read_models, _revision_finalizer, _klc_validation
+    )
+    _catalog_health: CatalogHealth = CatalogHealth(_component_queries, _klc_validation)
 
     def __init__(self, store_root: Path | None = None, database_url: str | None = None) -> None:
         self._postgres_runtime = PostgresCatalogRuntime(database_url=database_url)

--- a/backend/tests/test_catalog_klc_validation.py
+++ b/backend/tests/test_catalog_klc_validation.py
@@ -1,0 +1,213 @@
+"""Direct contracts for KLC execution, evidence, and workflow decisions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.core.config import settings  # noqa: E402
+from app.services.catalog.klc_validation import (  # noqa: E402
+    VALIDATION_SEVERITY_ERROR,
+    VALIDATION_SEVERITY_INFO,
+    VALIDATION_SEVERITY_WARNING,
+    CatalogKlcValidation,
+)
+from app.services.catalog.release_workflow import WORKFLOW_TRANSITIONS, review_decision_for  # noqa: E402
+from app.services.catalog.runtime import CatalogRuntime  # noqa: E402
+
+
+JUNIT = """<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="klc">
+    <testcase name="R_Test - Errors" type="Errors">
+      <failure type="ERROR" message="S3.1: Origin is centered">
+S3.1: Origin is centered
+https://klc.kicad.org/symbol/s3/s3.1/
+Origin at (1.27, 0)
+      </failure>
+    </testcase>
+    <testcase name="R_Test - Warnings" type="Warnings">
+      <failure message="S4.1: Pin length">detail line</failure>
+    </testcase>
+    <testcase name="R_Test - Info" type="Info">
+      <failure type="INFO" message="note"></failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+
+class _Rows:
+    def __init__(self, row: dict[str, object] | None = None) -> None:
+        self._row = row
+
+    def fetchone(self) -> dict[str, object] | None:
+        return self._row
+
+
+class _RecordingConnection:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...] | None]] = []
+
+    def execute(self, sql: str, params: tuple[object, ...] | None = None) -> _Rows:
+        self.calls.append((sql, params))
+        if sql.strip().startswith("SELECT * FROM asset_validation_runs"):
+            return _Rows({"id": params[0] if params else ""})
+        return _Rows(None)
+
+    def commit(self) -> None:
+        raise AssertionError("KLC validation must not commit")
+
+
+class _ReadModels:
+    def validation_run_payload(self, row, *, include_findings=False, conn=None):
+        return {"id": str(row["id"]), "include_findings": include_findings}
+
+
+class KlcJunitParsingTests(unittest.TestCase):
+    def test_severities_rule_codes_and_urls_are_extracted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "report.junit.xml"
+            path.write_text(JUNIT, encoding="utf-8")
+            findings = CatalogKlcValidation.parse_klc_junit(path)
+        self.assertEqual(
+            [(f["severity"], f["rule_code"], f["object_name"]) for f in findings],
+            [
+                (VALIDATION_SEVERITY_ERROR, "S3.1", "R_Test"),
+                (VALIDATION_SEVERITY_WARNING, "S4.1", "R_Test"),
+                (VALIDATION_SEVERITY_INFO, "", "R_Test - Info"),
+            ],
+        )
+        self.assertEqual(findings[0]["rule_url"], "https://klc.kicad.org/symbol/s3/s3.1/")
+        self.assertEqual(findings[0]["details"], ["Origin at (1.27, 0)"])
+        self.assertEqual(findings[2]["message"], "note")
+
+    def test_missing_report_yields_no_findings(self) -> None:
+        self.assertEqual(CatalogKlcValidation.parse_klc_junit(Path("/nonexistent/report.xml")), [])
+
+
+class KlcRunTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.runtime = CatalogRuntime(store_root=self.root / "store", database_path=self.root / "unused.db")
+        self.klc = CatalogKlcValidation(revision_kernel=None, read_models=_ReadModels())  # type: ignore[arg-type]
+        self.asset = {
+            "id": "asset-1",
+            "asset_type": "symbol",
+            "name": "R_Test",
+            "target_library": "Prism_Test",
+            "target_name": "R_Test",
+            "canonical_path": str(self.root / "R_Test.kicad_sym"),
+        }
+
+    def _install_checker(self, body: str) -> Path:
+        utils = self.root / "kicad-library-utils"
+        (utils / "klc-check").mkdir(parents=True)
+        script = utils / "klc-check" / "check_symbol.py"
+        script.write_text(body, encoding="utf-8")
+        return utils
+
+    def test_missing_checker_records_a_skipped_run_with_evidence_files(self) -> None:
+        conn = _RecordingConnection()
+        with patch.object(settings, "CATALOG_KLC_UTILS_PATH", str(self.root / "absent")):
+            payload = self.klc.run_klc_for_asset(
+                conn, self.runtime, component_id="c1", revision_id="r1", asset=self.asset
+            )
+        insert = next(params for sql, params in conn.calls if "INSERT INTO asset_validation_runs" in sql)
+        self.assertEqual(insert[6], "skipped")
+        self.assertEqual(insert[5], "klc_symbol")
+        report_dir = Path(str(insert[11]))
+        self.assertTrue(report_dir.is_relative_to(self.runtime.validation_root))
+        report = json.loads((report_dir / "report.json").read_text(encoding="utf-8"))
+        self.assertEqual(report["status"], "skipped")
+        self.assertIn("KLC checker unavailable", (report_dir / "stderr.txt").read_text(encoding="utf-8"))
+        self.assertEqual((report_dir / "report.junit.xml").read_text(encoding="utf-8"), "<testsuites />\n")
+        self.assertEqual(payload["include_findings"], True)
+
+    def test_checker_findings_drive_status_and_are_persisted(self) -> None:
+        utils = self._install_checker(
+            "import sys\n"
+            "junit = sys.argv[sys.argv.index('--junit') + 1]\n"
+            f"open(junit, 'w').write({JUNIT!r})\n"
+            "print('checked')\n"
+            "sys.exit(3)\n"
+        )
+        conn = _RecordingConnection()
+        with (
+            patch.object(settings, "CATALOG_KLC_UTILS_PATH", str(utils)),
+            patch.object(settings, "CATALOG_KLC_SYMBOL_RULES", "S3,S4"),
+            patch.object(settings, "CATALOG_KLC_FOOTPRINT_LIB_DIR", ""),
+        ):
+            self.klc.run_klc_for_asset(
+                conn, self.runtime, component_id="c1", revision_id="r1", asset=self.asset
+            )
+        insert = next(params for sql, params in conn.calls if "INSERT INTO asset_validation_runs" in sql)
+        self.assertEqual(insert[6], "failed")
+        self.assertEqual((insert[7], insert[8], insert[9]), (1, 1, 3))
+        findings = [params for sql, params in conn.calls if "INSERT INTO asset_validation_findings" in sql]
+        self.assertEqual([row[2] for row in findings], ["error", "warning", "info"])
+        self.assertEqual(json.loads(findings[0][6]), ["Origin at (1.27, 0)"])
+
+    def test_warning_only_exit_code_two_is_a_warning_run(self) -> None:
+        utils = self._install_checker(
+            "import sys\n"
+            "junit = sys.argv[sys.argv.index('--junit') + 1]\n"
+            "open(junit, 'w').write('<testsuites/>')\n"
+            "sys.exit(2)\n"
+        )
+        conn = _RecordingConnection()
+        with patch.object(settings, "CATALOG_KLC_UTILS_PATH", str(utils)):
+            self.klc.run_klc_for_asset(
+                conn, self.runtime, component_id="c1", revision_id="r1", asset=self.asset
+            )
+        insert = next(params for sql, params in conn.calls if "INSERT INTO asset_validation_runs" in sql)
+        self.assertEqual(insert[6], "warning")
+
+    def test_unsupported_asset_type_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self.klc.run_klc_for_asset(
+                _RecordingConnection(),
+                self.runtime,
+                component_id="c1",
+                revision_id="r1",
+                asset={**self.asset, "asset_type": "3dmodel"},
+            )
+
+
+class ReleaseWorkflowDecisionTests(unittest.TestCase):
+    def test_transition_table_matches_the_shipped_workflow(self) -> None:
+        self.assertEqual(
+            {stage: sorted(targets) for stage, targets in WORKFLOW_TRANSITIONS.items()},
+            {
+                "open": ["archived", "in_progress"],
+                "in_progress": ["archived", "open", "qa_review"],
+                "qa_review": ["archived", "done", "in_progress"],
+                "done": ["archived", "qa_review", "released"],
+                "released": ["archived", "open"],
+                "archived": ["open"],
+            },
+        )
+
+    def test_review_decisions_per_transition(self) -> None:
+        self.assertEqual(review_decision_for("qa_review", "done", self_approval_override=False), "approved")
+        self.assertEqual(
+            review_decision_for("qa_review", "done", self_approval_override=True), "emergency_override"
+        )
+        self.assertEqual(
+            review_decision_for("qa_review", "in_progress", self_approval_override=False), "changes_requested"
+        )
+        self.assertEqual(review_decision_for("done", "released", self_approval_override=False), "released")
+        self.assertEqual(review_decision_for("open", "archived", self_approval_override=False), "archived")
+        self.assertEqual(review_decision_for("open", "in_progress", self_approval_override=False), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/catalog_architecture_baseline.json
+++ b/scripts/catalog_architecture_baseline.json
@@ -87,7 +87,7 @@
     "backend/app/api/projects.py": 2153,
     "backend/app/release_studio/closure.py": 1336,
     "backend/app/release_studio/documents/artwork.py": 1533,
-    "backend/app/services/component_catalog_domain.py": 3983,
+    "backend/app/services/component_catalog_domain.py": 3421,
     "backend/app/services/design_compare_service.py": 2185,
     "backend/app/services/fabrication_compare_service.py": 1543,
     "backend/app/services/job_service.py": 1916,


### PR DESCRIPTION
Stacked on PR #217. Catalog PR 7: validation and release.

## Summary
- `catalog/klc_validation.py`: KLC configuration, checker discovery, JUnit parsing, report files, `asset_validation_runs` persistence, per-asset and per-component execution, validation reads, confined report paths.
- `catalog/release_workflow.py`: workflow transition table, two-person approval, provisional-identity and default-representation gates, KLC release gate, review decisions, release records, audit, and component retirement. Release stays fail-closed; review/release evidence is written once per transition.
- `catalog/health.py`: operator health snapshot over the component query plan.
- The domain facade keeps every signature and owns the transaction; it delegates and commits. The PostgreSQL subclass wires the same collaborators over its transactional locks.
- New direct tests: JUnit severities/rules/URLs, skipped run when the checker is absent, status derivation from findings and exit codes, evidence files under the validation root, transition table, review decisions.

Domain module: 3,983 -> 3,421 lines on this PR.

## Verification
- `python -m compileall -q app`
- Full backend suite mirroring the dev quality gate env (Postgres 17, isolated TEST_POSTGRES_URL): 1134 + 8 new tests OK, 15 skipped (kicad-cli/pcbnew gated).
- `tests.test_component_catalog_postgres_integration`: 15 passed, zero skips.
- `scripts/check_catalog_architecture.py`: 0 legacy-import violations, 16 private-use keys (tests only), domain ceiling ratcheted to 3,421.

Made with [Cursor](https://cursor.com)