### PR TITLE
refactor(catalog): extract placement, provider tokens, signed URLs, and DBL export

### DIFF
--- a/backend/app/services/AGENTS.md
+++ b/backend/app/services/AGENTS.md
@@ -11,14 +11,15 @@ Three files, and the names do not tell you which to use:
 | --- | --- |
 | `component_catalog_service.py` | Compatibility import and runtime singleton. |
 | `component_catalog_service_postgres.py` | Concrete PostgreSQL connection, schema initialization, and database-specific overrides. |
-| `component_catalog_domain.py` | Inherited catalog API and behavior, including SQL through the connection abstraction and file-backed assets. |
+| `component_catalog_domain.py` | Compatibility facade: the historical callable surface, delegating to collaborators in `catalog/`. |
 
-`ComponentCatalogPostgresService` inherits the large
-`ComponentCatalogDomainService`; the latter is not storage-neutral despite its
-name. Navigate it with symbol search rather than loading the file wholesale.
-Useful search terms are `project_import`, `folder_import`, `metadata_batch`,
-`validation`, `_klc_`, `preview`, `asset`, `representation`, `release`, and
-`dbl`. Public reads generally begin with `list_`, `get_`, or `search_`.
+`ComponentCatalogPostgresService` inherits `ComponentCatalogDomainService`,
+composes the `catalog/` collaborators, and owns transactions. The behavior
+itself lives in `backend/app/services/catalog/`; read
+`backend/app/services/catalog/AGENTS.md` for the layer map. To find where a
+facade method lands, search the facade for the method name and follow the
+`self._<collaborator>.` call. Public reads generally begin with `list_`,
+`get_`, or `search_`.
 
 Do not extend the inheritance split casually. When adding a cohesive capability,
 first consider a narrow collaborator with a public API that both workers and

--- a/backend/app/services/catalog/AGENTS.md
+++ b/backend/app/services/catalog/AGENTS.md
@@ -1,35 +1,49 @@
-# Catalog decomposition
+# Catalog package
 
-This directory is the target package for the incremental catalog split. It is
-an empty package marker in PR 1: the running implementation remains the
-compatibility singleton in `backend/app/services/component_catalog_service.py`,
-backed by `backend/app/services/component_catalog_service_postgres.py` and
-`backend/app/services/component_catalog_domain.py`.
+This package holds the decomposed catalog implementation. The running service
+is still composed outside it: `backend/app/services/component_catalog_service.py`
+is the stable singleton root, `backend/app/services/component_catalog_service_postgres.py`
+owns the PostgreSQL connection and wires collaborators, and
+`backend/app/services/component_catalog_domain.py` is the compatibility facade
+that keeps the historical callable surface by explicit delegation. Callers
+outside `backend/app/services/` use the facade; new behavior lives here.
 
-## Future layering
+## Layers
 
-Later slices may add narrow, dependency-injected collaborators in four layers:
+Modules depend downward only. Nothing here may import the three legacy catalog
+modules, directly or relatively. No mixins, no `__getattr__` delegation, no
+collaborator that holds a reference back to the facade.
 
-- foundation: stable value shaping, hashing, signing, and shared primitives;
-- persistence: PostgreSQL reads/writes and transaction boundaries;
-- domain: component, revision, asset, import, validation, release, and export
-  operations;
-- compatibility facade: an explicit adapter for the existing public callable
-  surface, composed by the stable root outside this package.
+| Layer | Modules |
+| --- | --- |
+| Foundation (pure) | `normalization.py`, `metadata_normalization.py`, `metadata_schema.py`, `asset_types.py`, `runtime.py` (paths and process-local caches), `kicad_cli.py`, `signed_urls.py`, `placement_payloads.py`, `metadata_csv.py`, `inventory_csv.py` (parsing) |
+| Persistence (PostgreSQL) | `postgres_runtime.py`, `postgres_schema.py`, `postgres_projections.py`, `postgres_integrity.py`, `locking.py`, `revision_kernel.py`, `asset_registry.py`, `asset_files.py`, `preview_store.py`, `metadata_fields.py`, `metadata_grid.py`, `metadata_batches.py`, `project_import_matching.py`, `provider_tokens.py` |
+| Domain operations | components: `component_read_models.py`, `component_queries.py`, `component_history.py`, `revision_comparison.py`, `revision_finalization.py`, `representations.py` · assets: `asset_browser.py`, `asset_links.py`, `asset_imports.py`, `preview_renderer.py`, `preview_pipeline.py` · metadata: `metadata_batch_staging.py`, `metadata_batch_application.py` · imports: `project_import_sessions.py`, `project_import_assets.py`, `project_import_acceptance.py` · validation and release: `klc_validation.py`, `release_workflow.py`, `health.py` · provider: `placement.py`, `dbl_export.py` |
 
-The layer names describe the destination architecture, not files that exist
-yet. Keep each new collaborator pointed toward lower layers only. In
-particular, nothing in this package may import or depend back on the three
-legacy catalog modules, directly or through a relative import. Avoid mixins and
-dynamic `__getattr__` delegation; pass dependencies explicitly.
+Collaborators take `conn` (and `runtime` where files are touched) as explicit
+parameters and never commit; the facade owns transactions. The exception is
+batch preview generation, which commits per component for durability and says
+so at the call site.
+
+## Contracts that must not move
+
+- Revision manifest hashes, audit-chain hashes, and preview fingerprints
+  (`revision_kernel.py`, `preview_pipeline.py`).
+- Placement manifests, inline bundles, and signed-URL messages
+  (`placement.py`, `placement_payloads.py`, `signed_urls.py`); outputs are
+  byte-stable for identical inputs.
+- DBL bundle layout, column order, and file names (`dbl_export.py`).
+- Release gating is fail-closed and review/release records are append-only
+  (`release_workflow.py`).
+- Canonical asset paths under the store root (`asset_files.py`, `runtime.py`).
 
 ## Navigation
 
-Start from the public API routes in `backend/app/api/catalog_admin.py` and
-`backend/app/api/remote_provider.py`, then follow worker dispatch in
-`backend/app/services/catalog_worker_tasks.py`. The PostgreSQL behavior and
-characterization contracts are covered by
-`backend/tests/test_component_catalog_postgres_integration.py`; the private
-caller and module-size ratchets are checked by
-`backend/tests/test_catalog_architecture.py` and
-`scripts/check_catalog_architecture.py`.
+Start from `backend/app/api/catalog_admin.py` and
+`backend/app/api/remote_provider.py`, then follow the facade method into its
+collaborator. Worker dispatch is in `backend/app/services/catalog_worker_tasks.py`.
+Characterization coverage is `backend/tests/test_component_catalog_postgres_integration.py`;
+focused unit coverage sits in `backend/tests/test_catalog_*.py`. Private-caller
+and module-size ratchets are enforced by `scripts/check_catalog_architecture.py`
+and `backend/tests/test_catalog_architecture.py`; run the script with
+`--update-baseline` only to record reductions.

