### PR TITLE
fix(workspace): repository link opens the forge instead of the Prism page

### DIFF
--- a/frontend/src/components/workspace/workspace-project-properties-sheet.test.tsx
+++ b/frontend/src/components/workspace/workspace-project-properties-sheet.test.tsx
@@ -109,3 +109,34 @@ describe("WorkspaceProjectPropertiesSheet thumbnail controls", () => {
     expect(onRegenerateThumbnail).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("WorkspaceProjectPropertiesSheet repository link", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens the derived web URL for a scp-style remote", async () => {
+    renderSheet(makeProject({ repo_url: "git@github.com:org/repo.git" }));
+    const link = await screen.findByRole("link", { name: "https://github.com/org/repo" });
+    expect(link).toHaveAttribute("href", "https://github.com/org/repo");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("keeps an https remote as the link target", async () => {
+    renderSheet(makeProject({ repo_url: "https://github.com/org/repo.git" }));
+    const link = await screen.findByRole("link", { name: "https://github.com/org/repo" });
+    expect(link).toHaveAttribute("href", "https://github.com/org/repo");
+  });
+
+  it("shows a remote it cannot resolve as plain text, not a dead link", async () => {
+    renderSheet(makeProject({ repo_url: "github.com/org/repo" }));
+    expect(await screen.findByText("github.com/org/repo")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("falls back to the parent repository name when there is no remote", async () => {
+    renderSheet(makeProject({ parent_repo: "org/repo" }));
+    expect(await screen.findByText("org/repo")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+});

--- a/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
+++ b/frontend/src/components/workspace/workspace-project-properties-sheet.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { fetchJson } from "@/lib/api";
+import { repositoryWebUrl } from "@/lib/repository-url";
 import { cn } from "@/lib/utils";
 import type { FolderTreeItem, Project, ProjectPropertiesResponse } from "@/types/project";
 import { Button } from "@/components/ui/button";
@@ -276,6 +277,7 @@ export function WorkspaceProjectPropertiesSheet({
   const panelProject = activeProject ?? project;
   const displayName = activeProject?.display_name || activeProject?.name || "Project";
   const repositoryLabel = panelProject ? resolveRepositoryLabel(panelProject) : "Standalone Project";
+  const repositoryUrl = panelProject ? repositoryWebUrl(panelProject.repo_url) : null;
   const folderPath = useMemo(
     () => buildFolderPath(panelProject?.folder_id ?? null, folderById),
     [panelProject?.folder_id, folderById]
@@ -424,15 +426,17 @@ export function WorkspaceProjectPropertiesSheet({
                 <MetadataRow
                   label="Repository Link"
                   value={
-                    panelProject.repo_url ? (
+                    repositoryUrl ? (
                       <a
-                        href={panelProject.repo_url}
+                        href={repositoryUrl}
                         target="_blank"
                         rel="noreferrer"
                         className="break-all underline underline-offset-4 transition-colors hover:text-primary"
                       >
-                        {panelProject.repo_url}
+                        {repositoryUrl}
                       </a>
+                    ) : panelProject.repo_url ? (
+                      <span className="break-all">{panelProject.repo_url}</span>
                     ) : (
                       repositoryLabel
                     )

--- a/frontend/src/lib/repository-url.test.ts
+++ b/frontend/src/lib/repository-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { repositoryWebUrl } from "./repository-url";
+
+describe("repositoryWebUrl", () => {
+  it("derives an https URL from scp-style GitHub remotes", () => {
+    expect(repositoryWebUrl("git@github.com:org/repo.git")).toBe("https://github.com/org/repo");
+    expect(repositoryWebUrl("git@github.com:org/repo")).toBe("https://github.com/org/repo");
+    expect(repositoryWebUrl("git@gitlab.com:org/repo.git")).toBe("https://gitlab.com/org/repo");
+  });
+
+  it("derives an https URL from ssh:// remotes and drops the ssh port", () => {
+    expect(repositoryWebUrl("ssh://git@github.com/org/repo.git")).toBe("https://github.com/org/repo");
+    expect(repositoryWebUrl("ssh://git@github.com:2222/org/repo.git")).toBe("https://github.com/org/repo");
+  });
+
+  it("keeps http(s) remotes and strips the trailing .git", () => {
+    expect(repositoryWebUrl("https://github.com/org/repo.git")).toBe("https://github.com/org/repo");
+    expect(repositoryWebUrl("https://github.com/org/repo/")).toBe("https://github.com/org/repo");
+    expect(repositoryWebUrl("http://git.internal.example/org/repo.git")).toBe("http://git.internal.example/org/repo");
+  });
+
+  it("preserves a non-default https port and drops the normalized default", () => {
+    expect(repositoryWebUrl("https://git.internal.example:8443/org/repo.git")).toBe("https://git.internal.example:8443/org/repo");
+    expect(repositoryWebUrl("https://github.com:443/org/repo.git")).toBe("https://github.com/org/repo");
+  });
+
+  it("drops credentials from an https remote", () => {
+    expect(repositoryWebUrl("https://user:token@github.com/org/repo.git")).toBe("https://github.com/org/repo");
+  });
+
+  it("handles IPv6 ssh hosts", () => {
+    expect(repositoryWebUrl("ssh://git@[::1]/org/repo.git")).toBe("https://[::1]/org/repo");
+  });
+
+  it("returns null for empty and null input", () => {
+    expect(repositoryWebUrl(null)).toBeNull();
+    expect(repositoryWebUrl(undefined)).toBeNull();
+    expect(repositoryWebUrl("")).toBeNull();
+    expect(repositoryWebUrl("   ")).toBeNull();
+  });
+
+  it("returns null when no safe derivation exists", () => {
+    expect(repositoryWebUrl("github.com/org/repo")).toBeNull();
+    expect(repositoryWebUrl("git@github.com")).toBeNull();
+    expect(repositoryWebUrl("https://github.com/")).toBeNull();
+    expect(repositoryWebUrl("file:///org/repo")).toBeNull();
+    expect(repositoryWebUrl("not a url")).toBeNull();
+  });
+});

--- a/frontend/src/lib/repository-url.ts
+++ b/frontend/src/lib/repository-url.ts
@@ -1,0 +1,60 @@
+/**
+ * Turn a stored Git remote into the web URL a browser can open.
+ *
+ * The import field accepts scp-style (`git@host:org/repo.git`) and `ssh://`
+ * remotes, and the workspace stores that transport spelling verbatim. Used
+ * verbatim as an anchor href, a scp-style remote has no scheme, so the browser
+ * resolves it as a *relative* URL against the Prism origin, and `ssh://` has
+ * no web handler at all. Forge hosts serve their web UI over HTTPS on the same
+ * host the remote names, so the browsable spelling is `https://host/path` with
+ * the transport user dropped and the trailing `.git` removed.
+ *
+ * Returns null when no safe http(s) derivation exists so callers can render
+ * the raw remote as plain text instead of a dead link.
+ */
+
+const SCP_LIKE_RE = /^[^/@]+@(\[[^\]]+\]|[^/:]+):(.+)$/;
+
+export function repositoryWebUrl(raw: string | null | undefined): string | null {
+  const remote = raw?.trim();
+  if (!remote) {
+    return null;
+  }
+
+  const scp = SCP_LIKE_RE.exec(remote);
+  if (scp && !remote.includes("://")) {
+    return buildWebUrl("https:", scp[1], "", scp[2]);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(remote);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol === "ssh:") {
+    return buildWebUrl("https:", parsed.hostname, "", parsed.pathname);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+  return buildWebUrl(parsed.protocol, parsed.hostname, parsed.port, parsed.pathname);
+}
+
+function buildWebUrl(
+  protocol: string,
+  host: string,
+  port: string,
+  pathname: string
+): string | null {
+  if (!host) {
+    return null;
+  }
+  const path = pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/, "");
+  if (!path) {
+    return null;
+  }
+  const origin = port ? `${protocol}//${host}:${port}` : `${protocol}//${host}`;
+  return `${origin}/${path}`;
+}


### PR DESCRIPTION
## Problem

Closes #224. The Repository Link in the project properties panel pointed back at Prism instead of the repository on the forge.

The panel rendered the stored Git remote verbatim as the anchor `href` (`workspace-project-properties-sheet.tsx`). Prism stores the transport spelling of the remote (`ws_repositories.url`), which is frequently scp-shaped:

- the import dialog accepts and stores `git@github.com:org/repo.git` verbatim, and
- a private GitHub import pasted as HTTPS is rewritten to `git@github.com:org/repo.git` before registration (`project_import_service.py` `_github_ssh_equivalent`).

An scp-style string has no URL scheme, so the browser resolves it as a relative path against the Prism origin (`https://<prism>/git@github.com:org/repo.git`), landing on the SPA catch-all. `ssh://` remotes have no web handler at all.

## Fix

New pure helper `frontend/src/lib/repository-url.ts` (`repositoryWebUrl`) derives the forge web URL from the stored remote:

- scp / `ssh://` remotes become `https://host/path` (transport user dropped, trailing `.git` removed);
- `http(s)://` remotes keep their scheme, path, and non-default port;
- IPv6 hosts, GitLab, and self-hosted forge hosts behave the same way;
- returns `null` when no safe derivation exists, in which case the panel shows the remote as plain text instead of a dead link (the `href` can never be a relative or non-http(s) URL).

The link text now shows the derived web URL, so the click target and the label agree.

## Tests

- `src/lib/repository-url.test.ts`: derivation cases (scp, ssh, ports, `.git` stripping, credentials, IPv6, null and unresolvable inputs).
- `workspace-project-properties-sheet.test.tsx`: renders the derived href for scp and https remotes, and plain text for unresolvable or absent remotes.

## Checks

- `npm run lint`: pass
- `npm test`: 534/534 pass (under the pinned Node 22.23.2)
- `npm run build` / `npm run build:panel`: pass
- `npm run scan:gate`: at baseline

Note: `npm test` under Node 26 (not the pinned runtime) shows 47 failures in unrelated suites (resizable-panel, release-studio, design-comparison) caused by Node's `localStorage`/`--localstorage-file` change; identical failures reproduce on clean `dev`, and all pass under Node 22.23.2.