### PR TITLE
fix(catalog): classify availability from the default representation

### DIFF
--- a/backend/app/services/catalog/component_queries.py
+++ b/backend/app/services/catalog/component_queries.py
@@ -19,6 +19,17 @@ from app.services.catalog.component_read_models import (
 from app.services.catalog.revision_kernel import WORKFLOW_STAGES, normalize_workflow_stage
 
 
+def default_representation_has_asset(revision_ref: str, column: str, alias: str) -> str:
+    """SQL predicate: the default representation has a non-empty ``column`` asset id."""
+
+    return (
+        f"EXISTS (SELECT 1 FROM revision_representations {alias} "
+        f"WHERE {alias}.revision_id = {revision_ref}.id "
+        f"AND {alias}.is_default = 1 "
+        f"AND COALESCE({alias}.{column}, '') <> '')"
+    )
+
+
 @dataclass(frozen=True)
 class CatalogComponentListPlan:
     """Purely prepared SQL fragments and values for one component-list read."""
@@ -102,13 +113,11 @@ class CatalogComponentQueries:
             filters.append(f"{revision_ref}.release_status IN ({placeholders})")
             params.extend(requested_workflow_stages)
         if availability_state:
-            symbol_exists = (
-                f"EXISTS (SELECT 1 FROM revision_assets ra_symbol "
-                f"WHERE ra_symbol.revision_id = {revision_ref}.id AND ra_symbol.asset_type = 'symbol')"
+            symbol_exists = default_representation_has_asset(
+                revision_ref, "symbol_asset_id", "rr_avail_symbol"
             )
-            footprint_exists = (
-                f"EXISTS (SELECT 1 FROM revision_assets ra_footprint "
-                f"WHERE ra_footprint.revision_id = {revision_ref}.id AND ra_footprint.asset_type = 'footprint')"
+            footprint_exists = default_representation_has_asset(
+                revision_ref, "footprint_asset_id", "rr_avail_footprint"
             )
             if availability_state == STATE_PLACE_READY:
                 filters.append(f"{symbol_exists} AND {footprint_exists}")
@@ -209,13 +218,11 @@ class CatalogComponentQueries:
         sort_direction = "DESC" if sort_dir.lower() == "desc" else "ASC"
         sort_column = sort_columns.get(sort_by)
         if sort_by == "availability_state":
-            symbol_exists = (
-                f"EXISTS (SELECT 1 FROM revision_assets ra_symbol_sort "
-                f"WHERE ra_symbol_sort.revision_id = {revision_ref}.id AND ra_symbol_sort.asset_type = 'symbol')"
+            symbol_exists = default_representation_has_asset(
+                revision_ref, "symbol_asset_id", "rr_avail_symbol_sort"
             )
-            footprint_exists = (
-                f"EXISTS (SELECT 1 FROM revision_assets ra_footprint_sort "
-                f"WHERE ra_footprint_sort.revision_id = {revision_ref}.id AND ra_footprint_sort.asset_type = 'footprint')"
+            footprint_exists = default_representation_has_asset(
+                revision_ref, "footprint_asset_id", "rr_avail_footprint_sort"
             )
             sort_column = f"CASE WHEN {symbol_exists} AND {footprint_exists} THEN 0 WHEN ({symbol_exists}) <> ({footprint_exists}) THEN 1 ELSE 2 END"
 
@@ -267,22 +274,30 @@ class CatalogComponentQueries:
         )
         rows = conn.execute(
             f"""
-            SELECT c.*, {plan.revision_ref}.id AS revision_id
+            SELECT c.*, {plan.revision_ref}.id AS revision_id,
+                   default_rep.symbol_asset_id AS default_symbol_asset_id,
+                   default_rep.footprint_asset_id AS default_footprint_asset_id
             FROM components c
             JOIN component_revisions {plan.revision_ref} ON {plan.revision_ref}.id = c.{plan.revision_join_column}
+            LEFT JOIN revision_representations default_rep
+              ON default_rep.revision_id = {plan.revision_ref}.id AND default_rep.is_default = 1
             {plan.where_sql}
             {plan.order_sql}
             LIMIT %s OFFSET %s
             """,
             plan.params + plan.order_params + (plan.page_size, plan.offset),
         ).fetchall()
-        row_pairs: list[tuple[dict[str, Any], str]] = []
+        row_pairs: list[tuple[dict[str, Any], str, str, str]] = []
         for row in rows:
             component_row = dict(row)
             revision_id = str(component_row.pop("revision_id"))
-            row_pairs.append((component_row, revision_id))
+            default_symbol_asset_id = str(component_row.pop("default_symbol_asset_id") or "")
+            default_footprint_asset_id = str(component_row.pop("default_footprint_asset_id") or "")
+            row_pairs.append(
+                (component_row, revision_id, default_symbol_asset_id, default_footprint_asset_id)
+            )
 
-        revision_ids = [revision_id for _, revision_id in row_pairs]
+        revision_ids = [revision_id for _, revision_id, _, _ in row_pairs]
         revisions_by_id: dict[str, dict[str, Any]] = {}
         if revision_ids:
             placeholders = ",".join("%s" for _ in revision_ids)
@@ -293,12 +308,19 @@ class CatalogComponentQueries:
             revisions_by_id = {str(revision["id"]): dict(revision) for revision in revision_rows}
 
         parsed_rows = []
-        for component_row, revision_id in row_pairs:
+        for component_row, revision_id, default_symbol_asset_id, default_footprint_asset_id in row_pairs:
             revision = revisions_by_id.get(revision_id)
             if revision:
-                parsed_rows.append((component_row, revision))
+                parsed_rows.append(
+                    (
+                        component_row,
+                        revision,
+                        default_symbol_asset_id,
+                        default_footprint_asset_id,
+                    )
+                )
 
-        revision_ids = [str(rev["id"]) for _, rev in parsed_rows]
+        revision_ids = [str(rev["id"]) for _, rev, _, _ in parsed_rows]
         assets_by_revision: dict[str, list[dict[str, Any]]] = {}
         all_asset_ids: list[str] = []
         if revision_ids:
@@ -367,7 +389,7 @@ class CatalogComponentQueries:
                     revision_runs[asset_id] = dict(inherited_row)
 
         items = []
-        for component_row, revision_row in parsed_rows:
+        for component_row, revision_row, default_symbol_asset_id, default_footprint_asset_id in parsed_rows:
             rev_assets = assets_by_revision.get(str(revision_row["id"]), [])
             if plan.lightweight:
                 validation = self._component_read_models.component_validation_summary(
@@ -383,6 +405,8 @@ class CatalogComponentQueries:
                         rev_assets,
                         released_view=plan.released_only,
                         validation_summary=validation,
+                        default_symbol_asset_id=default_symbol_asset_id,
+                        default_footprint_asset_id=default_footprint_asset_id,
                     )
                 )
                 continue
@@ -501,4 +525,8 @@ class CatalogComponentQueries:
         }
 
 
-__all__ = ["CatalogComponentListPlan", "CatalogComponentQueries"]
+__all__ = [
+    "CatalogComponentListPlan",
+    "CatalogComponentQueries",
+    "default_representation_has_asset",
+]

--- a/backend/app/services/catalog/component_queries.py
+++ b/backend/app/services/catalog/component_queries.py
@@ -19,15 +19,29 @@ from app.services.catalog.component_read_models import (
 from app.services.catalog.revision_kernel import WORKFLOW_STAGES, normalize_workflow_stage
 
 
-def default_representation_has_asset(revision_ref: str, column: str, alias: str) -> str:
-    """SQL predicate: the default representation has a non-empty ``column`` asset id."""
+REPRESENTATION_ASSET_COLUMNS = {
+    "symbol": "symbol_asset_id",
+    "footprint": "footprint_asset_id",
+}
 
+
+def default_representation_has_asset(revision_ref: str, asset_type: str, alias: str) -> str:
+    """SQL predicate: the default representation has a non-empty asset for ``asset_type``."""
+
+    column = REPRESENTATION_ASSET_COLUMNS[asset_type]
     return (
         f"EXISTS (SELECT 1 FROM revision_representations {alias} "
         f"WHERE {alias}.revision_id = {revision_ref}.id "
         f"AND {alias}.is_default = 1 "
         f"AND COALESCE({alias}.{column}, '') <> '')"
     )
+
+
+def default_rep_slot_present(asset_type: str) -> str:
+    """SQL predicate over the ``default_rep`` join used by the paged list query."""
+
+    column = REPRESENTATION_ASSET_COLUMNS[asset_type]
+    return f"COALESCE(default_rep.{column}, '') <> ''"
 
 
 @dataclass(frozen=True)
@@ -114,10 +128,10 @@ class CatalogComponentQueries:
             params.extend(requested_workflow_stages)
         if availability_state:
             symbol_exists = default_representation_has_asset(
-                revision_ref, "symbol_asset_id", "rr_avail_symbol"
+                revision_ref, "symbol", "rr_avail_symbol"
             )
             footprint_exists = default_representation_has_asset(
-                revision_ref, "footprint_asset_id", "rr_avail_footprint"
+                revision_ref, "footprint", "rr_avail_footprint"
             )
             if availability_state == STATE_PLACE_READY:
                 filters.append(f"{symbol_exists} AND {footprint_exists}")
@@ -218,13 +232,13 @@ class CatalogComponentQueries:
         sort_direction = "DESC" if sort_dir.lower() == "desc" else "ASC"
         sort_column = sort_columns.get(sort_by)
         if sort_by == "availability_state":
-            symbol_exists = default_representation_has_asset(
-                revision_ref, "symbol_asset_id", "rr_avail_symbol_sort"
+            # Paged SELECT already LEFT JOINs default_rep; COUNT has no ORDER BY.
+            symbol_present = default_rep_slot_present("symbol")
+            footprint_present = default_rep_slot_present("footprint")
+            sort_column = (
+                f"CASE WHEN {symbol_present} AND {footprint_present} THEN 0 "
+                f"WHEN ({symbol_present}) <> ({footprint_present}) THEN 1 ELSE 2 END"
             )
-            footprint_exists = default_representation_has_asset(
-                revision_ref, "footprint_asset_id", "rr_avail_footprint_sort"
-            )
-            sort_column = f"CASE WHEN {symbol_exists} AND {footprint_exists} THEN 0 WHEN ({symbol_exists}) <> ({footprint_exists}) THEN 1 ELSE 2 END"
 
         if sort_column:
             order_sql = f"ORDER BY {sort_column} {sort_direction}, {revision_ref}.updated_at DESC"
@@ -473,26 +487,21 @@ class CatalogComponentQueries:
 
         The release workspace is server paginated, so its header metrics must be
         computed independently from the visible page. A blocker is either missing
-        required CAD or a failed validation run for the exact current revision.
+        required CAD on the default representation or a failed validation run for
+        the exact current revision.
         """
 
+        symbol_exists = default_representation_has_asset("cr", "symbol", "rr_queue_symbol")
+        footprint_exists = default_representation_has_asset("cr", "footprint", "rr_queue_footprint")
         row = conn.execute(
-            """
+            f"""
             SELECT
                 SUM(CASE WHEN cr.release_status = 'qa_review' THEN 1 ELSE 0 END) AS qa_review,
                 SUM(CASE WHEN cr.release_status = 'done' THEN 1 ELSE 0 END) AS done,
                 SUM(
                     CASE WHEN
-                        NOT EXISTS (
-                            SELECT 1 FROM revision_assets ra_symbol
-                            WHERE ra_symbol.revision_id = cr.id
-                              AND ra_symbol.asset_type = 'symbol'
-                        )
-                        OR NOT EXISTS (
-                            SELECT 1 FROM revision_assets ra_footprint
-                            WHERE ra_footprint.revision_id = cr.id
-                              AND ra_footprint.asset_type = 'footprint'
-                        )
+                        NOT {symbol_exists}
+                        OR NOT {footprint_exists}
                         OR EXISTS (
                             SELECT 1
                             FROM revision_assets ra_validation
@@ -528,5 +537,7 @@ class CatalogComponentQueries:
 __all__ = [
     "CatalogComponentListPlan",
     "CatalogComponentQueries",
+    "REPRESENTATION_ASSET_COLUMNS",
+    "default_rep_slot_present",
     "default_representation_has_asset",
 ]

--- a/backend/app/services/catalog/component_read_models.py
+++ b/backend/app/services/catalog/component_read_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.core.config import settings
+from app.services.catalog.asset_types import PLACE_REQUIRED_ASSET_TYPES
 from app.services.catalog.metadata_normalization import IDENTITY_KIND_MPN
 from app.services.catalog.normalization import (
     json_loads,
@@ -16,31 +17,23 @@ from app.services.catalog.revision_kernel import CatalogRevisionKernel, normaliz
 
 
 PREVIEW_STATUS_READY = "ready"
-PLACE_REQUIRED_ASSET_TYPES = ("symbol", "footprint")
 
 STATE_METADATA_ONLY = "metadata_only"
 STATE_FILES_PARTIAL = "files_partial"
 STATE_PLACE_READY = "place_ready"
 
 
-def representation_slot_present(value: Any) -> bool:
-    """True when a default-representation symbol or footprint slot is populated."""
+def representation_slot_present(asset: dict[str, Any] | None) -> bool:
+    """True when a representation symbol or footprint slot carries an asset id."""
 
-    if value is None:
-        return False
-    if isinstance(value, dict):
-        return bool(str(value.get("id") or "").strip())
-    return bool(str(value).strip())
+    return bool(asset) and bool(str(asset.get("id") or "").strip())
 
 
 def cad_availability(has_symbol: bool, has_footprint: bool) -> tuple[str, list[str]]:
     """Classify CAD completeness from the effective representation pair."""
 
-    missing = [
-        kind
-        for kind, present in (("symbol", has_symbol), ("footprint", has_footprint))
-        if not present
-    ]
+    present = {"symbol": has_symbol, "footprint": has_footprint}
+    missing = [kind for kind in PLACE_REQUIRED_ASSET_TYPES if not present[kind]]
     if not missing:
         return STATE_PLACE_READY, missing
     if len(missing) == 1:
@@ -518,15 +511,13 @@ class CatalogComponentReadModels:
 
     def availability(
         self,
-        assets: list[dict[str, Any]],
+        *,
+        default_symbol: dict[str, Any] | None,
+        default_footprint: dict[str, Any] | None,
         release_status: str,
         is_active: bool,
-        *,
-        default_symbol: Any = None,
-        default_footprint: Any = None,
         identity_kind: str = IDENTITY_KIND_MPN,
     ) -> tuple[str, list[str], bool]:
-        del assets  # Historical facade argument; completeness is the default pair.
         state, missing = cad_availability(
             representation_slot_present(default_symbol),
             representation_slot_present(default_footprint),
@@ -576,11 +567,10 @@ class CatalogComponentReadModels:
         symbol_asset = effective_representation.get("symbol") if effective_representation else None
         footprint_asset = effective_representation.get("footprint") if effective_representation else None
         availability_state, missing_assets, place_enabled = self.availability(
-            assets,
-            str(revision_row["release_status"]),
-            bool(component_row["is_active"]),
             default_symbol=symbol_asset,
             default_footprint=footprint_asset,
+            release_status=str(revision_row["release_status"]),
+            is_active=bool(component_row["is_active"]),
             identity_kind=str(component_row.get("identity_kind") or IDENTITY_KIND_MPN),
         )
         local_inventory = self.local_inventory(conn, str(component_row["id"]))
@@ -718,11 +708,10 @@ class CatalogComponentReadModels:
         symbol_asset = assets_by_id.get(str(default_symbol_asset_id or ""))
         footprint_asset = assets_by_id.get(str(default_footprint_asset_id or ""))
         availability_state, missing_assets, place_enabled = self.availability(
-            assets,
-            str(revision_row["release_status"]),
-            bool(component_row["is_active"]),
             default_symbol=symbol_asset,
             default_footprint=footprint_asset,
+            release_status=str(revision_row["release_status"]),
+            is_active=bool(component_row["is_active"]),
             identity_kind=str(component_row.get("identity_kind") or IDENTITY_KIND_MPN),
         )
         # Lightweight payloads are used by the KiCad remote panel; avoid validation lookups on search paths.
@@ -763,6 +752,7 @@ class CatalogComponentReadModels:
             "summary": str(revision_row["summary"]),
             "revision": int(revision_row["version"]),
             "version": f"{int(revision_row['version'])}.0.0",
+            # LIB_ID follows the default pair, matching detail payloads.
             "library_name": str(symbol_asset["target_library"]) if symbol_asset else "",
             "symbol_name": str(symbol_asset["target_name"]) if symbol_asset else "",
             "availability_state": availability_state,

--- a/backend/app/services/catalog/component_read_models.py
+++ b/backend/app/services/catalog/component_read_models.py
@@ -22,6 +22,48 @@ STATE_METADATA_ONLY = "metadata_only"
 STATE_FILES_PARTIAL = "files_partial"
 STATE_PLACE_READY = "place_ready"
 
+
+def representation_slot_present(value: Any) -> bool:
+    """True when a default-representation symbol or footprint slot is populated."""
+
+    if value is None:
+        return False
+    if isinstance(value, dict):
+        return bool(str(value.get("id") or "").strip())
+    return bool(str(value).strip())
+
+
+def cad_availability(has_symbol: bool, has_footprint: bool) -> tuple[str, list[str]]:
+    """Classify CAD completeness from the effective representation pair."""
+
+    missing = [
+        kind
+        for kind, present in (("symbol", has_symbol), ("footprint", has_footprint))
+        if not present
+    ]
+    if not missing:
+        return STATE_PLACE_READY, missing
+    if len(missing) == 1:
+        return STATE_FILES_PARTIAL, missing
+    return STATE_METADATA_ONLY, missing
+
+
+def remote_place_enabled(
+    *,
+    is_active: bool,
+    identity_kind: str,
+    missing_assets: list[str],
+    release_status: str,
+) -> bool:
+    """Permission to place is separate from CAD completeness."""
+
+    return (
+        bool(is_active)
+        and str(identity_kind or IDENTITY_KIND_MPN) == IDENTITY_KIND_MPN
+        and not missing_assets
+        and _release_allows_remote(release_status)
+    )
+
 # Availability sources shown in the remote-provider payload. Everything today
 # is local inventory; distributor adapters (supply_quotes) extend
 # SUPPLY_VENDOR_SOURCE_NAMES when they land.
@@ -475,22 +517,26 @@ class CatalogComponentReadModels:
         }
 
     def availability(
-        self, assets: list[dict[str, Any]], release_status: str, is_active: bool
+        self,
+        assets: list[dict[str, Any]],
+        release_status: str,
+        is_active: bool,
+        *,
+        default_symbol: Any = None,
+        default_footprint: Any = None,
+        identity_kind: str = IDENTITY_KIND_MPN,
     ) -> tuple[str, list[str], bool]:
-        asset_types = {str(asset["asset_type"]) for asset in assets}
-        missing = [
-            asset_type
-            for asset_type in PLACE_REQUIRED_ASSET_TYPES
-            if asset_type not in asset_types
-        ]
-        if missing and len(missing) == len(PLACE_REQUIRED_ASSET_TYPES):
-            state = STATE_METADATA_ONLY
-        elif missing:
-            state = STATE_FILES_PARTIAL
-        else:
-            state = STATE_PLACE_READY
-        place_enabled = is_active and not missing and _release_allows_remote(release_status)
-        return state, missing, place_enabled
+        del assets  # Historical facade argument; completeness is the default pair.
+        state, missing = cad_availability(
+            representation_slot_present(default_symbol),
+            representation_slot_present(default_footprint),
+        )
+        return state, missing, remote_place_enabled(
+            is_active=is_active,
+            identity_kind=identity_kind,
+            missing_assets=missing,
+            release_status=release_status,
+        )
 
     def component_payload(
         self,
@@ -529,23 +575,13 @@ class CatalogComponentReadModels:
                 raise ValueError("Selected representation is incomplete")
         symbol_asset = effective_representation.get("symbol") if effective_representation else None
         footprint_asset = effective_representation.get("footprint") if effective_representation else None
-        missing_assets = [
-            kind
-            for kind, value in (("symbol", symbol_asset), ("footprint", footprint_asset))
-            if not value
-        ]
-        availability_state = (
-            STATE_PLACE_READY
-            if not missing_assets
-            else STATE_FILES_PARTIAL
-            if len(missing_assets) == 1
-            else STATE_METADATA_ONLY
-        )
-        place_enabled = (
-            bool(component_row["is_active"])
-            and str(component_row.get("identity_kind") or IDENTITY_KIND_MPN) == IDENTITY_KIND_MPN
-            and not missing_assets
-            and _release_allows_remote(str(revision_row["release_status"]))
+        availability_state, missing_assets, place_enabled = self.availability(
+            assets,
+            str(revision_row["release_status"]),
+            bool(component_row["is_active"]),
+            default_symbol=symbol_asset,
+            default_footprint=footprint_asset,
+            identity_kind=str(component_row.get("identity_kind") or IDENTITY_KIND_MPN),
         )
         local_inventory = self.local_inventory(conn, str(component_row["id"]))
         supply_sources = self.supply_sources(conn, str(component_row["id"]))
@@ -675,15 +711,20 @@ class CatalogComponentReadModels:
         *,
         released_view: bool = False,
         validation_summary: dict[str, Any] | None = None,
+        default_symbol_asset_id: str = "",
+        default_footprint_asset_id: str = "",
     ) -> dict[str, Any]:
+        assets_by_id = {str(asset["id"]): asset for asset in assets}
+        symbol_asset = assets_by_id.get(str(default_symbol_asset_id or ""))
+        footprint_asset = assets_by_id.get(str(default_footprint_asset_id or ""))
         availability_state, missing_assets, place_enabled = self.availability(
             assets,
             str(revision_row["release_status"]),
             bool(component_row["is_active"]),
+            default_symbol=symbol_asset,
+            default_footprint=footprint_asset,
+            identity_kind=str(component_row.get("identity_kind") or IDENTITY_KIND_MPN),
         )
-        if str(component_row.get("identity_kind") or IDENTITY_KIND_MPN) != IDENTITY_KIND_MPN:
-            place_enabled = False
-        symbol_asset = next((asset for asset in assets if asset["asset_type"] == "symbol"), None)
         # Lightweight payloads are used by the KiCad remote panel; avoid validation lookups on search paths.
         validation_summary = validation_summary or {
             "status": VALIDATION_STATUS_NOT_RUN,
@@ -784,6 +825,9 @@ class CatalogComponentReadModels:
 
 __all__ = [
     "CatalogComponentReadModels",
+    "cad_availability",
+    "remote_place_enabled",
+    "representation_slot_present",
     "supply_source_payload",
     "SUPPLY_KIND_VENDOR",
     "SUPPLY_KIND_LOCAL",

--- a/backend/app/services/catalog/remote_heads.py
+++ b/backend/app/services/catalog/remote_heads.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 from typing import Any
 
 from app.services.catalog.component_read_models import (
-    STATE_FILES_PARTIAL,
-    STATE_METADATA_ONLY,
-    STATE_PLACE_READY,
+    cad_availability,
+    remote_place_enabled,
     supply_source_payload,
 )
 from app.services.catalog.metadata_normalization import IDENTITY_KIND_MPN
@@ -31,15 +30,7 @@ def remote_head_payload(raw: Any) -> dict[str, Any]:
     has_symbol = bool(row.get("has_symbol"))
     has_footprint = bool(row.get("has_footprint"))
     identity_kind = str(row.get("identity_kind") or IDENTITY_KIND_MPN)
-    missing_assets = [
-        kind for kind, present in (("symbol", has_symbol), ("footprint", has_footprint)) if not present
-    ]
-    if has_symbol and has_footprint:
-        availability_state = STATE_PLACE_READY
-    elif has_symbol or has_footprint:
-        availability_state = STATE_FILES_PARTIAL
-    else:
-        availability_state = STATE_METADATA_ONLY
+    availability_state, missing_assets = cad_availability(has_symbol, has_footprint)
     assets: list[dict[str, Any]] = []
     if has_symbol:
         assets.append(
@@ -83,7 +74,12 @@ def remote_head_payload(raw: Any) -> dict[str, Any]:
         "previews": previews,
         "availability_state": availability_state,
         "missing_assets": missing_assets,
-        "place_enabled": has_symbol and has_footprint and identity_kind == IDENTITY_KIND_MPN,
+        "place_enabled": remote_place_enabled(
+            is_active=True,
+            identity_kind=identity_kind,
+            missing_assets=missing_assets,
+            release_status="released",
+        ),
         "release_status": "released",
         "workflow_stage": "released",
         "supply": {

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -640,9 +640,6 @@ class ComponentCatalogDomainService:
             preloaded_runs=preloaded_runs,
         )
 
-    def _availability(self, assets: list[dict[str, Any]], release_status: str, is_active: bool) -> tuple[str, list[str], bool]:
-        return self._component_read_models.availability(assets, release_status, is_active)
-
     def _component_payload(
         self,
         conn: Any,

--- a/backend/tests/test_catalog_availability.py
+++ b/backend/tests/test_catalog_availability.py
@@ -1,0 +1,161 @@
+"""CAD availability is the default representation pair, not any attached assets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.catalog.component_queries import CatalogComponentQueries  # noqa: E402
+from app.services.catalog.component_read_models import (  # noqa: E402
+    CatalogComponentReadModels,
+    cad_availability,
+    remote_place_enabled,
+)
+from app.services.catalog.metadata_normalization import (  # noqa: E402
+    IDENTITY_KIND_MPN,
+    IDENTITY_KIND_PROVISIONAL_IPN,
+)
+
+
+class CadAvailabilityContractTests(unittest.TestCase):
+    def test_pair_completeness_matches_named_states(self) -> None:
+        self.assertEqual(cad_availability(False, False), ("metadata_only", ["symbol", "footprint"]))
+        self.assertEqual(cad_availability(True, False), ("files_partial", ["footprint"]))
+        self.assertEqual(cad_availability(False, True), ("files_partial", ["symbol"]))
+        self.assertEqual(cad_availability(True, True), ("place_ready", []))
+
+    def test_place_enabled_stays_distinct_from_cad_completeness(self) -> None:
+        complete: list[str] = []
+        self.assertTrue(
+            remote_place_enabled(
+                is_active=True,
+                identity_kind=IDENTITY_KIND_MPN,
+                missing_assets=complete,
+                release_status="released",
+            )
+        )
+        self.assertFalse(
+            remote_place_enabled(
+                is_active=True,
+                identity_kind=IDENTITY_KIND_MPN,
+                missing_assets=complete,
+                release_status="in_progress",
+            )
+        )
+        self.assertFalse(
+            remote_place_enabled(
+                is_active=False,
+                identity_kind=IDENTITY_KIND_MPN,
+                missing_assets=complete,
+                release_status="released",
+            )
+        )
+        self.assertFalse(
+            remote_place_enabled(
+                is_active=True,
+                identity_kind=IDENTITY_KIND_PROVISIONAL_IPN,
+                missing_assets=complete,
+                release_status="released",
+            )
+        )
+        self.assertFalse(
+            remote_place_enabled(
+                is_active=True,
+                identity_kind=IDENTITY_KIND_MPN,
+                missing_assets=["footprint"],
+                release_status="released",
+            )
+        )
+
+
+class CatalogAvailabilityQueryTests(unittest.TestCase):
+    def test_filters_and_sort_use_the_default_representation(self) -> None:
+        queries = CatalogComponentQueries(component_read_models=object())  # type: ignore[arg-type]
+        for state in ("place_ready", "files_partial", "metadata_only"):
+            plan = queries.prepare_list_components(availability_state=state)
+            self.assertIn("revision_representations", plan.where_sql)
+            self.assertIn("is_default = 1", plan.where_sql)
+            self.assertNotIn("revision_assets", plan.where_sql)
+        sort_plan = queries.prepare_list_components(sort_by="availability_state")
+        self.assertIn("revision_representations", sort_plan.order_sql)
+        self.assertIn("is_default = 1", sort_plan.order_sql)
+        self.assertNotIn("revision_assets", sort_plan.order_sql)
+
+
+class CatalogAvailabilitySummaryTests(unittest.TestCase):
+    def test_summary_follows_an_incomplete_default_despite_attached_assets(self) -> None:
+        models = CatalogComponentReadModels(revision_kernel=object())  # type: ignore[arg-type]
+        component = {
+            "id": "c1",
+            "slug": "c1",
+            "source": "manual",
+            "identity_kind": IDENTITY_KIND_MPN,
+            "is_active": 1,
+            "updated_at": "t",
+        }
+        revision = {
+            "id": "r1",
+            "name": "R",
+            "value": "",
+            "manufacturer": "M",
+            "mpn": "P",
+            "description": "",
+            "package_name": "",
+            "category": "",
+            "datasheet_url": "",
+            "vendor": "",
+            "vendor_part_number": "",
+            "mass_g": "",
+            "rqjc_c_w": "",
+            "rqjc_top_c_w": "",
+            "temp_max_c": "",
+            "temp_min_c": "",
+            "power_dissipation_w": "",
+            "rate": "",
+            "sap_code": "",
+            "extra_fields": "{}",
+            "summary": "",
+            "version": 1,
+            "release_status": "draft",
+            "updated_at": "t",
+            "created_by": "",
+        }
+        assets = [
+            {
+                "id": "sym-default",
+                "asset_type": "symbol",
+                "target_library": "Def",
+                "target_name": "S1",
+            },
+            {
+                "id": "sym-other",
+                "asset_type": "symbol",
+                "target_library": "Other",
+                "target_name": "S2",
+            },
+            {
+                "id": "fp-other",
+                "asset_type": "footprint",
+                "target_library": "Other",
+                "target_name": "F2",
+            },
+        ]
+        payload = models.component_summary_payload(
+            component,
+            revision,
+            assets,
+            default_symbol_asset_id="sym-default",
+            default_footprint_asset_id="",
+        )
+        self.assertEqual(payload["availability_state"], "files_partial")
+        self.assertEqual(payload["missing_assets"], ["footprint"])
+        self.assertFalse(payload["place_enabled"])
+        self.assertEqual(payload["library_name"], "Def")
+        self.assertEqual(payload["symbol_name"], "S1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_catalog_availability.py
+++ b/backend/tests/test_catalog_availability.py
@@ -8,7 +8,13 @@ import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from app.services.catalog.component_queries import CatalogComponentQueries  # noqa: E402
+from app.services.catalog.asset_types import PLACE_REQUIRED_ASSET_TYPES  # noqa: E402
+from app.services.catalog.component_queries import (  # noqa: E402
+    CatalogComponentQueries,
+    REPRESENTATION_ASSET_COLUMNS,
+    default_rep_slot_present,
+    default_representation_has_asset,
+)
 from app.services.catalog.component_read_models import (  # noqa: E402
     CatalogComponentReadModels,
     cad_availability,
@@ -20,12 +26,72 @@ from app.services.catalog.metadata_normalization import (  # noqa: E402
 )
 
 
+def _summary_rows() -> tuple[dict[str, object], dict[str, object], list[dict[str, str]]]:
+    component = {
+        "id": "c1",
+        "slug": "c1",
+        "source": "manual",
+        "identity_kind": IDENTITY_KIND_MPN,
+        "is_active": 1,
+        "updated_at": "t",
+    }
+    revision = {
+        "id": "r1",
+        "name": "R",
+        "value": "",
+        "manufacturer": "M",
+        "mpn": "P",
+        "description": "",
+        "package_name": "",
+        "category": "",
+        "datasheet_url": "",
+        "vendor": "",
+        "vendor_part_number": "",
+        "mass_g": "",
+        "rqjc_c_w": "",
+        "rqjc_top_c_w": "",
+        "temp_max_c": "",
+        "temp_min_c": "",
+        "power_dissipation_w": "",
+        "rate": "",
+        "sap_code": "",
+        "extra_fields": "{}",
+        "summary": "",
+        "version": 1,
+        "release_status": "draft",
+        "updated_at": "t",
+        "created_by": "",
+    }
+    assets = [
+        {
+            "id": "sym-default",
+            "asset_type": "symbol",
+            "target_library": "Def",
+            "target_name": "S1",
+        },
+        {
+            "id": "sym-other",
+            "asset_type": "symbol",
+            "target_library": "Other",
+            "target_name": "S2",
+        },
+        {
+            "id": "fp-other",
+            "asset_type": "footprint",
+            "target_library": "Other",
+            "target_name": "F2",
+        },
+    ]
+    return component, revision, assets
+
+
 class CadAvailabilityContractTests(unittest.TestCase):
     def test_pair_completeness_matches_named_states(self) -> None:
         self.assertEqual(cad_availability(False, False), ("metadata_only", ["symbol", "footprint"]))
         self.assertEqual(cad_availability(True, False), ("files_partial", ["footprint"]))
         self.assertEqual(cad_availability(False, True), ("files_partial", ["symbol"]))
         self.assertEqual(cad_availability(True, True), ("place_ready", []))
+        self.assertEqual(cad_availability(False, False)[1], list(PLACE_REQUIRED_ASSET_TYPES))
 
     def test_place_enabled_stays_distinct_from_cad_completeness(self) -> None:
         complete: list[str] = []
@@ -72,77 +138,53 @@ class CadAvailabilityContractTests(unittest.TestCase):
 
 
 class CatalogAvailabilityQueryTests(unittest.TestCase):
-    def test_filters_and_sort_use_the_default_representation(self) -> None:
+    def test_sql_columns_cover_required_asset_types(self) -> None:
+        self.assertEqual(set(REPRESENTATION_ASSET_COLUMNS), set(PLACE_REQUIRED_ASSET_TYPES))
+        symbol_sql = default_representation_has_asset("cr", "symbol", "alias_sym")
+        self.assertIn("revision_representations alias_sym", symbol_sql)
+        self.assertIn("alias_sym.is_default = 1", symbol_sql)
+        self.assertIn("COALESCE(alias_sym.symbol_asset_id, '') <> ''", symbol_sql)
+        self.assertNotIn("revision_assets", symbol_sql)
+        self.assertEqual(
+            default_rep_slot_present("footprint"),
+            "COALESCE(default_rep.footprint_asset_id, '') <> ''",
+        )
+
+    def test_filters_encode_each_availability_state(self) -> None:
         queries = CatalogComponentQueries(component_read_models=object())  # type: ignore[arg-type]
-        for state in ("place_ready", "files_partial", "metadata_only"):
-            plan = queries.prepare_list_components(availability_state=state)
-            self.assertIn("revision_representations", plan.where_sql)
-            self.assertIn("is_default = 1", plan.where_sql)
-            self.assertNotIn("revision_assets", plan.where_sql)
-        sort_plan = queries.prepare_list_components(sort_by="availability_state")
-        self.assertIn("revision_representations", sort_plan.order_sql)
-        self.assertIn("is_default = 1", sort_plan.order_sql)
-        self.assertNotIn("revision_assets", sort_plan.order_sql)
+        ready = queries.prepare_list_components(availability_state="place_ready")
+        self.assertIn(
+            "COALESCE(rr_avail_symbol.symbol_asset_id, '') <> ''",
+            ready.where_sql,
+        )
+        self.assertIn(
+            "COALESCE(rr_avail_footprint.footprint_asset_id, '') <> ''",
+            ready.where_sql,
+        )
+        self.assertIn("AND", ready.where_sql)
+        self.assertNotIn("revision_assets", ready.where_sql)
+
+        partial = queries.prepare_list_components(availability_state="files_partial")
+        self.assertIn("<>", partial.where_sql)
+        self.assertNotIn("NOT EXISTS", partial.where_sql)
+
+        empty = queries.prepare_list_components(availability_state="metadata_only")
+        self.assertIn("NOT EXISTS", empty.where_sql)
+        self.assertIn("AND NOT EXISTS", empty.where_sql)
+
+    def test_availability_sort_reads_the_joined_default_representation(self) -> None:
+        queries = CatalogComponentQueries(component_read_models=object())  # type: ignore[arg-type]
+        plan = queries.prepare_list_components(sort_by="availability_state")
+        self.assertIn("COALESCE(default_rep.symbol_asset_id, '') <> ''", plan.order_sql)
+        self.assertIn("COALESCE(default_rep.footprint_asset_id, '') <> ''", plan.order_sql)
+        self.assertNotIn("EXISTS", plan.order_sql)
+        self.assertNotIn("revision_assets", plan.order_sql)
 
 
 class CatalogAvailabilitySummaryTests(unittest.TestCase):
     def test_summary_follows_an_incomplete_default_despite_attached_assets(self) -> None:
         models = CatalogComponentReadModels(revision_kernel=object())  # type: ignore[arg-type]
-        component = {
-            "id": "c1",
-            "slug": "c1",
-            "source": "manual",
-            "identity_kind": IDENTITY_KIND_MPN,
-            "is_active": 1,
-            "updated_at": "t",
-        }
-        revision = {
-            "id": "r1",
-            "name": "R",
-            "value": "",
-            "manufacturer": "M",
-            "mpn": "P",
-            "description": "",
-            "package_name": "",
-            "category": "",
-            "datasheet_url": "",
-            "vendor": "",
-            "vendor_part_number": "",
-            "mass_g": "",
-            "rqjc_c_w": "",
-            "rqjc_top_c_w": "",
-            "temp_max_c": "",
-            "temp_min_c": "",
-            "power_dissipation_w": "",
-            "rate": "",
-            "sap_code": "",
-            "extra_fields": "{}",
-            "summary": "",
-            "version": 1,
-            "release_status": "draft",
-            "updated_at": "t",
-            "created_by": "",
-        }
-        assets = [
-            {
-                "id": "sym-default",
-                "asset_type": "symbol",
-                "target_library": "Def",
-                "target_name": "S1",
-            },
-            {
-                "id": "sym-other",
-                "asset_type": "symbol",
-                "target_library": "Other",
-                "target_name": "S2",
-            },
-            {
-                "id": "fp-other",
-                "asset_type": "footprint",
-                "target_library": "Other",
-                "target_name": "F2",
-            },
-        ]
+        component, revision, assets = _summary_rows()
         payload = models.component_summary_payload(
             component,
             revision,
@@ -155,6 +197,30 @@ class CatalogAvailabilitySummaryTests(unittest.TestCase):
         self.assertFalse(payload["place_enabled"])
         self.assertEqual(payload["library_name"], "Def")
         self.assertEqual(payload["symbol_name"], "S1")
+
+    def test_summary_lib_id_is_empty_without_a_default_symbol(self) -> None:
+        models = CatalogComponentReadModels(revision_kernel=object())  # type: ignore[arg-type]
+        component, revision, assets = _summary_rows()
+        payload = models.component_summary_payload(
+            component,
+            revision,
+            assets,
+            default_symbol_asset_id="",
+            default_footprint_asset_id="",
+        )
+        self.assertEqual(payload["availability_state"], "metadata_only")
+        self.assertEqual(payload["missing_assets"], ["symbol", "footprint"])
+        self.assertEqual(payload["library_name"], "")
+        self.assertEqual(payload["symbol_name"], "")
+
+    def test_availability_rejects_the_historical_assets_argument(self) -> None:
+        models = CatalogComponentReadModels(revision_kernel=object())  # type: ignore[arg-type]
+        with self.assertRaises(TypeError):
+            models.availability(  # type: ignore[misc]
+                [{"id": "a1", "asset_type": "symbol"}],
+                "released",
+                True,
+            )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -1372,6 +1372,16 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
             missing=["footprint"],
             place_enabled=False,
         )
+        before_queue = self.service.release_queue_summary()
+        self.service.set_release_status(
+            str(mismatched["id"]), "in_progress", actor="designer@example.com"
+        )
+        self.service.set_release_status(
+            str(mismatched["id"]), "qa_review", actor="designer@example.com"
+        )
+        queued = self.service.release_queue_summary()
+        self.assertEqual(queued["qa_review"], before_queue["qa_review"] + 1)
+        self.assertEqual(queued["blocked"], before_queue["blocked"] + 1)
 
         ready = self._complete_cad(
             self._component("avail-ready-" + uuid.uuid4().hex[:8]),

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -1234,6 +1234,232 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
                 )
                 conn.commit()
 
+    def _import_symbol(self, component_id: str, name: str) -> dict:
+        payload = f'''(kicad_symbol_lib (version 20231120) (generator "test")
+          (symbol "{name}"
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "{name}" (at 0 0 0) (effects (font (size 1.27 1.27))))
+          )
+        )'''.encode()
+        return self.service.import_symbol_library(
+            component_id,
+            upload_name=f"{name}.kicad_sym",
+            payload=payload,
+            target_library="Availability",
+            selected_symbol=name,
+            actor="designer@example.com",
+        )["component"]
+
+    def _import_footprint(self, component_id: str, name: str) -> dict:
+        return self.service.import_footprint(
+            component_id,
+            upload_name=f"{name}.kicad_mod",
+            payload=f'(footprint "{name}" (version 20240108) (generator "test"))'.encode(),
+            target_library="Availability",
+            selected_footprint=name,
+            actor="designer@example.com",
+        )["component"]
+
+    def _complete_cad(self, component: dict, name: str) -> dict:
+        after_symbol = self._import_symbol(str(component["id"]), name)
+        return self._import_footprint(str(after_symbol["id"]), name)
+
+    def _listed(
+        self,
+        component_id: str,
+        *,
+        lightweight: bool = False,
+        include_inactive: bool = False,
+        **kwargs: object,
+    ) -> dict:
+        detail = self.service.get_component(component_id, include_inactive=True)
+        assert detail is not None
+        page = self.service.list_components(
+            query=str(detail.get("mpn") or detail.get("name") or ""),
+            page=1,
+            page_size=50,
+            lightweight=lightweight,
+            include_inactive=include_inactive,
+            **kwargs,
+        )
+        match = next((item for item in page["items"] if item["id"] == component_id), None)
+        self.assertIsNotNone(match, f"{component_id} missing from list {kwargs}")
+        return match or {}
+
+    def _assert_availability(
+        self,
+        component_id: str,
+        *,
+        state: str,
+        missing: list[str],
+        place_enabled: bool,
+        include_inactive: bool = False,
+    ) -> None:
+        detail = self.service.get_component(component_id, include_inactive=include_inactive)
+        assert detail is not None
+        summary = self._listed(
+            component_id, lightweight=True, include_inactive=include_inactive
+        )
+        full_list = self._listed(
+            component_id, lightweight=False, include_inactive=include_inactive
+        )
+        for payload in (detail, summary, full_list):
+            self.assertEqual(payload["availability_state"], state)
+            self.assertEqual(payload["missing_assets"], missing)
+            self.assertEqual(payload["place_enabled"], place_enabled)
+        filtered = self.service.list_components(
+            query=str(detail.get("mpn") or detail.get("name") or ""),
+            availability_state=state,
+            page=1,
+            page_size=50,
+            include_inactive=include_inactive,
+        )
+        self.assertIn(component_id, {item["id"] for item in filtered["items"]})
+        other_states = {"metadata_only", "files_partial", "place_ready"} - {state}
+        for other in other_states:
+            other_page = self.service.list_components(
+                query=str(detail.get("mpn") or detail.get("name") or ""),
+                availability_state=other,
+                page=1,
+                page_size=50,
+                include_inactive=include_inactive,
+            )
+            self.assertNotIn(component_id, {item["id"] for item in other_page["items"]})
+
+    def test_availability_agrees_across_filter_summary_and_detail(self) -> None:
+        metadata = self._component("avail-meta-" + uuid.uuid4().hex[:8])
+        self._assert_availability(
+            str(metadata["id"]),
+            state="metadata_only",
+            missing=["symbol", "footprint"],
+            place_enabled=False,
+        )
+
+        partial = self._import_symbol(
+            str(self._component("avail-partial-" + uuid.uuid4().hex[:8])["id"]),
+            "PartialSym",
+        )
+        self._assert_availability(
+            str(partial["id"]),
+            state="files_partial",
+            missing=["footprint"],
+            place_enabled=False,
+        )
+
+        complete = self._complete_cad(
+            self._component("avail-complete-" + uuid.uuid4().hex[:8]),
+            "Complete",
+        )
+        default_symbol_id = next(
+            item["symbol"]["id"]
+            for item in complete["representations"]
+            if item.get("is_default") and item.get("symbol")
+        )
+        mismatched = self.service.create_representation(
+            str(complete["id"]),
+            label="Incomplete default",
+            symbol_asset_id=default_symbol_id,
+            make_default=True,
+            expected_revision_id=str(complete["revision_id"]),
+            actor="designer@example.com",
+        )
+        self.assertTrue(
+            any(asset["asset_type"] == "footprint" for asset in mismatched["assets"])
+        )
+        self._assert_availability(
+            str(mismatched["id"]),
+            state="files_partial",
+            missing=["footprint"],
+            place_enabled=False,
+        )
+
+        ready = self._complete_cad(
+            self._component("avail-ready-" + uuid.uuid4().hex[:8]),
+            "Ready",
+        )
+        self._assert_availability(
+            str(ready["id"]),
+            state="place_ready",
+            missing=[],
+            place_enabled=False,
+        )
+
+        token = uuid.uuid4().hex[:8]
+        provisional = self._complete_cad(
+            self.service.create_manual_component(
+                name=f"IPN-{token}",
+                value="provisional",
+                description="Provisional availability fixture",
+                datasheet="https://example.com/provisional.pdf",
+                manufacturer="Prism Availability",
+                manufacturer_part_number="",
+                identity_kind="provisional_ipn",
+                identity_source="fixture",
+                source_internal_part_number=f"IPN-{token}",
+                actor="author@example.com",
+            ),
+            "Provisional",
+        )
+        self.component_ids.append(str(provisional["id"]))
+        self._assert_availability(
+            str(provisional["id"]),
+            state="place_ready",
+            missing=[],
+            place_enabled=False,
+        )
+
+        inactive = self._complete_cad(
+            self._component("avail-inactive-" + uuid.uuid4().hex[:8]),
+            "Inactive",
+        )
+        self.assertTrue(
+            self.service.deactivate_component(
+                str(inactive["id"]), actor="author@example.com", reason="availability fixture"
+            )
+        )
+        hidden = self.service.list_components(page=1, page_size=100, include_inactive=False)
+        self.assertNotIn(str(inactive["id"]), {item["id"] for item in hidden["items"]})
+        self._assert_availability(
+            str(inactive["id"]),
+            state="place_ready",
+            missing=[],
+            place_enabled=False,
+            include_inactive=True,
+        )
+
+        released = self._complete_cad(
+            self._component("avail-released-" + uuid.uuid4().hex[:8]),
+            "Released",
+        )
+        self.service.set_release_status(
+            str(released["id"]), "in_progress", actor="designer@example.com"
+        )
+        self.service.set_release_status(
+            str(released["id"]), "qa_review", actor="designer@example.com"
+        )
+        current = self.service.get_component(str(released["id"]))
+        assert current is not None
+        approved = self.service.set_release_status(
+            str(released["id"]),
+            "done",
+            actor="qa@example.com",
+            expected_revision_id=current["revision_id"],
+            expected_manifest_hash=current["manifest_hash"],
+        )
+        self.service.set_release_status(
+            str(released["id"]),
+            "released",
+            actor="designer@example.com",
+            expected_revision_id=approved["revision_id"],
+            expected_manifest_hash=approved["manifest_hash"],
+        )
+        self._assert_availability(
+            str(released["id"]),
+            state="place_ready",
+            missing=[],
+            place_enabled=True,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Catalog list filters, CAD-state sorting, and lightweight summaries now use the same representation-aware completeness contract as component detail: the default symbol/footprint pair, not any attached assets of those types.
- `place_enabled` stays a separate authorization check (active + MPN identity + released). Incomplete defaults with extra attached CAD no longer appear as place-ready in the grid.
- Lightweight `library_name` / `symbol_name` now follow that same default pair, matching detail. Rows with no default symbol return empty strings instead of the first attached symbol.
- Review follow-up: removed the unused `_availability` facade wrapper (it would have classified every component as `metadata_only`), aligned the release-queue blocked counter with the default representation, reused the shared helpers in remote heads, and sorted availability from the existing `default_rep` join.

## Test plan
- [x] `python3 scripts/check_catalog_architecture.py`
- [x] `backend/venv/bin/python -m unittest backend.tests.test_catalog_availability backend.tests.test_catalog_architecture backend.tests.test_catalog_component_writer`
- [x] `TEST_POSTGRES_URL=... backend/venv/bin/python -m unittest backend.tests.test_component_catalog_postgres_integration`
- [ ] GitHub `dev` quality gate on this PR
- [ ] Confirm a component with an incomplete default representation and an extra attached footprint filters as `files_partial` in the catalog grid, on the detail page, and in the release-queue Evidence blockers count