--- a/backend/app/services/catalog/dbl_export.py
+++ b/backend/app/services/catalog/dbl_export.py
@@ -1,0 +1,298 @@
+"""KiCad database-library (DBL) export of released, placeable components.
+
+The bundle is a SQLite interchange file plus per-platform ``.kicad_dbl``
+configs, extracted symbol/footprint libraries, and library tables. Prism's
+runtime state stays in PostgreSQL; SQLite is only the delivery format KiCad
+reads. Output is byte-stable for an unchanged catalog.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import shutil
+import sqlite3
+from typing import Any
+
+from app.services.catalog.normalization import sanitize_name
+from app.services.catalog.placement import CatalogPlacement
+from app.services.catalog.placement_payloads import materialize_asset
+from app.services.catalog.runtime import CatalogRuntime
+
+
+DBL_COMMON_COLUMNS: tuple[str, ...] = (
+    "Part Number",
+    "Part Number Nocolon",
+    "Comment",
+    "Value",
+    "Manufacturer",
+    "Manufacturer Part Number",
+    "PackageDescription",
+    "Status",
+    "Part Description",
+    "Datasheet",
+    "LibSymbol",
+    "LibFootprint",
+)
+
+DBL_KEY_COLUMN = "Part Number Nocolon"
+DBL_LINUX_FILENAME = "Prism_Linux.kicad_dbl"
+DBL_WINDOWS_FILENAME = "Prism_Windows.kicad_dbl"
+DBL_LINUX_CONNECTION = "Driver={SQLite3};Database=${CWD}/Prism.sqlite;"
+DBL_WINDOWS_CONNECTION = "Driver={SQLite3 ODBC Driver};Database=${CWD}/Prism.sqlite;"
+
+
+def quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def sexpr_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def part_number_nocolon(value: str) -> str:
+    cleaned = re.sub(r":+", "_", value.strip())
+    cleaned = re.sub(r"\s+", "_", cleaned)
+    return cleaned or "PART"
+
+
+def dbl_symbol_library_name(part_number: str, symbol_asset: dict[str, Any] | None) -> str:
+    if not symbol_asset:
+        return ""
+    raw = f"Prism_{part_number}_{symbol_asset['target_library']}_{symbol_asset['target_name']}"
+    return sanitize_name(raw, "Prism_Symbol")
+
+
+def dbl_row_for_component(
+    component: dict[str, Any],
+    part_number: str,
+    custom_fields: list[dict[str, Any]],
+) -> dict[str, str]:
+    default_representation = next(
+        (item for item in component.get("representations", []) if item.get("is_default")),
+        None,
+    )
+    symbol_asset = default_representation.get("symbol") if default_representation else None
+    footprint_asset = default_representation.get("footprint") if default_representation else None
+    lib_symbol = ""
+    lib_footprint = ""
+    if symbol_asset:
+        lib_symbol = f"{dbl_symbol_library_name(part_number, symbol_asset)}:{symbol_asset['target_name']}"
+    if footprint_asset:
+        lib_footprint = f"{footprint_asset['target_library']}:{footprint_asset['target_name']}"
+    row = {
+        "Part Number": part_number,
+        "Part Number Nocolon": part_number,
+        "Comment": component["value"] or component["name"],
+        "Value": component["value"],
+        "Manufacturer": component["manufacturer"],
+        "Manufacturer Part Number": component["mpn"],
+        "PackageDescription": component["package_name"],
+        "Status": component["workflow_stage"],
+        "Part Description": component["description"],
+        "Datasheet": component["datasheet_url"],
+        "LibSymbol": lib_symbol,
+        "LibFootprint": lib_footprint,
+    }
+    extras = dict(component.get("extra_fields") or {})
+    row.update({field["key"]: str(extras.get(field["storage_key"], "")) for field in custom_fields})
+    return row
+
+
+def write_dbl_config(
+    export_root: Path,
+    *,
+    filename: str,
+    connection_string: str,
+    libraries: list[dict[str, Any]],
+) -> None:
+    payload = {
+        "meta": {"version": 0},
+        "name": "KiCAD Prism Database Library",
+        "description": "KiCAD Prism released component database library",
+        "source": {
+            "type": "odbc",
+            "dsn": "",
+            "username": "",
+            "password": "",
+            "timeout_seconds": 2,
+            "connection_string": connection_string,
+        },
+        "cache": {"max_age": 28800},
+        "libraries": libraries,
+    }
+    (export_root / filename).write_text(json.dumps(payload, indent=4) + "\n", encoding="utf-8")
+
+
+class CatalogDblExport:
+    """Write the DBL bundle for an already-selected set of components."""
+
+    def __init__(self, placement: CatalogPlacement) -> None:
+        self._placement = placement
+
+    def collect_dbl_assets(
+        self,
+        conn: Any,
+        component: dict[str, Any],
+        part_number: str,
+        export_root: Path,
+    ) -> None:
+        _, assets = self._placement.placement_assets(conn, component["revision_id"])
+        for raw_asset in assets:
+            if raw_asset["asset_type"] not in {"symbol", "footprint"}:
+                continue
+            asset = materialize_asset(raw_asset, assets, component)
+            if raw_asset["asset_type"] == "symbol":
+                library_name = dbl_symbol_library_name(part_number, asset)
+                destination = export_root / "SchLib" / f"{library_name}.kicad_sym"
+            else:
+                destination = (
+                    export_root / "PcbLib" / f"{asset['target_library']}.pretty" / f"{asset['target_name']}.kicad_mod"
+                )
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(asset["payload"])
+
+    def export_bundle(
+        self,
+        conn: Any,
+        runtime: CatalogRuntime,
+        components: list[dict[str, Any]],
+        metadata_fields: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Rebuild the export root from ``components`` (already released and placeable)."""
+        export_root = runtime.export_root
+        if export_root.exists():
+            shutil.rmtree(export_root)
+        (export_root / "SchLib").mkdir(parents=True, exist_ok=True)
+        (export_root / "PcbLib").mkdir(parents=True, exist_ok=True)
+
+        components = sorted(components, key=lambda c: (c["category"], c["mpn"], c["id"]))
+        custom_fields = [
+            field
+            for field in metadata_fields
+            if field["storage_kind"] == "extra" and field["key"] not in DBL_COMMON_COLUMNS
+        ]
+        effective_columns = (*DBL_COMMON_COLUMNS, *(field["key"] for field in custom_fields))
+        db_path = export_root / "Prism.sqlite"
+        used_part_numbers: set[str] = set()
+        grouped_rows: dict[str, list[dict[str, str]]] = {}
+
+        for component in components:
+            base_part = part_number_nocolon(component["mpn"] or component["value"] or component["id"])
+            part_number = base_part
+            counter = 2
+            while part_number in used_part_numbers:
+                part_number = f"{base_part}_{counter}"
+                counter += 1
+            used_part_numbers.add(part_number)
+            category = component["category"] or "Uncategorized"
+            grouped_rows.setdefault(category, []).append(
+                dbl_row_for_component(component, part_number, custom_fields)
+            )
+            self.collect_dbl_assets(conn, component, part_number, export_root)
+
+        with sqlite3.connect(db_path) as dbl_conn:
+            for category, rows in sorted(grouped_rows.items()):
+                table = quote_identifier(category)
+                columns_sql = ", ".join(
+                    f"{quote_identifier(column)} TEXT NOT NULL DEFAULT ''" for column in effective_columns
+                )
+                dbl_conn.execute(f"CREATE TABLE {table} ({columns_sql})")
+                column_names = ", ".join(quote_identifier(column) for column in effective_columns)
+                placeholders = ", ".join("?" for _ in effective_columns)
+                for row in rows:
+                    dbl_conn.execute(
+                        f"INSERT INTO {table} ({column_names}) VALUES ({placeholders})",
+                        tuple(row.get(column, "") for column in effective_columns),
+                    )
+
+        fields = [
+            {
+                "column": column,
+                "name": column,
+                "visible_on_add": False,
+                "visible_in_chooser": column not in {"LibSymbol", "LibFootprint"},
+                "show_name": True,
+                "inherit_properties": True,
+            }
+            for column in effective_columns
+            if column != DBL_KEY_COLUMN
+        ]
+        libraries = [
+            {
+                "name": category,
+                "table": category,
+                "key": DBL_KEY_COLUMN,
+                "symbols": "LibSymbol",
+                "footprints": "LibFootprint",
+                "fields": fields,
+            }
+            for category in sorted(grouped_rows)
+        ]
+        write_dbl_config(
+            export_root,
+            filename=DBL_LINUX_FILENAME,
+            connection_string=DBL_LINUX_CONNECTION,
+            libraries=libraries,
+        )
+        write_dbl_config(
+            export_root,
+            filename=DBL_WINDOWS_FILENAME,
+            connection_string=DBL_WINDOWS_CONNECTION,
+            libraries=libraries,
+        )
+
+        symbol_libraries = sorted(path.stem for path in (export_root / "SchLib").glob("*.kicad_sym"))
+        footprint_libraries = sorted(
+            {
+                asset["target_library"]
+                for component in components
+                for asset in component["assets"]
+                if asset["asset_type"] == "footprint"
+            }
+        )
+        sym_lines = [
+            "(sym_lib_table",
+            f'  (lib (name "Prism")(type "Database")(uri "${{PRISM_LIB_DIR}}/{DBL_LINUX_FILENAME}")(options "")(descr ""))',
+        ]
+        sym_lines.extend(
+            f'  (lib (name "{sexpr_string(library)}")(type "KiCad")(uri "${{PRISM_LIB_DIR}}/SchLib/{sexpr_string(library)}.kicad_sym")(options "")(descr "")(hidden))'
+            for library in symbol_libraries
+        )
+        sym_lines.append(")")
+        (export_root / "sym-lib-table").write_text("\n".join(sym_lines) + "\n", encoding="utf-8")
+
+        fp_lines = ["(fp_lib_table"]
+        fp_lines.extend(
+            f'  (lib (name "{sexpr_string(library)}")(type "KiCad")(uri "${{PRISM_LIB_DIR}}/PcbLib/{sexpr_string(library)}.pretty")(options "")(descr ""))'
+            for library in footprint_libraries
+        )
+        fp_lines.append(")")
+        (export_root / "fp-lib-table").write_text("\n".join(fp_lines) + "\n", encoding="utf-8")
+
+        return {
+            "export_root": str(export_root),
+            "component_count": len(components),
+            "category_count": len(grouped_rows),
+            "sqlite_path": str(db_path),
+            "linux_dbl": str(export_root / DBL_LINUX_FILENAME),
+            "windows_dbl": str(export_root / DBL_WINDOWS_FILENAME),
+            "sym_lib_table": str(export_root / "sym-lib-table"),
+            "fp_lib_table": str(export_root / "fp-lib-table"),
+        }
+
+
+__all__ = [
+    "DBL_COMMON_COLUMNS",
+    "DBL_KEY_COLUMN",
+    "DBL_LINUX_FILENAME",
+    "DBL_WINDOWS_FILENAME",
+    "CatalogDblExport",
+    "dbl_row_for_component",
+    "dbl_symbol_library_name",
+    "part_number_nocolon",
+    "quote_identifier",
+    "sexpr_string",
+    "write_dbl_config",
+]

