### PR TITLE
fix(catalog): close decomposition review follow-ups

### DIFF
--- a/backend/app/services/AGENTS.md
+++ b/backend/app/services/AGENTS.md
@@ -14,8 +14,9 @@ Three files, and the names do not tell you which to use:
 | `component_catalog_domain.py` | Compatibility facade: the historical callable surface, delegating to collaborators in `catalog/`. |
 
 `ComponentCatalogPostgresService` inherits `ComponentCatalogDomainService`,
-composes the `catalog/` collaborators, and owns transactions. The behavior
-itself lives in `backend/app/services/catalog/`; read
+owns PostgreSQL connection and schema setup, and composes the `catalog/`
+collaborators. The compatibility facade owns transaction boundaries. The
+behavior itself lives in `backend/app/services/catalog/`; read
 `backend/app/services/catalog/AGENTS.md` for the layer map. To find where a
 facade method lands, search the facade for the method name and follow the
 `self._<collaborator>.` call. Public reads generally begin with `list_`,

--- a/backend/app/services/catalog/AGENTS.md
+++ b/backend/app/services/catalog/AGENTS.md
@@ -25,6 +25,17 @@ parameters and never commit; the facade owns transactions. The exception is
 batch preview generation, which commits per component for durability and says
 so at the call site.
 
+## Compatibility-facade size waiver
+
+The alpha-lifecycle compatibility facade is explicitly grandfathered at 2,132
+physical lines, above the 500-line target for new facades and orchestrators.
+Its size comes from 183 explicit, signature-preserving forwarding methods and
+the transaction scopes around them. It may contain no domain implementation,
+may not grow, and its architecture ceiling can only decrease. New behavior
+belongs in this package; dynamic delegation, mixins, and collaborators that
+depend back on the facade remain prohibited. The retirement conditions and
+rationale are recorded in `docs/CATALOG_DECOMPOSITION_HANDOFF.md`.
+
 ## Contracts that must not move
 
 - Revision manifest hashes, audit-chain hashes, and preview fingerprints

--- a/backend/app/services/catalog/component_writer.py
+++ b/backend/app/services/catalog/component_writer.py
@@ -97,7 +97,7 @@ def metadata_matches_revision(revision: dict[str, Any], metadata: dict[str, Any]
             if key == "extra_fields"
             else str(revision.get(key) or "") == str(metadata[key])
         )
-        for key in metadata
+        for key in (*_METADATA_COLUMNS, "extra_fields")
     )
 
 

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -1896,11 +1896,11 @@ class ComponentCatalogDomainService:
     def _parse_klc_junit(self, junit_path: Path) -> list[dict[str, Any]]:
         return self._klc_validation.parse_klc_junit(junit_path)
 
-    def _write_validation_report_json(self, path: Path, **report: Any) -> None:
-        self._klc_validation.write_validation_report_json(path, **report)
+    def _write_validation_report_json(self, path: Path, *, run_id: str, asset: dict[str, Any], status: str, exit_code: int | None, findings: list[dict[str, Any]], stdout: str, stderr: str, tool_version: str, created_at: str, finished_at: str) -> None:
+        self._klc_validation.write_validation_report_json(path, run_id=run_id, asset=asset, status=status, exit_code=exit_code, findings=findings, stdout=stdout, stderr=stderr, tool_version=tool_version, created_at=created_at, finished_at=finished_at)
 