--- a/backend/app/services/catalog/placement.py
+++ b/backend/app/services/catalog/placement.py
@@ -1,0 +1,191 @@
+"""Placement bundles for desktop KiCad: manifests, inline bundles, asset fetches.
+
+A placement is always anchored to one representation (a symbol/footprint pair)
+on a released revision. Auxiliary 3D/SPICE assets ride along with whichever
+representation is selected.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from app.services.catalog.asset_types import AUXILIARY_ASSET_TYPES
+from app.services.catalog.component_read_models import CatalogComponentReadModels
+from app.services.catalog.placement_payloads import materialize_asset
+from app.services.catalog.revision_kernel import CatalogRevisionKernel
+from app.services.catalog.signed_urls import CatalogAssetUrlSigner
+
+
+NOT_PLACEABLE_MESSAGE = "Component is not placeable because it is not released or required files are missing"
+
+
+class CatalogPlacement:
+    """Resolve representation assets and shape them for remote placement."""
+
+    def __init__(
+        self,
+        revision_kernel: CatalogRevisionKernel,
+        read_models: CatalogComponentReadModels,
+        signer: type[CatalogAssetUrlSigner] = CatalogAssetUrlSigner,
+    ) -> None:
+        self._revision_kernel = revision_kernel
+        self._read_models = read_models
+        self._signer = signer
+
+    def placement_assets(
+        self,
+        conn: Any,
+        revision_id: str,
+        representation_id: str = "",
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Return ``(representation_row, assets)`` for the chosen or default pair."""
+        if representation_id:
+            row = conn.execute(
+                "SELECT * FROM revision_representations WHERE id = %s AND revision_id = %s",
+                (representation_id, revision_id),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT * FROM revision_representations WHERE revision_id = %s AND is_default = 1 LIMIT 1",
+                (revision_id,),
+            ).fetchone()
+        if not row:
+            raise ValueError("Representation was not found on this revision")
+        if not row["symbol_asset_id"] or not row["footprint_asset_id"]:
+            raise ValueError("Selected representation is incomplete")
+        all_assets = self._revision_kernel.load_assets_for_revision(conn, revision_id)
+        selected_ids = {str(row["symbol_asset_id"]), str(row["footprint_asset_id"])}
+        assets = [
+            asset
+            for asset in all_assets
+            if str(asset["asset_type"]) in AUXILIARY_ASSET_TYPES or str(asset["id"]) in selected_ids
+        ]
+        if len([asset for asset in assets if str(asset["id"]) in selected_ids]) != 2:
+            raise ValueError("Selected representation references unavailable assets")
+        return dict(row), assets
+
+    @staticmethod
+    def _require_placeable(component: dict[str, Any]) -> None:
+        if not component["place_enabled"]:
+            raise ValueError(NOT_PLACEABLE_MESSAGE)
+
+    def build_manifest(
+        self,
+        conn: Any,
+        component: dict[str, Any],
+        base_url: str,
+        representation_id: str = "",
+    ) -> dict[str, Any]:
+        self._require_placeable(component)
+        representation, assets = self.placement_assets(conn, component["revision_id"], representation_id)
+        manifest_assets = []
+        for raw_asset in assets:
+            asset = materialize_asset(raw_asset, assets, component)
+            manifest_assets.append(
+                {
+                    "asset_type": asset["asset_type"],
+                    "name": asset["name"],
+                    "target_library": asset["target_library"],
+                    "target_name": asset["target_name"],
+                    "content_type": asset["content_type"],
+                    "size_bytes": asset["size_bytes"],
+                    "sha256": asset["sha256"],
+                    "required": bool(raw_asset["required"]),
+                    "download_url": self._signer.build_signed_asset_url(
+                        asset["id"],
+                        component["revision_id"],
+                        base_url,
+                        representation_id=str(representation["id"]),
+                    ),
+                }
+            )
+        return {
+            "part_id": component["id"],
+            "display_name": component["name"],
+            "summary": component["summary"] or component["description"],
+            "license": "Managed in KiCAD Prism",
+            "representation_id": str(representation["id"]),
+            "library_name": next(str(a["target_library"]) for a in assets if a["asset_type"] == "symbol"),
+            "symbol_name": next(str(a["target_name"]) for a in assets if a["asset_type"] == "symbol"),
+            "assets": manifest_assets,
+        }
+
+    def build_inline_bundle(
+        self,
+        conn: Any,
+        component: dict[str, Any],
+        representation_id: str = "",
+    ) -> dict[str, Any]:
+        self._require_placeable(component)
+        representation, assets = self.placement_assets(conn, component["revision_id"], representation_id)
+        bundle_entries = []
+        for raw_asset in assets:
+            asset = materialize_asset(raw_asset, assets, component)
+            bundle_entries.append(
+                {
+                    "type": asset["asset_type"],
+                    "name": (
+                        asset["name"]
+                        if asset["asset_type"] == "3dmodel"
+                        else asset["target_name"] or asset["name"]
+                    ),
+                    "compression": "NONE",
+                    "content": base64.b64encode(asset["payload"]).decode("ascii"),
+                    "checksum": asset["sha256"],
+                }
+            )
+        return {
+            "part_id": component["id"],
+            "display_name": component["name"],
+            "representation_id": str(representation["id"]),
+            "library": next(str(a["target_library"]) for a in assets if a["asset_type"] == "symbol"),
+            "symbol_name": next(str(a["target_name"]) for a in assets if a["asset_type"] == "symbol"),
+            "compression": "NONE",
+            "data": base64.b64encode(
+                json.dumps(bundle_entries, separators=(",", ":")).encode("utf-8")
+            ).decode("ascii"),
+        }
+
+    def asset_by_id(
+        self,
+        conn: Any,
+        asset_id: str,
+        *,
+        revision_id: str = "",
+        representation_id: str = "",
+    ) -> dict[str, Any] | None:
+        """Materialize one asset in the context of a revision and representation.
+
+        Without an explicit revision the asset's most recently linked revision is
+        used so the symbol rewrite still sees its footprint and metadata.
+        """
+        row = conn.execute("SELECT * FROM assets WHERE id = %s", (asset_id,)).fetchone()
+        if not row:
+            return None
+        asset = dict(row)
+        effective_revision_id = revision_id
+        if not effective_revision_id:
+            link = conn.execute(
+                "SELECT revision_id FROM revision_assets WHERE asset_id = %s ORDER BY updated_at DESC LIMIT 1",
+                (asset_id,),
+            ).fetchone()
+            effective_revision_id = str(link["revision_id"]) if link else ""
+        if effective_revision_id and representation_id:
+            _, assets_for_revision = self.placement_assets(conn, effective_revision_id, representation_id)
+        elif effective_revision_id:
+            assets_for_revision = self._revision_kernel.load_assets_for_revision(conn, effective_revision_id)
+        else:
+            assets_for_revision = [asset]
+        component = None
+        if effective_revision_id:
+            revision = self._revision_kernel.revision_row(conn, effective_revision_id)
+            if revision:
+                component_row = self._revision_kernel.component_row(conn, str(revision["component_id"]))
+                if component_row:
+                    component = self._read_models.component_payload(conn, component_row, revision)
+        return materialize_asset(asset, assets_for_revision, component)
+
+
+__all__ = ["NOT_PLACEABLE_MESSAGE", "CatalogPlacement"]

--- a/backend/app/services/catalog/placement_payloads.py
+++ b/backend/app/services/catalog/placement_payloads.py
@@ -1,0 +1,233 @@
+"""Rewrite stored KiCad files into the payloads desktop KiCad places.
+
+Symbols gain the component's metadata properties and a footprint reference
+that points at the remote library nickname; footprints have their 3D model
+paths redirected to the remote provider destination. These rewrites are pure
+and byte-stable for identical inputs, which is what keeps manifest hashes and
+inline bundles reproducible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Any
+
+from app.core.config import settings
+from app.services.catalog.asset_files import content_type_for_asset
+from app.services.catalog.metadata_schema import SYMBOL_METADATA_LABEL_TO_KEY
+from app.services.catalog.normalization import sanitize_name, sha256_bytes
+
+
+SYMBOL_METADATA_FIELD_ORDER: tuple[str, ...] = (
+    "Value",
+    "Description",
+    "Datasheet",
+    "Manufacturer",
+    "Manufacturer Part Number",
+    "Vendor",
+    "Vendor Part Number",
+    "Mass (g)",
+    "RQjC (C/W)",
+    "RQjC_top (C/W)",
+    "Temp_max (C)",
+    "Temp_min (C)",
+    "Power Dissipation (W)",
+    "Rate",
+    "SAP Code",
+)
+
+_TOP_LEVEL_PROPERTY_RE = re.compile(r'^([ \t]+)\(property "([^"]+)" ')
+_MODEL_RE = re.compile(r'\(model\s+"[^"]+"')
+
+
+def remote_library_nickname(library_name: str) -> str:
+    prefix = sanitize_name(settings.REMOTE_PROVIDER_LIBRARY_PREFIX, "remote").lower()
+    library = sanitize_name(library_name, "library").lower()
+    return f"{prefix}_{library}"
+
+
+def escape_symbol_property_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def symbol_property_block(name: str, value: str, *, indent: str = "    ", hidden: bool = True) -> str:
+    hide = " hide" if hidden else ""
+    child_indent = f"{indent}  "
+    return (
+        f'{indent}(property "{name}" "{escape_symbol_property_value(value)}" (at 0 0 0)\n'
+        f"{child_indent}(effects (font (size 1.27 1.27)){hide})\n"
+        f"{indent})\n"
+    )
+
+
+def symbol_metadata_fields(component: dict[str, Any] | None) -> dict[str, str]:
+    if not component:
+        return {label: "" for label in SYMBOL_METADATA_FIELD_ORDER}
+    fields = {label: str(component.get(key) or "") for label, key in SYMBOL_METADATA_LABEL_TO_KEY.items()}
+    for key, value in sorted(dict(component.get("extra_fields") or {}).items()):
+        normalized_key = str(key).strip()
+        if normalized_key and normalized_key not in fields and normalized_key not in {"Reference", "Footprint"}:
+            fields[normalized_key] = str(value or "")
+    return fields
+
+
+def extract_top_level_symbol_properties(header: str) -> tuple[str, list[tuple[str, str]], str, str]:
+    """Split a symbol header into prefix, property blocks, trailing text, indent."""
+    lines = header.splitlines(keepends=True)
+    prefix_parts: list[str] = []
+    property_blocks: list[tuple[str, str]] = []
+    trailing = ""
+    first_indent = ""
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        match = _TOP_LEVEL_PROPERTY_RE.match(line)
+        if not match:
+            if property_blocks:
+                trailing = "".join(lines[index:])
+                break
+            prefix_parts.append(line)
+            index += 1
+            continue
+
+        indent = match.group(1)
+        if not first_indent:
+            first_indent = indent
+        name = match.group(2)
+        depth = line.count("(") - line.count(")")
+        block_lines = [line]
+        index += 1
+
+        while depth > 0 and index < len(lines):
+            block_line = lines[index]
+            block_lines.append(block_line)
+            depth += block_line.count("(") - block_line.count(")")
+            index += 1
+
+        property_blocks.append((name, "".join(block_lines)))
+
+    return "".join(prefix_parts), property_blocks, trailing, first_indent or "    "
+
+
+def rewrite_symbol_payload(
+    payload: bytes,
+    footprint_ref: str | None,
+    component: dict[str, Any] | None = None,
+) -> bytes:
+    text = payload.decode("utf-8")
+    first_symbol_index = text.find('(symbol "')
+    marker_index = text.find('(symbol "', first_symbol_index + 1) if first_symbol_index != -1 else -1
+    if marker_index <= 0:
+        header = text
+        suffix = ""
+    else:
+        header = text[:marker_index]
+        suffix = text[marker_index:]
+
+    prefix, extracted_blocks, trailing, indent = extract_top_level_symbol_properties(header)
+    if not extracted_blocks:
+        return payload
+
+    existing_blocks = {name: block for name, block in extracted_blocks}
+    ordered_names = [name for name, _ in extracted_blocks]
+    metadata_fields = symbol_metadata_fields(component)
+    custom_blocks = {
+        label: symbol_property_block(label, value, indent=indent, hidden=label != "Value")
+        for label, value in metadata_fields.items()
+    }
+    if footprint_ref:
+        custom_blocks["Footprint"] = symbol_property_block("Footprint", footprint_ref, indent=indent)
+    elif "Footprint" in existing_blocks:
+        custom_blocks["Footprint"] = existing_blocks["Footprint"]
+
+    for property_name in SYMBOL_METADATA_FIELD_ORDER:
+        if property_name not in ordered_names:
+            ordered_names.append(property_name)
+    for property_name in sorted(set(metadata_fields) - set(SYMBOL_METADATA_FIELD_ORDER)):
+        if property_name not in ordered_names:
+            ordered_names.append(property_name)
+    if "Footprint" not in ordered_names:
+        ordered_names.append("Footprint")
+
+    rebuilt_blocks = [
+        custom_blocks.get(property_name, existing_blocks.get(property_name, ""))
+        for property_name in ordered_names
+    ]
+    return (prefix + "".join(rebuilt_blocks) + trailing + suffix).encode("utf-8")
+
+
+def rewrite_footprint_payload(
+    payload: bytes,
+    asset: dict[str, Any],
+    model_assets: list[dict[str, Any]] | None = None,
+) -> bytes:
+    text = payload.decode("utf-8")
+    models = list(model_assets or [])
+    if not models or "(model " not in text:
+        return payload
+    prefix = sanitize_name(settings.REMOTE_PROVIDER_LIBRARY_PREFIX, "remote").lower()
+    destination = settings.REMOTE_PROVIDER_DESTINATION_DIR.rstrip("/")
+    if destination in {"/RemoteLibrary", "$/RemoteLibrary"}:
+        destination = "${KIPRJMOD}/RemoteLibrary"
+    model_index = 0
+
+    def replace_model(match: re.Match[str]) -> str:
+        nonlocal model_index
+        if model_index >= len(models):
+            return match.group(0)
+        model = models[model_index]
+        model_index += 1
+        model_name = Path(str(model.get("canonical_path") or model.get("name") or "model.step")).name
+        model_path = f"{destination}/{prefix}_3d/{model_name}"
+        return f'(model "{model_path}"'
+
+    return _MODEL_RE.sub(replace_model, text).encode("utf-8")
+
+
+def materialize_asset(
+    asset: dict[str, Any],
+    assets_for_revision: list[dict[str, Any]],
+    component: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Read one stored asset and return it with its placement payload attached."""
+    path = Path(str(asset["canonical_path"]))
+    payload = path.read_bytes()
+    if asset["asset_type"] == "symbol":
+        footprint_asset = next(
+            (candidate for candidate in assets_for_revision if candidate["asset_type"] == "footprint"), None
+        )
+        footprint_ref = None
+        if footprint_asset:
+            footprint_ref = (
+                f"{remote_library_nickname(str(footprint_asset['target_library']))}:{footprint_asset['target_name']}"
+            )
+        payload = rewrite_symbol_payload(payload, footprint_ref, component)
+    elif asset["asset_type"] == "footprint":
+        payload = rewrite_footprint_payload(
+            payload,
+            asset,
+            [candidate for candidate in assets_for_revision if candidate["asset_type"] == "3dmodel"],
+        )
+    return {
+        **asset,
+        "payload": payload,
+        "content_type": content_type_for_asset(str(asset["asset_type"]), path),
+        "size_bytes": len(payload),
+        "sha256": sha256_bytes(payload),
+        "name": path.name,
+    }
+
+
+__all__ = [
+    "SYMBOL_METADATA_FIELD_ORDER",
+    "escape_symbol_property_value",
+    "extract_top_level_symbol_properties",
+    "materialize_asset",
+    "remote_library_nickname",
+    "rewrite_footprint_payload",
+    "rewrite_symbol_payload",
+    "symbol_metadata_fields",
+    "symbol_property_block",
+]