-    def _store_validation_run(self, conn: Any, **run: Any) -> dict[str, Any]:
-        return self._klc_validation.store_validation_run(conn, **run)
+    def _store_validation_run(self, conn: Any, *, run_id: str, component_id: str, revision_id: str, asset: dict[str, Any], status: str, exit_code: int | None, findings: list[dict[str, Any]], report_dir: Path, stdout_path: Path, stderr_path: Path, junit_path: Path, json_path: Path, raw_output: str, tool_version: str, created_at: str, finished_at: str) -> dict[str, Any]:
+        return self._klc_validation.store_validation_run(conn, run_id=run_id, component_id=component_id, revision_id=revision_id, asset=asset, status=status, exit_code=exit_code, findings=findings, report_dir=report_dir, stdout_path=stdout_path, stderr_path=stderr_path, junit_path=junit_path, json_path=json_path, raw_output=raw_output, tool_version=tool_version, created_at=created_at, finished_at=finished_at)
 
     def _run_klc_for_asset(
         self,

--- a/backend/tests/test_catalog_component_writer.py
+++ b/backend/tests/test_catalog_component_writer.py
@@ -16,7 +16,6 @@ from app.services.catalog.component_writer import (  # noqa: E402
 from app.services.catalog.metadata_normalization import (  # noqa: E402
     IDENTITY_KIND_MPN,
     IDENTITY_KIND_PROVISIONAL_IPN,
-    normalize_metadata,
 )
 from app.services.catalog.remote_heads import remote_head_payload  # noqa: E402
 
@@ -29,6 +28,9 @@ def _revision(**overrides: object) -> dict[str, object]:
         "datasheet_url": "https://prism.example/r1.pdf",
         "manufacturer": "Prism",
         "mpn": "PG-R-1",
+        "normalized_manufacturer": "prism",
+        "normalized_mpn": "pg-r-1",
+        "mpn_source": "manufacturer",
         "category": "Passives",
         "package_name": "0402",
         "vendor": "",
@@ -41,7 +43,7 @@ def _revision(**overrides: object) -> dict[str, object]:
         "power_dissipation_w": "",
         "rate": "",
         "sap_code": "",
-        "summary": "",
+        "summary": "Resistor",
         "extra_fields": '{"Tolerance": "1%"}',
     }
     base.update(overrides)
@@ -75,22 +77,13 @@ class MergeMetadataPatchTests(unittest.TestCase):
     def test_unchanged_patch_is_detected_against_the_revision(self) -> None:
         component = {"identity_kind": IDENTITY_KIND_MPN, "identity_source": ""}
         revision = _revision()
-        normalized = normalize_metadata(
-            {
-                **revision,
-                "identity_kind": IDENTITY_KIND_MPN,
-                "identity_source": "",
-                "extra_fields": {"Tolerance": "1%"},
-            }
-        )
-        stored = {**revision, **{k: v for k, v in normalized.items() if k != "extra_fields"}}
-        self.assertTrue(metadata_matches_revision(stored, merge_metadata_patch(component, stored, {})))
+        self.assertTrue(metadata_matches_revision(revision, merge_metadata_patch(component, revision, {})))
         self.assertFalse(
-            metadata_matches_revision(stored, merge_metadata_patch(component, stored, {"value": "33k"}))
+            metadata_matches_revision(revision, merge_metadata_patch(component, revision, {"value": "33k"}))
         )
         self.assertFalse(
             metadata_matches_revision(
-                stored, merge_metadata_patch(component, stored, {"extra_fields": {"Tolerance": "5%"}})
+                revision, merge_metadata_patch(component, revision, {"extra_fields": {"Tolerance": "5%"}})
             )
         )
 

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -424,6 +424,21 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
         assert corrected is not None
         self.assertEqual(corrected["mpn"], corrected_mpn)
 
+    def test_unchanged_metadata_patch_does_not_create_a_revision(self) -> None:
+        component = self._component("unchanged-" + uuid.uuid4().hex[:8])
+        before = self.service.list_component_revisions(component["id"])
+
+        unchanged = self.service.update_component_metadata(
+            component["id"],
+            {},
+            actor="editor@example.com",
+            expected_revision_id=component["revision_id"],
+        )
+
+        assert unchanged is not None
+        self.assertEqual(unchanged["revision_id"], component["revision_id"])
+        self.assertEqual(self.service.list_component_revisions(component["id"]), before)
+
     def test_concurrent_edits_serialize_head_and_audit(self) -> None:
         component = self._component("concurrent-" + uuid.uuid4().hex[:8])
         expected_revision_id = component["revision_id"]

--- a/docs/CATALOG_DECOMPOSITION_HANDOFF.md
+++ b/docs/CATALOG_DECOMPOSITION_HANDOFF.md
@@ -200,3 +200,27 @@ dependencies, or collaborators depending back on the facade are prohibited.
 After Catalog PR 8, continue the planned waves for catalog API/UI, design
 comparison, viewer UI, jobs/ingestion, Release Studio, fabrication/document
 tooling, and finally mechanical migration-file separation.
+
+## Approved compatibility-facade size exception
+
+The completed decomposition retains `component_catalog_domain.py` as a 2,132
+line compatibility facade for the alpha lifecycle. This is an explicit waiver
+from the original 500-line facade/orchestrator target, not permission for a new
+god module. The stable historical surface has 183 forwarding signatures, and
+preserving them explicitly keeps runtime callers, tests, maintenance tooling,
+and third-party integrations inspectable without the prohibited alternatives
+of mixins or dynamic `__getattr__` delegation.
+
+The exception has these hard bounds:
+
+- the facade contains transaction and connection scopes plus explicit
+  delegation, but no domain implementation;
+- new catalog behavior must be implemented in `backend/app/services/catalog/`;
+- the checked-in 2,132-line architecture ceiling may only shrink and must never
+  increase;
+- collaborators must not import or retain a reference to the facade; and
+- after the alpha compatibility window, callers should migrate to supported
+  narrow services so forwarding methods and their ceiling can be retired.
+
+This exception does not relax the 500-line limit for any new catalog facade,
+composition root, or orchestrator.


### PR DESCRIPTION
## Summary

- correct the catalog transaction-ownership documentation
- compare no-op metadata updates only against revision-backed columns and add PostgreSQL regression coverage
- restore the two historical private KLC wrapper signatures exactly
- document the explicit 2,132-line compatibility-facade waiver and its shrink-only constraints

## Verification

- full backend suite: 1,158 passed, 15 expected conditional skips
- isolated PostgreSQL catalog suite: 16 passed, zero skips
- catalog architecture: 0 forbidden legacy imports, 16 test-only private-use keys, 202 production modules, 16 grandfathered ceilings
- agent documentation check: 301 paths, 5 model-neutral skill shims
- architecture unit suite: 17 passed
- historical KLC wrapper AST signatures match origin/dev exactly
- Python compilation and git diff checks passed

## Stack

This PR is intentionally stacked on #221 and should be merged after it.