--- a/backend/app/services/catalog/provider_tokens.py
+++ b/backend/app/services/catalog/provider_tokens.py
@@ -1,0 +1,57 @@
+"""OAuth authorization codes and revoked tokens for the remote provider.
+
+Both tables live in the catalog database. Expired rows are swept on the
+access paths that already touch them; nothing here commits.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.services.catalog.normalization import json_loads
+
+
+class CatalogProviderTokens:
+    """Single-use authorization codes and the token revocation list."""
+
+    @staticmethod
+    def store_auth_code(conn: Any, code: str, grant: dict[str, Any], exp: int) -> None:
+        conn.execute(
+            """
+            INSERT INTO oauth_auth_codes (code, grant_json, exp)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (code) DO UPDATE SET grant_json = excluded.grant_json, exp = excluded.exp
+            """,
+            (code, json.dumps(grant, separators=(",", ":")), exp),
+        )
+
+    @staticmethod
+    def consume_auth_code(conn: Any, code: str, *, now: int) -> dict[str, Any] | None:
+        """Delete the code on read so it can only ever be exchanged once."""
+        row = conn.execute("SELECT grant_json, exp FROM oauth_auth_codes WHERE code = %s", (code,)).fetchone()
+        conn.execute("DELETE FROM oauth_auth_codes WHERE code = %s", (code,))
+        conn.execute("DELETE FROM oauth_auth_codes WHERE exp <= %s", (now,))
+        if not row or int(row["exp"]) <= now:
+            return None
+        return dict(json_loads(row["grant_json"], {}))
+
+    @staticmethod
+    def add_revoked_token(conn: Any, jti: str, exp: int) -> None:
+        conn.execute(
+            """
+            INSERT INTO oauth_revoked_tokens (jti, exp)
+            VALUES (%s, %s)
+            ON CONFLICT (jti) DO UPDATE SET exp = excluded.exp
+            """,
+            (jti, exp),
+        )
+
+    @staticmethod
+    def is_token_revoked(conn: Any, jti: str, *, now: int) -> bool:
+        conn.execute("DELETE FROM oauth_revoked_tokens WHERE exp <= %s", (now,))
+        row = conn.execute("SELECT 1 FROM oauth_revoked_tokens WHERE jti = %s", (jti,)).fetchone()
+        return bool(row)
+
+
+__all__ = ["CatalogProviderTokens"]

--- a/backend/app/services/catalog/signed_urls.py
+++ b/backend/app/services/catalog/signed_urls.py
@@ -1,0 +1,64 @@
+"""HMAC-signed, time-limited download URLs for remote-provider assets."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+
+from app.core.config import settings
+
+
+DEFAULT_SIGNED_URL_TTL_SECONDS = 300
+
+
+class CatalogAssetUrlSigner:
+    """Sign and verify ``asset:revision:representation:expiry`` messages.
+
+    Signatures are bound to the exact revision and representation so a URL
+    minted for one placement cannot fetch another revision's file.
+    """
+
+    @staticmethod
+    def sign(message: str) -> str:
+        if not settings.SESSION_SECRET:
+            raise RuntimeError("SESSION_SECRET is required to sign catalog asset URLs")
+        secret = settings.SESSION_SECRET.encode("utf-8")
+        digest = hmac.new(secret, message.encode("utf-8"), hashlib.sha256).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    @classmethod
+    def build_signed_asset_url(
+        cls,
+        asset_id: str,
+        revision_id: str,
+        base_url: str,
+        ttl_seconds: int = DEFAULT_SIGNED_URL_TTL_SECONDS,
+        *,
+        representation_id: str = "",
+    ) -> str:
+        expires_at = int(time.time()) + ttl_seconds
+        signature = cls.sign(f"{asset_id}:{revision_id}:{representation_id}:{expires_at}")
+        return (
+            f"{base_url.rstrip('/')}/api/remote-provider/assets/{asset_id}?rev={revision_id}"
+            f"&representation={representation_id}&exp={expires_at}&sig={signature}"
+        )
+
+    @classmethod
+    def validate_asset_signature(
+        cls,
+        asset_id: str,
+        revision_id: str,
+        expires_at: int,
+        signature: str,
+        representation_id: str = "",
+    ) -> bool:
+        if expires_at <= int(time.time()):
+            return False
+        return hmac.compare_digest(
+            cls.sign(f"{asset_id}:{revision_id}:{representation_id}:{expires_at}"), signature
+        )
+
+
+__all__ = ["DEFAULT_SIGNED_URL_TTL_SECONDS", "CatalogAssetUrlSigner"]

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-import base64
-import hashlib
-import hmac
 import json
 import logging
-import re
-import shutil
 import time
 import uuid
 from contextlib import contextmanager
@@ -14,7 +9,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
-from app.core.config import settings
 from app.services.catalog.component_history import CatalogComponentHistoryReads
 from app.services.catalog.component_read_models import (
     CatalogComponentReadModels,
@@ -25,6 +19,16 @@ from app.services.catalog.component_read_models import (
     supply_source_payload as _supply_source_payload,
 )
 from app.services.catalog.component_queries import CatalogComponentQueries
+from app.services.catalog.dbl_export import (
+    DBL_COMMON_COLUMNS,
+    CatalogDblExport,
+    dbl_row_for_component,
+    dbl_symbol_library_name as _dbl_symbol_library_name,
+    part_number_nocolon as _part_number_nocolon,
+    quote_identifier as _quote_identifier,
+    sexpr_string as _sexpr_string,
+    write_dbl_config,
+)
 from app.services.catalog.health import CatalogHealth
 from app.services.catalog.klc_validation import (
     VALIDATION_SEVERITY_ERROR,
@@ -95,7 +99,19 @@ from app.services.catalog.normalization import (
 from app.services.catalog.project_import_sessions import CatalogProjectImportSessions
 from app.services.catalog.project_import_matching import CatalogProjectImportMatching
 from app.services.catalog.project_import_assets import CatalogProjectImportAssets
+from app.services.catalog.provider_tokens import CatalogProviderTokens
 from app.services.catalog.project_import_acceptance import CatalogProjectImportAcceptance
+from app.services.catalog.placement import CatalogPlacement
+from app.services.catalog.placement_payloads import (
+    SYMBOL_METADATA_FIELD_ORDER,
+    extract_top_level_symbol_properties as _extract_top_level_symbol_properties,
+    materialize_asset,
+    remote_library_nickname as _remote_library_nickname,
+    rewrite_footprint_payload as _rewrite_footprint_payload,
+    rewrite_symbol_payload as _rewrite_symbol_payload,
+    symbol_metadata_fields as _symbol_metadata_fields,
+    symbol_property_block as _symbol_property_block,
+)
 from app.services.catalog.preview_pipeline import (
     CatalogPreview,
     CatalogPreviewPipeline,
@@ -121,6 +137,7 @@ from app.services.catalog.revision_kernel import (
     WORKFLOW_STAGES,
     normalize_workflow_stage,
 )
+from app.services.catalog.signed_urls import CatalogAssetUrlSigner
 from app.services.catalog.runtime import (
     CatalogRuntime, DBL_EXPORT_DIRNAME, DEFAULT_STORE_DIRNAME, KLC_VALIDATION_DIRNAME,
     _ASSET_BROWSE_CACHE_TTL_SECONDS,
@@ -143,185 +160,16 @@ VALIDATION_STATUS_SKIPPED = "skipped"
 VALIDATION_STATUS_NOT_RUN = "not_run"
 KLC_RELEASE_GATE_VALUES = {"off", "warn", "block"}
 
-SYMBOL_METADATA_FIELD_ORDER: tuple[str, ...] = (
-    "Value",
-    "Description",
-    "Datasheet",
-    "Manufacturer",
-    "Manufacturer Part Number",
-    "Vendor",
-    "Vendor Part Number",
-    "Mass (g)",
-    "RQjC (C/W)",
-    "RQjC_top (C/W)",
-    "Temp_max (C)",
-    "Temp_min (C)",
-    "Power Dissipation (W)",
-    "Rate",
-    "SAP Code",
-)
-
-DBL_COMMON_COLUMNS: tuple[str, ...] = (
-    "Part Number",
-    "Part Number Nocolon",
-    "Comment",
-    "Value",
-    "Manufacturer",
-    "Manufacturer Part Number",
-    "PackageDescription",
-    "Status",
-    "Part Description",
-    "Datasheet",
-    "LibSymbol",
-    "LibFootprint",
-)
-
-_TOP_LEVEL_PROPERTY_RE = re.compile(r'^([ \t]+)\(property "([^"]+)" ')
-
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _remote_library_nickname(library_name: str) -> str:
-    prefix = _sanitize_name(settings.REMOTE_PROVIDER_LIBRARY_PREFIX, "remote").lower()
-    library = _sanitize_name(library_name, "library").lower()
-    return f"{prefix}_{library}"
 
 
-def _escape_symbol_property_value(value: str) -> str:
-    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
-def _symbol_property_block(name: str, value: str, *, indent: str = "    ", hidden: bool = True) -> str:
-    hide = " hide" if hidden else ""
-    child_indent = f"{indent}  "
-    return (
-        f'{indent}(property "{name}" "{_escape_symbol_property_value(value)}" (at 0 0 0)\n'
-        f'{child_indent}(effects (font (size 1.27 1.27)){hide})\n'
-        f"{indent})\n"
-    )
 
-
-def _symbol_metadata_fields(component: dict[str, Any] | None) -> dict[str, str]:
-    if not component:
-        return {label: "" for label in SYMBOL_METADATA_FIELD_ORDER}
-    fields = {label: str(component.get(key) or "") for label, key in SYMBOL_METADATA_LABEL_TO_KEY.items()}
-    for key, value in sorted(dict(component.get("extra_fields") or {}).items()):
-        normalized_key = str(key).strip()
-        if normalized_key and normalized_key not in fields and normalized_key not in {"Reference", "Footprint"}:
-            fields[normalized_key] = str(value or "")
-    return fields
-
-
-def _extract_top_level_symbol_properties(header: str) -> tuple[str, list[tuple[str, str]], str, str]:
-    lines = header.splitlines(keepends=True)
-    prefix_parts: list[str] = []
-    property_blocks: list[tuple[str, str]] = []
-    trailing = ""
-    first_indent = ""
-    index = 0
-
-    while index < len(lines):
-        line = lines[index]
-        match = _TOP_LEVEL_PROPERTY_RE.match(line)
-        if not match:
-            if property_blocks:
-                trailing = "".join(lines[index:])
-                break
-            prefix_parts.append(line)
-            index += 1
-            continue
-
-        indent = match.group(1)
-        if not first_indent:
-            first_indent = indent
-        name = match.group(2)
-        depth = line.count("(") - line.count(")")
-        block_lines = [line]
-        index += 1
-
-        while depth > 0 and index < len(lines):
-            block_line = lines[index]
-            block_lines.append(block_line)
-            depth += block_line.count("(") - block_line.count(")")
-            index += 1
-
-        property_blocks.append((name, "".join(block_lines)))
-
-    return "".join(prefix_parts), property_blocks, trailing, first_indent or "    "
-
-
-def _rewrite_symbol_payload(payload: bytes, footprint_ref: str | None, component: dict[str, Any] | None = None) -> bytes:
-    text = payload.decode("utf-8")
-    first_symbol_index = text.find('(symbol "')
-    marker_index = text.find('(symbol "', first_symbol_index + 1) if first_symbol_index != -1 else -1
-    if marker_index <= 0:
-        header = text
-        suffix = ""
-    else:
-        header = text[:marker_index]
-        suffix = text[marker_index:]
-
-    prefix, extracted_blocks, trailing, indent = _extract_top_level_symbol_properties(header)
-    if not extracted_blocks:
-        return payload
-
-    existing_blocks = {name: block for name, block in extracted_blocks}
-    ordered_names = [name for name, _ in extracted_blocks]
-    metadata_fields = _symbol_metadata_fields(component)
-    custom_blocks = {
-        label: _symbol_property_block(label, value, indent=indent, hidden=label != "Value")
-        for label, value in metadata_fields.items()
-    }
-    if footprint_ref:
-        custom_blocks["Footprint"] = _symbol_property_block("Footprint", footprint_ref, indent=indent)
-    elif "Footprint" in existing_blocks:
-        custom_blocks["Footprint"] = existing_blocks["Footprint"]
-
-    for property_name in SYMBOL_METADATA_FIELD_ORDER:
-        if property_name not in ordered_names:
-            ordered_names.append(property_name)
-    for property_name in sorted(set(metadata_fields) - set(SYMBOL_METADATA_FIELD_ORDER)):
-        if property_name not in ordered_names:
-            ordered_names.append(property_name)
-    if "Footprint" not in ordered_names:
-        ordered_names.append("Footprint")
-
-    rebuilt_blocks = [
-        custom_blocks.get(property_name, existing_blocks.get(property_name, ""))
-        for property_name in ordered_names
-    ]
-    return (prefix + "".join(rebuilt_blocks) + trailing + suffix).encode("utf-8")
-
-
-def _rewrite_footprint_payload(
-    payload: bytes,
-    asset: dict[str, Any],
-    model_assets: list[dict[str, Any]] | None = None,
-) -> bytes:
-    text = payload.decode("utf-8")
-    models = list(model_assets or [])
-    if not models or "(model " not in text:
-        return payload
-    prefix = _sanitize_name(settings.REMOTE_PROVIDER_LIBRARY_PREFIX, "remote").lower()
-    destination = settings.REMOTE_PROVIDER_DESTINATION_DIR.rstrip("/")
-    if destination in {"/RemoteLibrary", "$/RemoteLibrary"}:
-        destination = "${KIPRJMOD}/RemoteLibrary"
-    model_index = 0
-
-    def replace_model(match: re.Match[str]) -> str:
-        nonlocal model_index
-        if model_index >= len(models):
-            return match.group(0)
-        model = models[model_index]
-        model_index += 1
-        model_name = Path(str(model.get("canonical_path") or model.get("name") or "model.step")).name
-        model_path = f"{destination}/{prefix}_3d/{model_name}"
-        return f'(model "{model_path}"'
-
-    text = re.sub(r'\(model\s+"[^"]+"', replace_model, text)
-    return text.encode("utf-8")
 
 
 def _release_allows_remote(release_status: str) -> bool:
@@ -332,25 +180,8 @@ def _normalize_workflow_stage(stage: str) -> str:
     return normalize_workflow_stage(stage)
 
 
-def _quote_identifier(identifier: str) -> str:
-    return '"' + identifier.replace('"', '""') + '"'
 
 
-def _sexpr_string(value: str) -> str:
-    return value.replace("\\", "\\\\").replace('"', '\\"')
-
-
-def _part_number_nocolon(value: str) -> str:
-    cleaned = re.sub(r":+", "_", value.strip())
-    cleaned = re.sub(r"\s+", "_", cleaned)
-    return cleaned or "PART"
-
-
-def _dbl_symbol_library_name(part_number: str, symbol_asset: dict[str, Any] | None) -> str:
-    if not symbol_asset:
-        return ""
-    raw = f"Prism_{part_number}_{symbol_asset['target_library']}_{symbol_asset['target_name']}"
-    return _sanitize_name(raw, "Prism_Symbol")
 
 
 class ComponentCatalogDomainService:
@@ -385,6 +216,9 @@ class ComponentCatalogDomainService:
         _catalog_locks, _revision_kernel, _component_read_models, _revision_finalizer, _klc_validation
     )
     _catalog_health: CatalogHealth = CatalogHealth(_component_queries, _klc_validation)
+    _placement: CatalogPlacement = CatalogPlacement(_revision_kernel, _component_read_models)
+    _dbl_export: CatalogDblExport = CatalogDblExport(_placement)
+    _provider_tokens: CatalogProviderTokens = CatalogProviderTokens()
     _project_import_sessions: CatalogProjectImportSessions = CatalogProjectImportSessions()
     _project_import_matching: CatalogProjectImportMatching = CatalogProjectImportMatching()
     _project_import_assets: CatalogProjectImportAssets = CatalogProjectImportAssets(_revision_kernel)
@@ -463,6 +297,9 @@ class ComponentCatalogDomainService:
             self._klc_validation,
         )
         self._catalog_health = CatalogHealth(self._component_queries, self._klc_validation)
+        self._placement = CatalogPlacement(self._revision_kernel, self._component_read_models)
+        self._dbl_export = CatalogDblExport(self._placement)
+        self._provider_tokens = CatalogProviderTokens()
 
     def _runtime_for_compat(self) -> CatalogRuntime:
         """Lazily support legacy ``__new__``-constructed test doubles."""
@@ -2984,58 +2821,18 @@ class ComponentCatalogDomainService:
         # so existing callers retain their UX while compliance history remains intact.
         return self.deactivate_component(component_id, actor=actor, reason=reason)
 
-    def _materialize_asset(self, asset: dict[str, Any], assets_for_revision: list[dict[str, Any]], component: dict[str, Any] | None = None) -> dict[str, Any]:
-        path = Path(str(asset["canonical_path"]))
-        payload = path.read_bytes()
-        if asset["asset_type"] == "symbol":
-            footprint_asset = next((candidate for candidate in assets_for_revision if candidate["asset_type"] == "footprint"), None)
-            footprint_ref = None
-            if footprint_asset:
-                footprint_ref = f"{_remote_library_nickname(str(footprint_asset['target_library']))}:{footprint_asset['target_name']}"
-            payload = _rewrite_symbol_payload(payload, footprint_ref, component)
-        elif asset["asset_type"] == "footprint":
-            payload = _rewrite_footprint_payload(
-                payload,
-                asset,
-                [candidate for candidate in assets_for_revision if candidate["asset_type"] == "3dmodel"],
-            )
-        content_type = _content_type_for_asset(str(asset["asset_type"]), path)
-        return {
-            **asset,
-            "payload": payload,
-            "content_type": content_type,
-            "size_bytes": len(payload),
-            "sha256": _sha256_bytes(payload),
-            "name": path.name,
-        }
+    def _materialize_asset(
+        self,
+        asset: dict[str, Any],
+        assets_for_revision: list[dict[str, Any]],
+        component: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return materialize_asset(asset, assets_for_revision, component)
 
     def _placement_assets(
         self, conn: Any, revision_id: str, representation_id: str = ""
     ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-        if representation_id:
-            row = conn.execute(
-                "SELECT * FROM revision_representations WHERE id = %s AND revision_id = %s",
-                (representation_id, revision_id),
-            ).fetchone()
-        else:
-            row = conn.execute(
-                "SELECT * FROM revision_representations WHERE revision_id = %s AND is_default = 1 LIMIT 1",
-                (revision_id,),
-            ).fetchone()
-        if not row:
-            raise ValueError("Representation was not found on this revision")
-        if not row["symbol_asset_id"] or not row["footprint_asset_id"]:
-            raise ValueError("Selected representation is incomplete")
-        all_assets = self._load_assets_for_revision(conn, revision_id)
-        selected_ids = {str(row["symbol_asset_id"]), str(row["footprint_asset_id"])}
-        assets = [
-            asset
-            for asset in all_assets
-            if str(asset["asset_type"]) in {"3dmodel", "spice"} or str(asset["id"]) in selected_ids
-        ]
-        if len([asset for asset in assets if str(asset["id"]) in selected_ids]) != 2:
-            raise ValueError("Selected representation references unavailable assets")
-        return dict(row), assets
+        return self._placement.placement_assets(conn, revision_id, representation_id)
 
     def build_manifest(
         self, component_id: str, base_url: str, representation_id: str = ""
@@ -3044,41 +2841,8 @@ class ComponentCatalogDomainService:
         component = self.get_component(component_id, include_inactive=False, released_only=True)
         if not component:
             return None
-        if not component["place_enabled"]:
-            raise ValueError("Component is not placeable because it is not released or required files are missing")
         with self._connect() as conn:
-            representation, assets = self._placement_assets(
-                conn, component["revision_id"], representation_id
-            )
-        manifest_assets = []
-        for raw_asset in assets:
-            asset = self._materialize_asset(raw_asset, assets, component)
-            manifest_assets.append(
-                {
-                    "asset_type": asset["asset_type"],
-                    "name": asset["name"],
-                    "target_library": asset["target_library"],
-                    "target_name": asset["target_name"],
-                    "content_type": asset["content_type"],
-                    "size_bytes": asset["size_bytes"],
-                    "sha256": asset["sha256"],
-                    "required": bool(raw_asset["required"]),
-                    "download_url": self.build_signed_asset_url(
-                        asset["id"], component["revision_id"], base_url,
-                        representation_id=str(representation["id"]),
-                    ),
-                }
-            )
-        return {
-            "part_id": component["id"],
-            "display_name": component["name"],
-            "summary": component["summary"] or component["description"],
-            "license": "Managed in KiCAD Prism",
-            "representation_id": str(representation["id"]),
-            "library_name": next(str(a["target_library"]) for a in assets if a["asset_type"] == "symbol"),
-            "symbol_name": next(str(a["target_name"]) for a in assets if a["asset_type"] == "symbol"),
-            "assets": manifest_assets,
-        }
+            return self._placement.build_manifest(conn, component, base_url, representation_id)
 
     def build_inline_bundle(
         self, component_id: str, representation_id: str = ""
@@ -3087,61 +2851,17 @@ class ComponentCatalogDomainService:
         component = self.get_component(component_id, include_inactive=False, released_only=True)
         if not component:
             return None
-        if not component["place_enabled"]:
-            raise ValueError("Component is not placeable because it is not released or required files are missing")
         with self._connect() as conn:
-            representation, assets = self._placement_assets(
-                conn, component["revision_id"], representation_id
-            )
-        bundle_entries = []
-        for raw_asset in assets:
-            asset = self._materialize_asset(raw_asset, assets, component)
-            bundle_entries.append(
-                {
-                    "type": asset["asset_type"],
-                    "name": asset["name"] if asset["asset_type"] == "3dmodel" else asset["target_name"] or asset["name"],
-                    "compression": "NONE",
-                    "content": base64.b64encode(asset["payload"]).decode("ascii"),
-                    "checksum": asset["sha256"],
-                }
-            )
-        return {
-            "part_id": component["id"],
-            "display_name": component["name"],
-            "representation_id": str(representation["id"]),
-            "library": next(str(a["target_library"]) for a in assets if a["asset_type"] == "symbol"),
-            "symbol_name": next(str(a["target_name"]) for a in assets if a["asset_type"] == "symbol"),
-            "compression": "NONE",
-            "data": base64.b64encode(json.dumps(bundle_entries, separators=(",", ":")).encode("utf-8")).decode("ascii"),
-        }
+            return self._placement.build_inline_bundle(conn, component, representation_id)
 
     def get_asset_by_id(
         self, asset_id: str, *, revision_id: str = "", representation_id: str = ""
     ) -> dict[str, Any] | None:
         self.initialize()
         with self._connect() as conn:
-            row = conn.execute("SELECT * FROM assets WHERE id = %s", (asset_id,)).fetchone()
-            if not row:
-                return None
-            asset = dict(row)
-            effective_revision_id = revision_id
-            if not effective_revision_id:
-                link = conn.execute("SELECT revision_id FROM revision_assets WHERE asset_id = %s ORDER BY updated_at DESC LIMIT 1", (asset_id,)).fetchone()
-                effective_revision_id = str(link["revision_id"]) if link else ""
-            if effective_revision_id and representation_id:
-                _, assets_for_revision = self._placement_assets(
-                    conn, effective_revision_id, representation_id
-                )
-            else:
-                assets_for_revision = self._load_assets_for_revision(conn, effective_revision_id) if effective_revision_id else [asset]
-            component = None
-            if effective_revision_id:
-                revision = self._revision_row(conn, effective_revision_id)
-                if revision:
-                    component_row = self._component_row(conn, str(revision["component_id"]))
-                    if component_row:
-                        component = self._component_payload(conn, component_row, revision)
-        return self._materialize_asset(asset, assets_for_revision, component)
+            return self._placement.asset_by_id(
+                conn, asset_id, revision_id=revision_id, representation_id=representation_id
+            )
 
     def get_preview(self, preview_id: str) -> CatalogPreview | None:
         self.initialize()
@@ -3149,78 +2869,49 @@ class ComponentCatalogDomainService:
             return self._preview_pipeline.preview_record(conn, preview_id)
 
     def _sign(self, message: str) -> str:
-        if not settings.SESSION_SECRET:
-            raise RuntimeError("SESSION_SECRET is required to sign catalog asset URLs")
-        secret = settings.SESSION_SECRET.encode("utf-8")
-        return base64.urlsafe_b64encode(hmac.new(secret, message.encode("utf-8"), hashlib.sha256).digest()).rstrip(b"=").decode("ascii")
+        return CatalogAssetUrlSigner.sign(message)
 
     def build_signed_asset_url(
         self, asset_id: str, revision_id: str, base_url: str, ttl_seconds: int = 300,
         *, representation_id: str = "",
     ) -> str:
-        expires_at = int(time.time()) + ttl_seconds
-        signature = self._sign(f"{asset_id}:{revision_id}:{representation_id}:{expires_at}")
-        return (
-            f"{base_url.rstrip('/')}/api/remote-provider/assets/{asset_id}?rev={revision_id}"
-            f"&representation={representation_id}&exp={expires_at}&sig={signature}"
+        return CatalogAssetUrlSigner.build_signed_asset_url(
+            asset_id, revision_id, base_url, ttl_seconds, representation_id=representation_id
         )
 
     def validate_asset_signature(
         self, asset_id: str, revision_id: str, expires_at: int, signature: str,
         representation_id: str = "",
     ) -> bool:
-        if expires_at <= int(time.time()):
-            return False
-        return hmac.compare_digest(
-            self._sign(f"{asset_id}:{revision_id}:{representation_id}:{expires_at}"), signature
+        return CatalogAssetUrlSigner.validate_asset_signature(
+            asset_id, revision_id, expires_at, signature, representation_id
         )
 
     def store_auth_code(self, code: str, grant: dict[str, Any], exp: int) -> None:
         self.initialize()
         with self._connect() as conn:
-            conn.execute(
-                """
-                INSERT INTO oauth_auth_codes (code, grant_json, exp)
-                VALUES (%s, %s, %s)
-                ON CONFLICT (code) DO UPDATE SET grant_json = excluded.grant_json, exp = excluded.exp
-                """,
-                (code, json.dumps(grant, separators=(",", ":")), exp),
-            )
+            self._provider_tokens.store_auth_code(conn, code, grant, exp)
             conn.commit()
 
     def consume_auth_code(self, code: str) -> dict[str, Any] | None:
         self.initialize()
-        now = int(time.time())
         with self._connect() as conn:
-            row = conn.execute("SELECT grant_json, exp FROM oauth_auth_codes WHERE code = %s", (code,)).fetchone()
-            conn.execute("DELETE FROM oauth_auth_codes WHERE code = %s", (code,))
-            conn.execute("DELETE FROM oauth_auth_codes WHERE exp <= %s", (now,))
+            grant = self._provider_tokens.consume_auth_code(conn, code, now=int(time.time()))
             conn.commit()
-        if not row or int(row["exp"]) <= now:
-            return None
-        return dict(_json_loads(row["grant_json"], {}))
+        return grant
 
     def add_revoked_token(self, jti: str, exp: int) -> None:
         self.initialize()
         with self._connect() as conn:
-            conn.execute(
-                """
-                INSERT INTO oauth_revoked_tokens (jti, exp)
-                VALUES (%s, %s)
-                ON CONFLICT (jti) DO UPDATE SET exp = excluded.exp
-                """,
-                (jti, exp),
-            )
+            self._provider_tokens.add_revoked_token(conn, jti, exp)
             conn.commit()
 
     def is_token_revoked(self, jti: str) -> bool:
         self.initialize()
-        now = int(time.time())
         with self._connect() as conn:
-            conn.execute("DELETE FROM oauth_revoked_tokens WHERE exp <= %s", (now,))
-            row = conn.execute("SELECT 1 FROM oauth_revoked_tokens WHERE jti = %s", (jti,)).fetchone()
+            revoked = self._provider_tokens.is_token_revoked(conn, jti, now=int(time.time()))
             conn.commit()
-        return bool(row)
+        return revoked
 
     def _released_place_ready_components(self) -> list[dict[str, Any]]:
         return [
@@ -3235,35 +2926,7 @@ class ComponentCatalogDomainService:
         part_number: str,
         custom_fields: list[dict[str, Any]],
     ) -> dict[str, str]:
-        default_representation = next(
-            (item for item in component.get("representations", []) if item.get("is_default")),
-            None,
-        )
-        symbol_asset = default_representation.get("symbol") if default_representation else None
-        footprint_asset = default_representation.get("footprint") if default_representation else None
-        lib_symbol = ""
-        lib_footprint = ""
-        if symbol_asset:
-            lib_symbol = f"{_dbl_symbol_library_name(part_number, symbol_asset)}:{symbol_asset['target_name']}"
-        if footprint_asset:
-            lib_footprint = f"{footprint_asset['target_library']}:{footprint_asset['target_name']}"
-        row = {
-            "Part Number": part_number,
-            "Part Number Nocolon": part_number,
-            "Comment": component["value"] or component["name"],
-            "Value": component["value"],
-            "Manufacturer": component["manufacturer"],
-            "Manufacturer Part Number": component["mpn"],
-            "PackageDescription": component["package_name"],
-            "Status": component["workflow_stage"],
-            "Part Description": component["description"],
-            "Datasheet": component["datasheet_url"],
-            "LibSymbol": lib_symbol,
-            "LibFootprint": lib_footprint,
-        }
-        extras = dict(component.get("extra_fields") or {})
-        row.update({field["key"]: str(extras.get(field["storage_key"], "")) for field in custom_fields})
-        return row
+        return dbl_row_for_component(component, part_number, custom_fields)
 
     def _collect_dbl_assets(
         self,
@@ -3272,150 +2935,16 @@ class ComponentCatalogDomainService:
         export_root: Path,
         conn: Any,
     ) -> None:
-        _, assets = self._placement_assets(conn, component["revision_id"])
-        for raw_asset in assets:
-            if raw_asset["asset_type"] not in {"symbol", "footprint"}:
-                continue
-            asset = self._materialize_asset(raw_asset, assets, component)
-            if raw_asset["asset_type"] == "symbol":
-                library_name = _dbl_symbol_library_name(part_number, asset)
-                destination = export_root / "SchLib" / f"{library_name}.kicad_sym"
-            else:
-                destination = export_root / "PcbLib" / f"{asset['target_library']}.pretty" / f"{asset['target_name']}.kicad_mod"
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_bytes(asset["payload"])
+        self._dbl_export.collect_dbl_assets(conn, component, part_number, export_root)
 
-    def _write_dbl_config(self, export_root: Path, *, filename: str, connection_string: str, libraries: list[dict[str, Any]]) -> None:
-        payload = {
-            "meta": {"version": 0},
-            "name": "KiCAD Prism Database Library",
-            "description": "KiCAD Prism released component database library",
-            "source": {
-                "type": "odbc",
-                "dsn": "",
-                "username": "",
-                "password": "",
-                "timeout_seconds": 2,
-                "connection_string": connection_string,
-            },
-            "cache": {"max_age": 28800},
-            "libraries": libraries,
-        }
-        (export_root / filename).write_text(json.dumps(payload, indent=4) + "\n", encoding="utf-8")
+    def _write_dbl_config(
+        self, export_root: Path, *, filename: str, connection_string: str, libraries: list[dict[str, Any]]
+    ) -> None:
+        write_dbl_config(export_root, filename=filename, connection_string=connection_string, libraries=libraries)
 
     def export_kicad_dbl_bundle(self) -> dict[str, Any]:
-        # The generated KiCad database-library bundle intentionally uses SQLite as
-        # an interchange artifact. Prism's runtime state is PostgreSQL-only.
-        import sqlite3 as sqlite_export
-
         self.initialize()
-        export_root = self.export_root
-        if export_root.exists():
-            shutil.rmtree(export_root)
-        (export_root / "SchLib").mkdir(parents=True, exist_ok=True)
-        (export_root / "PcbLib").mkdir(parents=True, exist_ok=True)
-
-        components = sorted(self._released_place_ready_components(), key=lambda c: (c["category"], c["mpn"], c["id"]))
-        custom_fields = [
-            field for field in self.list_metadata_fields()
-            if field["storage_kind"] == "extra" and field["key"] not in DBL_COMMON_COLUMNS
-        ]
-        custom_columns = [field["key"] for field in custom_fields]
-        effective_columns = (*DBL_COMMON_COLUMNS, *custom_columns)
-        db_path = export_root / "Prism.sqlite"
-        used_part_numbers: set[str] = set()
-        grouped_rows: dict[str, list[dict[str, str]]] = {}
-
-        with self._connect() as catalog_conn:
-            for component in components:
-                base_part = _part_number_nocolon(component["mpn"] or component["value"] or component["id"])
-                part_number = base_part
-                counter = 2
-                while part_number in used_part_numbers:
-                    part_number = f"{base_part}_{counter}"
-                    counter += 1
-                used_part_numbers.add(part_number)
-                category = component["category"] or "Uncategorized"
-                grouped_rows.setdefault(category, []).append(self._dbl_row_for_component(component, part_number, custom_fields))
-                self._collect_dbl_assets(component, part_number, export_root, catalog_conn)
-
-        with sqlite_export.connect(db_path) as dbl_conn:
-            for category, rows in sorted(grouped_rows.items()):
-                table = _quote_identifier(category)
-                columns_sql = ", ".join(f"{_quote_identifier(column)} TEXT NOT NULL DEFAULT ''" for column in effective_columns)
-                dbl_conn.execute(f"CREATE TABLE {table} ({columns_sql})")
-                column_names = ", ".join(_quote_identifier(column) for column in effective_columns)
-                placeholders = ", ".join("?" for _ in effective_columns)
-                for row in rows:
-                    dbl_conn.execute(
-                        f"INSERT INTO {table} ({column_names}) VALUES ({placeholders})",
-                        tuple(row.get(column, "") for column in effective_columns),
-                    )
-
-        fields = [
-            {
-                "column": column,
-                "name": column,
-                "visible_on_add": False,
-                "visible_in_chooser": column not in {"LibSymbol", "LibFootprint"},
-                "show_name": True,
-                "inherit_properties": True,
-            }
-            for column in effective_columns
-            if column not in {"Part Number Nocolon"}
-        ]
-        libraries = [
-            {
-                "name": category,
-                "table": category,
-                "key": "Part Number Nocolon",
-                "symbols": "LibSymbol",
-                "footprints": "LibFootprint",
-                "fields": fields,
-            }
-            for category in sorted(grouped_rows)
-        ]
-        self._write_dbl_config(
-            export_root,
-            filename="Prism_Linux.kicad_dbl",
-            connection_string="Driver={SQLite3};Database=${CWD}/Prism.sqlite;",
-            libraries=libraries,
-        )
-        self._write_dbl_config(
-            export_root,
-            filename="Prism_Windows.kicad_dbl",
-            connection_string="Driver={SQLite3 ODBC Driver};Database=${CWD}/Prism.sqlite;",
-            libraries=libraries,
-        )
-
-        symbol_libraries = sorted(path.stem for path in (export_root / "SchLib").glob("*.kicad_sym"))
-        footprint_libraries = sorted({asset["target_library"] for component in components for asset in component["assets"] if asset["asset_type"] == "footprint"})
-        sym_lines = [
-            '(sym_lib_table',
-            '  (lib (name "Prism")(type "Database")(uri "${PRISM_LIB_DIR}/Prism_Linux.kicad_dbl")(options "")(descr ""))',
-        ]
-        sym_lines.extend(
-            f'  (lib (name "{_sexpr_string(library)}")(type "KiCad")(uri "${{PRISM_LIB_DIR}}/SchLib/{_sexpr_string(library)}.kicad_sym")(options "")(descr "")(hidden))'
-            for library in symbol_libraries
-        )
-        sym_lines.append(")")
-        (export_root / "sym-lib-table").write_text("\n".join(sym_lines) + "\n", encoding="utf-8")
-
-        fp_lines = ["(fp_lib_table"]
-        fp_lines.extend(
-            f'  (lib (name "{_sexpr_string(library)}")(type "KiCad")(uri "${{PRISM_LIB_DIR}}/PcbLib/{_sexpr_string(library)}.pretty")(options "")(descr ""))'
-            for library in footprint_libraries
-        )
-        fp_lines.append(")")
-        (export_root / "fp-lib-table").write_text("\n".join(fp_lines) + "\n", encoding="utf-8")
-
-        return {
-            "export_root": str(export_root),
-            "component_count": len(components),
-            "category_count": len(grouped_rows),
-            "sqlite_path": str(db_path),
-            "linux_dbl": str(export_root / "Prism_Linux.kicad_dbl"),
-            "windows_dbl": str(export_root / "Prism_Windows.kicad_dbl"),
-            "sym_lib_table": str(export_root / "sym-lib-table"),
-            "fp_lib_table": str(export_root / "fp-lib-table"),
-        }
+        components = self._released_place_ready_components()
+        metadata_fields = self.list_metadata_fields()
+        with self._connect() as conn:
+            return self._dbl_export.export_bundle(conn, self._runtime_for_compat(), components, metadata_fields)

--- a/backend/app/services/component_catalog_service_postgres.py
+++ b/backend/app/services/component_catalog_service_postgres.py
@@ -10,9 +10,11 @@ from app.services.catalog.asset_links import CatalogAssetLinks
 from app.services.catalog.component_history import CatalogComponentHistoryReads
 from app.services.catalog.component_read_models import CatalogComponentReadModels
 from app.services.catalog.component_queries import CatalogComponentQueries
+from app.services.catalog.dbl_export import CatalogDblExport
 from app.services.catalog.health import CatalogHealth
 from app.services.catalog.klc_validation import CatalogKlcValidation
 from app.services.catalog.locking import CatalogLockOperations, PostgresCatalogLocks
+from app.services.catalog.placement import CatalogPlacement
 from app.services.catalog.preview_pipeline import CatalogPreviewPipeline
 from app.services.catalog.project_import_assets import CatalogProjectImportAssets
 from app.services.catalog.release_workflow import CatalogReleaseWorkflow
@@ -83,6 +85,8 @@ class ComponentCatalogPostgresService(ComponentCatalogDomainService):
         _catalog_locks, _revision_kernel, _component_read_models, _revision_finalizer, _klc_validation
     )
     _catalog_health: CatalogHealth = CatalogHealth(_component_queries, _klc_validation)
+    _placement: CatalogPlacement = CatalogPlacement(_revision_kernel, _component_read_models)
+    _dbl_export: CatalogDblExport = CatalogDblExport(_placement)
 
     def __init__(self, store_root: Path | None = None, database_url: str | None = None) -> None:
         self._postgres_runtime = PostgresCatalogRuntime(database_url=database_url)

--- a/backend/tests/test_catalog_placement_payloads.py
+++ b/backend/tests/test_catalog_placement_payloads.py
@@ -1,0 +1,147 @@
+"""Direct contracts for placement payload rewriting, signing, and DBL naming."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.core.config import settings  # noqa: E402
+from app.services.catalog.dbl_export import (  # noqa: E402
+    dbl_symbol_library_name,
+    part_number_nocolon,
+    quote_identifier,
+    sexpr_string,
+)
+from app.services.catalog.placement_payloads import (  # noqa: E402
+    remote_library_nickname,
+    rewrite_footprint_payload,
+    rewrite_symbol_payload,
+)
+from app.services.catalog.signed_urls import CatalogAssetUrlSigner  # noqa: E402
+
+
+SYMBOL = (
+    '(kicad_symbol_lib (version 20231120) (generator "prism")\n'
+    '  (symbol "R_Test"\n'
+    '    (property "Reference" "R" (at 0 0 0)\n'
+    "      (effects (font (size 1.27 1.27)))\n"
+    "    )\n"
+    '    (property "Value" "old" (at 0 0 0)\n'
+    "      (effects (font (size 1.27 1.27)))\n"
+    "    )\n"
+    '    (property "Footprint" "Old:FP" (at 0 0 0)\n'
+    "      (effects (font (size 1.27 1.27)) hide)\n"
+    "    )\n"
+    '    (symbol "R_Test_0_1"\n'
+    "      (rectangle (start -1 -2) (end 1 2))\n"
+    "    )\n"
+    "  )\n"
+    ")\n"
+)
+
+
+class SymbolRewriteTests(unittest.TestCase):
+    def test_metadata_properties_and_footprint_are_rewritten_in_stable_order(self) -> None:
+        component = {
+            "value": "10k",
+            "description": "Resistor",
+            "manufacturer": "Prism",
+            "mpn": "PG-R-1",
+            "extra_fields": {"Tolerance": "1%", "Footprint": "ignored", "Reference": "ignored"},
+        }
+        with patch.object(settings, "REMOTE_PROVIDER_LIBRARY_PREFIX", "Remote"):
+            rewritten = rewrite_symbol_payload(SYMBOL.encode("utf-8"), "remote_prism_fp:R_0402", component).decode(
+                "utf-8"
+            )
+        names = [line.split('"')[1] for line in rewritten.splitlines() if line.strip().startswith("(property ")]
+        self.assertEqual(names[:3], ["Reference", "Value", "Footprint"])
+        self.assertIn("Tolerance", names)
+        self.assertEqual(names.index("SAP Code") + 1, names.index("Tolerance"))
+        self.assertIn('(property "Value" "10k" (at 0 0 0)\n      (effects (font (size 1.27 1.27)))\n', rewritten)
+        self.assertIn('(property "Footprint" "remote_prism_fp:R_0402"', rewritten)
+        self.assertIn('(property "Manufacturer Part Number" "PG-R-1"', rewritten)
+        self.assertEqual(rewritten.count('(property "Footprint"'), 1)
+        self.assertTrue(rewritten.endswith('    (symbol "R_Test_0_1"\n      (rectangle (start -1 -2) (end 1 2))\n    )\n  )\n)\n'))
+        self.assertEqual(
+            rewrite_symbol_payload(SYMBOL.encode("utf-8"), "remote_prism_fp:R_0402", component),
+            rewritten.encode("utf-8"),
+        )
+
+    def test_symbol_without_properties_is_returned_unchanged(self) -> None:
+        payload = b'(kicad_symbol_lib (version 1) (generator "x")\n  (symbol "Bare"\n  )\n)\n'
+        self.assertEqual(rewrite_symbol_payload(payload, None, None), payload)
+
+    def test_missing_footprint_ref_keeps_the_existing_footprint_block(self) -> None:
+        rewritten = rewrite_symbol_payload(SYMBOL.encode("utf-8"), None, None).decode("utf-8")
+        self.assertIn('(property "Footprint" "Old:FP"', rewritten)
+
+
+class FootprintRewriteTests(unittest.TestCase):
+    def test_model_paths_point_at_the_remote_destination(self) -> None:
+        payload = (
+            '(footprint "R_0402"\n'
+            '  (model "${KICAD8_3DMODEL_DIR}/R.step" (offset (xyz 0 0 0)))\n'
+            '  (model "other.wrl")\n'
+            ")\n"
+        ).encode("utf-8")
+        models = [{"canonical_path": "/store/3dmodel/Lib/R.step"}]
+        with (
+            patch.object(settings, "REMOTE_PROVIDER_LIBRARY_PREFIX", "Remote"),
+            patch.object(settings, "REMOTE_PROVIDER_DESTINATION_DIR", "/RemoteLibrary"),
+        ):
+            rewritten = rewrite_footprint_payload(payload, {}, models).decode("utf-8")
+        self.assertIn('(model "${KIPRJMOD}/RemoteLibrary/remote_3d/R.step" (offset', rewritten)
+        self.assertIn('(model "other.wrl")', rewritten)
+
+    def test_no_models_leaves_bytes_untouched(self) -> None:
+        payload = b'(footprint "R_0402"\n  (model "x.step")\n)\n'
+        self.assertEqual(rewrite_footprint_payload(payload, {}, []), payload)
+
+    def test_remote_library_nickname_is_sanitized_and_lowercase(self) -> None:
+        with patch.object(settings, "REMOTE_PROVIDER_LIBRARY_PREFIX", "Remote Lib"):
+            self.assertEqual(remote_library_nickname("Prism Footprints"), "remote_lib_prism_footprints")
+
+
+class SignedUrlTests(unittest.TestCase):
+    def test_signature_binds_asset_revision_representation_and_expiry(self) -> None:
+        with (
+            patch.object(settings, "SESSION_SECRET", "secret"),
+            patch("app.services.catalog.signed_urls.time.time", return_value=1_700_000_000),
+        ):
+            url = CatalogAssetUrlSigner.build_signed_asset_url("a1", "r1", "https://prism/", representation_id="rep1")
+            self.assertTrue(url.startswith("https://prism/api/remote-provider/assets/a1?rev=r1&representation=rep1&exp=1700000300&sig="))
+            sig = url.rsplit("sig=", 1)[1]
+            self.assertTrue(CatalogAssetUrlSigner.validate_asset_signature("a1", "r1", 1_700_000_300, sig, "rep1"))
+            self.assertFalse(CatalogAssetUrlSigner.validate_asset_signature("a1", "r2", 1_700_000_300, sig, "rep1"))
+            self.assertFalse(CatalogAssetUrlSigner.validate_asset_signature("a1", "r1", 1_700_000_300, sig, ""))
+        with (
+            patch.object(settings, "SESSION_SECRET", "secret"),
+            patch("app.services.catalog.signed_urls.time.time", return_value=1_700_000_300),
+        ):
+            self.assertFalse(CatalogAssetUrlSigner.validate_asset_signature("a1", "r1", 1_700_000_300, sig, "rep1"))
+
+    def test_missing_secret_refuses_to_sign(self) -> None:
+        with patch.object(settings, "SESSION_SECRET", ""), self.assertRaises(RuntimeError):
+            CatalogAssetUrlSigner.sign("anything")
+
+
+class DblNamingTests(unittest.TestCase):
+    def test_helpers_are_stable(self) -> None:
+        self.assertEqual(part_number_nocolon("  LM:317 T "), "LM_317_T")
+        self.assertEqual(part_number_nocolon(":::"), "_")
+        self.assertEqual(part_number_nocolon(""), "PART")
+        self.assertEqual(quote_identifier('Res "1"'), '"Res ""1"""')
+        self.assertEqual(sexpr_string('a"b\\c'), 'a\\"b\\\\c')
+        self.assertEqual(dbl_symbol_library_name("PN", None), "")
+        self.assertEqual(
+            dbl_symbol_library_name("PN", {"target_library": "Lib A", "target_name": "R Test"}),
+            "Prism_PN_Lib_A_R_Test",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -237,10 +237,10 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
         """Keep preview evidence independent of kicad-cli availability and version."""
 
         for target, value in (
-            ("app.services.component_catalog_domain.settings.CATALOG_KLC_ENABLED", False),
-            ("app.services.component_catalog_domain.settings.CATALOG_KLC_RELEASE_GATE", "warn"),
+            ("app.core.config.settings.CATALOG_KLC_ENABLED", False),
+            ("app.core.config.settings.CATALOG_KLC_RELEASE_GATE", "warn"),
             (
-                "app.services.component_catalog_domain.settings.SESSION_SECRET",
+                "app.core.config.settings.SESSION_SECRET",
                 "catalog-contract-test-secret",
             ),
         ):
@@ -725,7 +725,7 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
         self.assertTrue(self.service.verify_component_audit_chain(component["id"])["valid"])
 
         fixed_now = 1_700_000_000
-        with patch("app.services.component_catalog_domain.time.time", return_value=fixed_now):
+        with patch("app.services.catalog.signed_urls.time.time", return_value=fixed_now):
             manifest = self.service.build_manifest(component["id"], "https://prism.example")
         assert manifest is not None
         self.assertEqual(manifest["part_id"], component["id"])
@@ -747,7 +747,7 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
             [released["default_representation_id"]],
         )
         self.assertEqual(int(signed_query["exp"][0]), fixed_now + 300)
-        with patch("app.services.component_catalog_domain.time.time", return_value=fixed_now):
+        with patch("app.services.catalog.signed_urls.time.time", return_value=fixed_now):
             self.assertTrue(
                 self.service.validate_asset_signature(
                     released["assets"][0]["id"],
@@ -757,7 +757,7 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
                     signed_query["representation"][0],
                 )
             )
-        with patch("app.services.component_catalog_domain.time.time", return_value=fixed_now + 300):
+        with patch("app.services.catalog.signed_urls.time.time", return_value=fixed_now + 300):
             self.assertFalse(
                 self.service.validate_asset_signature(
                     released["assets"][0]["id"],

--- a/scripts/catalog_architecture_baseline.json
+++ b/scripts/catalog_architecture_baseline.json
@@ -87,7 +87,7 @@
     "backend/app/api/projects.py": 2153,
     "backend/app/release_studio/closure.py": 1336,
     "backend/app/release_studio/documents/artwork.py": 1533,
-    "backend/app/services/component_catalog_domain.py": 3421,
+    "backend/app/services/component_catalog_domain.py": 2950,
     "backend/app/services/design_compare_service.py": 2185,
     "backend/app/services/fabrication_compare_service.py": 1543,
     "backend/app/services/job_service.py": 1916,


### PR DESCRIPTION
## Summary

Catalog PR 8 (stacked on #219). Extracts the remote-provider and export surface out of `component_catalog_domain.py` into explicit collaborators:

- `catalog/placement_payloads.py` — pure symbol/footprint payload rewriting and asset materialization
- `catalog/placement.py` — placement manifests, inline bundles, asset-by-id resolution
- `catalog/signed_urls.py` — HMAC-signed, time-limited asset URLs (`CatalogAssetUrlSigner`)
- `catalog/provider_tokens.py` — OAuth auth codes and token revocation list
- `catalog/dbl_export.py` — KiCad database-library bundle export

The facade keeps every existing signature and delegates. Provider/OAuth contracts, signature messages, manifest and inline-bundle shapes, and DBL output are unchanged; the integration suite still asserts their hashes byte-for-byte. Unused stdlib imports left behind in the facade were removed and the integration tests now patch `time`/`settings` where they are actually read.

Also updates `backend/app/services/catalog/AGENTS.md` (was still describing an empty package) and the services map.

Domain facade: 3,421 → 2,951 lines (8,236 at program start).

## Verification

- `python -m compileall backend/app`
- Full backend suite: 1142 tests OK (15 skips are external-tool skips, unchanged)
- PostgreSQL integration suite against an isolated database: 15 passed, 0 skipped
- `tests.test_catalog_placement_payloads`: 9 new tests
- `scripts/check_catalog_architecture.py`: 0 violations, 16 private-use keys (tests only), ceiling ratcheted to 2951
- `scripts/check_agent_docs.py`: OK

Made with [Cursor](https://cursor.com)