### PR TITLE
fix(catalog): require a revision precondition for asset uploads and links

### DIFF
--- a/backend/app/api/catalog_admin.py
+++ b/backend/app/api/catalog_admin.py
@@ -1079,7 +1079,7 @@ async def import_symbol_library(
     file: UploadFile = File(...),
     target_library: str = Form(default=""),
     selected_symbol: str = Form(default=""),
-    counterpart_asset_id: str = Form(default=""),
+    counterpart_asset_id: str = Form(default=""), expected_revision_id: str = Form(default=""),
     user: AuthenticatedUser = Depends(require_catalog_writer),
 ):
     payload = await file.read()
@@ -1094,10 +1094,10 @@ async def import_symbol_library(
             target_library=target_library or component_id,
             selected_symbol=selected_symbol,
             counterpart_asset_id=counterpart_asset_id,
-            actor=user.email,
+            actor=user.email, expected_revision_id=expected_revision_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=409 if "revision conflict" in str(exc).lower() else 400, detail=str(exc)) from exc
 
 
 @router.post("/components/{component_id}/footprint-import")
@@ -1106,7 +1106,7 @@ async def import_footprint(
     file: UploadFile = File(...),
     target_library: str = Form(default=""),
     selected_footprint: str = Form(default=""),
-    counterpart_asset_id: str = Form(default=""),
+    counterpart_asset_id: str = Form(default=""), expected_revision_id: str = Form(default=""),
     user: AuthenticatedUser = Depends(require_catalog_writer),
 ):
     payload = await file.read()
@@ -1121,10 +1121,10 @@ async def import_footprint(
             target_library=target_library or "Prism_Footprints",
             selected_footprint=selected_footprint,
             counterpart_asset_id=counterpart_asset_id,
-            actor=user.email,
+            actor=user.email, expected_revision_id=expected_revision_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=409 if "revision conflict" in str(exc).lower() else 400, detail=str(exc)) from exc
 
 
 @router.post("/components/{component_id}/assets/{asset_type}")
@@ -1132,7 +1132,7 @@ async def import_auxiliary_asset(
     component_id: str,
     asset_type: str,
     file: UploadFile = File(...),
-    target_library: str = Form(default=""),
+    target_library: str = Form(default=""), expected_revision_id: str = Form(default=""),
     user: AuthenticatedUser = Depends(require_catalog_writer),
 ):
     payload = await file.read()
@@ -1146,10 +1146,10 @@ async def import_auxiliary_asset(
             upload_name=file.filename or f"{asset_type}.bin",
             payload=payload,
             target_library=target_library or "Prism_Assets",
-            actor=user.email,
+            actor=user.email, expected_revision_id=expected_revision_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=409 if "revision conflict" in str(exc).lower() else 400, detail=str(exc)) from exc
 
 
 @router.delete("/components/{component_id}/assets/{asset_type}")
@@ -1575,7 +1575,7 @@ class LinkAssetRequest(BaseModel):
     target_library: str = ""
     target_name: str = ""
     counterpart_asset_id: str = ""
-
+    expected_revision_id: str = ""
 
 @router.post("/components/{component_id}/assets/{asset_type}/link")
 def link_library_asset(
@@ -1593,7 +1593,7 @@ def link_library_asset(
             target_library=payload.target_library,
             target_name=payload.target_name,
             counterpart_asset_id=payload.counterpart_asset_id,
-            actor=user.email,
+            actor=user.email, expected_revision_id=payload.expected_revision_id,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=409 if "revision conflict" in str(exc).lower() else 400, detail=str(exc)) from exc

--- a/backend/app/services/catalog/asset_imports.py
+++ b/backend/app/services/catalog/asset_imports.py
@@ -67,6 +67,14 @@ class CatalogAssetImports:
         self._asset_files = asset_files or CatalogAssetFiles()
         self._asset_registry = asset_registry or CatalogAssetRegistry()
 
+    def _require_expected_revision(self, conn: Any, component_id: str, expected_revision_id: str = "") -> None:
+        if not expected_revision_id:
+            return
+        _, current = self._revision_kernel.active_revision_row(conn, component_id, released=False)
+        if not current:
+            raise ValueError("Component not found")
+        self._revision_kernel.assert_expected_revision(str(current["id"]), expected_revision_id)
+
     # -- pure upload shaping --------------------------------------------------
 
     @staticmethod
@@ -189,9 +197,11 @@ class CatalogAssetImports:
         *,
         counterpart_asset_id: str = "",
         actor: str = "",
+        expected_revision_id: str = "",
     ) -> dict[str, Any]:
         if asset_type not in SUPPORTED_ASSET_TYPES:
             raise ValueError("Unsupported asset type")
+        self._require_expected_revision(conn, component_id, expected_revision_id)
         asset = self.resolve_existing_asset(
             conn,
             runtime,
@@ -209,6 +219,7 @@ class CatalogAssetImports:
             actor=actor,
             change_summary=f"Link {asset_type} asset",
             counterpart_asset_id=counterpart_asset_id,
+            expected_revision_id=expected_revision_id,
         )
         return asset
 
@@ -226,8 +237,10 @@ class CatalogAssetImports:
         selected_symbol: str,
         counterpart_asset_id: str = "",
         actor: str = "",
+        expected_revision_id: str = "",
     ) -> dict[str, Any]:
         """Import one symbol; ``mode`` is ``selection_required`` until a symbol is chosen."""
+        self._require_expected_revision(conn, component_id, expected_revision_id)
         normalized = self.normalize_symbol_upload(runtime, upload_name, payload)
         text = normalized.decode("utf-8", errors="ignore")
         discovered = discover_symbol_names_in_text(text)
@@ -260,6 +273,7 @@ class CatalogAssetImports:
             actor=actor,
             change_summary=f"Import symbol {chosen}",
             counterpart_asset_id=counterpart_asset_id,
+            expected_revision_id=expected_revision_id,
         )
         return {"mode": "imported", "discovered_symbols": discovered, "selected_symbol": chosen}
 
@@ -275,7 +289,9 @@ class CatalogAssetImports:
         selected_footprint: str,
         counterpart_asset_id: str = "",
         actor: str = "",
+        expected_revision_id: str = "",
     ) -> dict[str, Any]:
+        self._require_expected_revision(conn, component_id, expected_revision_id)
         discovered = self.extract_footprints_from_upload(upload_name, payload)
         names = sorted(discovered)
         if not names:
@@ -306,6 +322,7 @@ class CatalogAssetImports:
             actor=actor,
             change_summary=f"Import footprint {chosen}",
             counterpart_asset_id=counterpart_asset_id,
+            expected_revision_id=expected_revision_id,
         )
         return {"mode": "imported", "discovered_footprints": names, "selected_footprint": chosen}
 
@@ -320,9 +337,11 @@ class CatalogAssetImports:
         payload: bytes,
         target_library: str,
         actor: str = "",
+        expected_revision_id: str = "",
     ) -> dict[str, Any]:
         if asset_type not in AUXILIARY_ASSET_TYPES:
             raise ValueError("Unsupported auxiliary asset type")
+        self._require_expected_revision(conn, component_id, expected_revision_id)
         library = target_library or DEFAULT_AUXILIARY_LIBRARY
         destination = self._asset_files.write_canonical_file(
             runtime,
@@ -345,6 +364,7 @@ class CatalogAssetImports:
             required=False,
             actor=actor,
             change_summary=f"Import {asset_type} asset {destination.name}",
+            expected_revision_id=expected_revision_id,
         )
         return asset
 

--- a/backend/app/services/catalog/asset_links.py
+++ b/backend/app/services/catalog/asset_links.py
@@ -175,6 +175,7 @@ class CatalogAssetLinks:
         actor: str,
         change_summary: str,
         counterpart_asset_id: str = "",
+        expected_revision_id: str = "",
     ) -> dict[str, Any]:
         """Attach ``asset`` to the component's current draft, cloning when needed.
 
@@ -185,6 +186,7 @@ class CatalogAssetLinks:
         if not current:
             raise ValueError("Component not found")
         current_id = str(current["id"])
+        self._revision_kernel.assert_expected_revision(current_id, expected_revision_id)
         asset_type = str(asset["asset_type"])
         asset_id = str(asset["id"])
         existing = conn.execute(
@@ -221,6 +223,7 @@ class CatalogAssetLinks:
             actor=actor,
             change_kind="asset",
             change_summary=change_summary,
+            expected_revision_id=expected_revision_id,
         )
         self.link_asset_to_revision(
             conn,

--- a/backend/app/services/catalog/revision_kernel.py
+++ b/backend/app/services/catalog/revision_kernel.py
@@ -202,6 +202,12 @@ class CatalogRevisionKernel:
         canonical = canonical_json(payload)
         return sha256_text(canonical)
 
+    @staticmethod
+    def assert_expected_revision(current_id: str, expected_revision_id: str = "") -> None:
+        # Empty expected_revision_id is the legacy skip used by older callers.
+        if expected_revision_id and current_id != expected_revision_id:
+            raise ValueError("Component revision conflict: refresh the component before saving")
+
     def clone_revision(
         self,
         conn: Any,
@@ -216,8 +222,7 @@ class CatalogRevisionKernel:
         component, current = self.active_revision_row(conn, component_id, released=False)
         if not component or not current:
             raise ValueError("Component not found")
-        if expected_revision_id and str(current["id"]) != expected_revision_id:
-            raise ValueError("Component revision conflict: refresh the component before saving")
+        self.assert_expected_revision(str(current["id"]), expected_revision_id)
 
         now = _utc_now_iso()
         next_version = int(

--- a/backend/app/services/component_catalog_domain.py
+++ b/backend/app/services/component_catalog_domain.py
@@ -1724,7 +1724,7 @@ class ComponentCatalogDomainService:
         target_name: str,
         *,
         counterpart_asset_id: str = "",
-        actor: str = "",
+        actor: str = "", expected_revision_id: str = "",
     ) -> dict[str, Any]:
         if asset_type not in SUPPORTED_ASSET_TYPES:
             raise ValueError("Unsupported asset type")
@@ -1739,7 +1739,7 @@ class ComponentCatalogDomainService:
                 target_library,
                 target_name,
                 counterpart_asset_id=counterpart_asset_id,
-                actor=actor,
+                actor=actor, expected_revision_id=expected_revision_id,
             )
             conn.commit()
         return {"component": self.get_component(component_id)}
@@ -1758,7 +1758,7 @@ class ComponentCatalogDomainService:
         target_library: str,
         selected_symbol: str,
         counterpart_asset_id: str = "",
-        actor: str = "",
+        actor: str = "", expected_revision_id: str = "",
     ) -> dict[str, Any]:
         self.initialize()
         with self._connect() as conn:
@@ -1771,7 +1771,7 @@ class ComponentCatalogDomainService:
                 target_library=target_library,
                 selected_symbol=selected_symbol,
                 counterpart_asset_id=counterpart_asset_id,
-                actor=actor,
+                actor=actor, expected_revision_id=expected_revision_id,
             )
             if result["mode"] == "imported":
                 conn.commit()
@@ -1791,7 +1791,7 @@ class ComponentCatalogDomainService:
         target_library: str,
         selected_footprint: str,
         counterpart_asset_id: str = "",
-        actor: str = "",
+        actor: str = "", expected_revision_id: str = "",
     ) -> dict[str, Any]:
         self.initialize()
         with self._connect() as conn:
@@ -1804,7 +1804,7 @@ class ComponentCatalogDomainService:
                 target_library=target_library,
                 selected_footprint=selected_footprint,
                 counterpart_asset_id=counterpart_asset_id,
-                actor=actor,
+                actor=actor, expected_revision_id=expected_revision_id,
             )
             if result["mode"] == "imported":
                 conn.commit()
@@ -1820,7 +1820,7 @@ class ComponentCatalogDomainService:
         upload_name: str,
         payload: bytes,
         target_library: str,
-        actor: str = "",
+        actor: str = "", expected_revision_id: str = "",
     ) -> dict[str, Any]:
         if asset_type not in {"3dmodel", "spice"}:
             raise ValueError("Unsupported auxiliary asset type")
@@ -1834,7 +1834,7 @@ class ComponentCatalogDomainService:
                 upload_name=upload_name,
                 payload=payload,
                 target_library=target_library,
-                actor=actor,
+                actor=actor, expected_revision_id=expected_revision_id,
             )
             conn.commit()
         return {"component": self.get_component(component_id)}

--- a/backend/tests/test_catalog_admin_permissions.py
+++ b/backend/tests/test_catalog_admin_permissions.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import inspect
 import sys
 import unittest
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
-from fastapi import HTTPException
+from fastapi import HTTPException, UploadFile
+from fastapi.params import Form as FormParam
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -114,6 +117,82 @@ class CatalogAdminPermissionTests(unittest.TestCase):
         self.assertEqual(updates[-1]["progress"], 100)
         self.assertEqual(result["validated"], 3)
         self.assertEqual(result["total"], 3)
+
+
+CONFLICT = "Component revision conflict: refresh the component before saving"
+WRITER = AuthenticatedUser(email="designer@example.com", name="Designer", role="designer")
+
+
+def _upload(name: str, payload: bytes = b"payload") -> UploadFile:
+    return UploadFile(filename=name, file=BytesIO(payload))
+
+
+class CatalogAdminAssetRevisionTests(unittest.IsolatedAsyncioTestCase):
+    def test_upload_and_link_keep_expected_revision_optional_for_legacy_callers(self) -> None:
+        for name in ("import_symbol_library", "import_footprint", "import_auxiliary_asset"):
+            default = inspect.signature(getattr(catalog_admin, name)).parameters["expected_revision_id"].default
+            self.assertIsInstance(default, FormParam)
+            self.assertEqual(default.default, "")
+        field = catalog_admin.LinkAssetRequest.model_fields["expected_revision_id"]
+        self.assertEqual(field.default, "")
+
+    async def test_stale_uploads_and_link_return_409_and_keep_session_actor(self) -> None:
+        cases = (
+            (
+                catalog_admin.import_symbol_library,
+                "import_symbol_library",
+                {"file": _upload("a.kicad_sym"), "target_library": "", "selected_symbol": "", "counterpart_asset_id": ""},
+            ),
+            (
+                catalog_admin.import_footprint,
+                "import_footprint",
+                {"file": _upload("a.kicad_mod"), "target_library": "", "selected_footprint": "", "counterpart_asset_id": ""},
+            ),
+            (
+                catalog_admin.import_auxiliary_asset,
+                "attach_auxiliary_asset",
+                {"asset_type": "3dmodel", "file": _upload("a.step"), "target_library": ""},
+            ),
+        )
+        for handler, service_name, kwargs in cases:
+            with self.subTest(service_name):
+                with patch.object(
+                    catalog_admin.catalog_service, service_name, side_effect=ValueError(CONFLICT)
+                ) as mocked:
+                    with self.assertRaises(HTTPException) as raised:
+                        await handler("cmp-1", expected_revision_id="stale-rev", user=WRITER, **kwargs)
+                self.assertEqual(raised.exception.status_code, 409)
+                self.assertEqual(mocked.call_args.kwargs["expected_revision_id"], "stale-rev")
+                self.assertEqual(mocked.call_args.kwargs["actor"], WRITER.email)
+
+        payload = catalog_admin.LinkAssetRequest(file_path="lib/a.kicad_sym", expected_revision_id="stale-rev")
+        with patch.object(
+            catalog_admin.catalog_service, "link_library_asset", side_effect=ValueError(CONFLICT)
+        ) as mocked:
+            with self.assertRaises(HTTPException) as raised:
+                catalog_admin.link_library_asset("cmp-1", "symbol", payload, user=WRITER)
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertEqual(mocked.call_args.kwargs["expected_revision_id"], "stale-rev")
+        self.assertEqual(mocked.call_args.kwargs["actor"], WRITER.email)
+
+    async def test_non_conflict_upload_errors_stay_400(self) -> None:
+        with patch.object(
+            catalog_admin.catalog_service,
+            "import_symbol_library",
+            side_effect=ValueError("No symbols were found in the uploaded library"),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await catalog_admin.import_symbol_library(
+                    "cmp-1",
+                    file=_upload("empty.kicad_sym"),
+                    target_library="",
+                    selected_symbol="",
+                    counterpart_asset_id="",
+                    expected_revision_id="rev-1",
+                    user=WRITER,
+                )
+        self.assertEqual(raised.exception.status_code, 400)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_catalog_workflow_clone.py
+++ b/backend/tests/test_catalog_workflow_clone.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from app.services.catalog.revision_kernel import CatalogRevisionKernel  # noqa: E402
 from app.services.component_catalog_domain import (  # noqa: E402
     _normalize_workflow_stage,
 )
@@ -20,6 +21,16 @@ class CatalogWorkflowNormalizeTests(unittest.TestCase):
         self.assertEqual(_normalize_workflow_stage("in_review"), "qa_review")
         self.assertEqual(_normalize_workflow_stage("qa_approved"), "done")
         self.assertEqual(_normalize_workflow_stage("deprecated"), "archived")
+
+
+class CatalogRevisionPreconditionTests(unittest.TestCase):
+    def test_empty_expected_revision_is_the_legacy_skip(self) -> None:
+        CatalogRevisionKernel.assert_expected_revision("rev-1", "")
+        CatalogRevisionKernel.assert_expected_revision("rev-1")
+
+    def test_mismatched_expected_revision_is_a_conflict(self) -> None:
+        with self.assertRaisesRegex(ValueError, "revision conflict"):
+            CatalogRevisionKernel.assert_expected_revision("rev-2", "rev-1")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -464,6 +464,127 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
         self.assertEqual(len(self.service.list_component_revisions(component["id"])), 2)
         self.assertTrue(self.service.verify_component_audit_chain(component["id"])["valid"])
 
+    def test_stale_asset_upload_and_link_do_not_advance_head(self) -> None:
+        component = self._component("asset-rev-" + uuid.uuid4().hex[:8])
+        self._import_symbol(str(self._component("asset-donor-" + uuid.uuid4().hex[:8])["id"]), "DonorSym")
+        stale_id = component["revision_id"]
+        advanced = self.service.update_component_metadata(
+            component["id"],
+            {"description": "Editor B advanced the head"},
+            actor="editor-b@example.com",
+            expected_revision_id=stale_id,
+        )
+        assert advanced is not None
+        head_id = str(advanced["revision_id"])
+        revisions_before = self.service.list_component_revisions(component["id"])
+        donor_file = next(
+            path for path in self.service.browse_library_assets("symbol")["files"]
+            if "DonorSym" in path
+        )
+
+        def conflict(action) -> None:
+            with self.assertRaisesRegex(ValueError, "revision conflict"):
+                action()
+
+        stale_symbol = b'''(kicad_symbol_lib (version 20231120) (generator "test")
+          (symbol "StaleSym"
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "StaleSym" (at 0 0 0) (effects (font (size 1.27 1.27))))
+          )
+        )'''
+        conflict(lambda: self.service.import_symbol_library(
+            component["id"], upload_name="StaleSym.kicad_sym", payload=stale_symbol,
+            target_library="Stale", selected_symbol="StaleSym", actor="editor-a@example.com",
+            expected_revision_id=stale_id,
+        ))
+        conflict(lambda: self.service.import_footprint(
+            component["id"], upload_name="StaleFp.kicad_mod",
+            payload=b'(footprint "StaleFp" (version 20240108) (generator "test"))',
+            target_library="Stale", selected_footprint="StaleFp", actor="editor-a@example.com",
+            expected_revision_id=stale_id,
+        ))
+        conflict(lambda: self.service.attach_auxiliary_asset(
+            component["id"], asset_type="3dmodel", upload_name="stale.step",
+            payload=b"ISO-10303-21;END-ISO-10303-21;", target_library="Stale",
+            actor="editor-a@example.com", expected_revision_id=stale_id,
+        ))
+        conflict(lambda: self.service.link_library_asset(
+            component["id"], "symbol", file_path_rel=donor_file,
+            target_library="Availability", target_name="DonorSym", actor="editor-a@example.com",
+            expected_revision_id=stale_id,
+        ))
+
+        blocked = self.service.get_component(component["id"])
+        assert blocked is not None
+        self.assertEqual(blocked["revision_id"], head_id)
+        self.assertEqual(blocked["assets"], [])
+        self.assertEqual(self.service.list_component_revisions(component["id"]), revisions_before)
+
+        imported = self.service.import_symbol_library(
+            component["id"], upload_name="FreshSym.kicad_sym",
+            payload=stale_symbol.replace(b"StaleSym", b"FreshSym"),
+            target_library="Fresh", selected_symbol="FreshSym", actor="editor-a@example.com",
+            expected_revision_id=head_id,
+        )
+        self.assertEqual(imported["mode"], "imported")
+        self.assertNotEqual(imported["component"]["revision_id"], head_id)
+
+        legacy = self.service.import_footprint(
+            component["id"], upload_name="LegacyFp.kicad_mod",
+            payload=b'(footprint "LegacyFp" (version 20240108) (generator "test"))',
+            target_library="Fresh", selected_footprint="LegacyFp", actor="editor-a@example.com",
+        )
+        self.assertEqual(legacy["mode"], "imported")
+
+        auxiliary = self.service.attach_auxiliary_asset(
+            component["id"], asset_type="3dmodel", upload_name="fresh.step",
+            payload=b"ISO-10303-21;END-ISO-10303-21;", target_library="Fresh",
+            actor="editor-a@example.com",
+            expected_revision_id=legacy["component"]["revision_id"],
+        )
+        self.assertTrue(any(item["asset_type"] == "3dmodel" for item in auxiliary["component"]["assets"]))
+
+        self.service.link_library_asset(
+            component["id"], "symbol", file_path_rel=donor_file,
+            target_library="Availability", target_name="DonorSym", actor="editor-a@example.com",
+            expected_revision_id=auxiliary["component"]["revision_id"],
+        )
+        after_link = self.service.get_component(component["id"])
+        assert after_link is not None
+        self.assertNotEqual(after_link["revision_id"], auxiliary["component"]["revision_id"])
+        self.assertGreaterEqual(sum(1 for item in after_link["assets"] if item["asset_type"] == "symbol"), 2)
+
+        multi = b'''(kicad_symbol_lib (version 20231120) (generator "test")
+          (symbol "PickA"
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "PickA" (at 0 0 0) (effects (font (size 1.27 1.27))))
+          )
+          (symbol "PickB"
+            (property "Reference" "U" (at 0 0 0) (effects (font (size 1.27 1.27))))
+            (property "Value" "PickB" (at 0 0 0) (effects (font (size 1.27 1.27))))
+          )
+        )'''
+        picker_head = str(after_link["revision_id"])
+        picker = self.service.import_symbol_library(
+            component["id"], upload_name="multi.kicad_sym", payload=multi,
+            target_library="Fresh", selected_symbol="", actor="editor-a@example.com",
+            expected_revision_id=picker_head,
+        )
+        self.assertEqual(picker["mode"], "selection_required")
+        self.assertEqual(self.service.get_component(component["id"])["revision_id"], picker_head)
+        chosen = self.service.import_symbol_library(
+            component["id"], upload_name="multi.kicad_sym", payload=multi,
+            target_library="Fresh", selected_symbol="PickB", actor="editor-a@example.com",
+            expected_revision_id=picker_head,
+        )
+        self.assertEqual(chosen["mode"], "imported")
+        self.assertEqual(chosen["selected_symbol"], "PickB")
+        conflict(lambda: self.service.import_symbol_library(
+            component["id"], upload_name="multi.kicad_sym", payload=multi,
+            target_library="Fresh", selected_symbol="", actor="editor-a@example.com",
+            expected_revision_id=picker_head,
+        ))
+
     def test_metadata_schema_and_qa_batch_round_trip(self) -> None:
         token = uuid.uuid4().hex[:10]
         component = self._component(f"metadata-{token}")

--- a/frontend/src/components/workspace/library-asset-mutation.test.ts
+++ b/frontend/src/components/workspace/library-asset-mutation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { assetMutationRevisionId } from "./library-asset-mutation";
+import {
+  assetMutationRevisionId,
+  releaseRetainedRevisionOnConflict,
+} from "./library-asset-mutation";
 
 describe("assetMutationRevisionId", () => {
   it("keeps the first selection_required revision after the loaded component moves on", () => {
@@ -10,5 +13,20 @@ describe("assetMutationRevisionId", () => {
   it("uses the loaded revision when there is no retained picker state", () => {
     expect(assetMutationRevisionId("rev-current")).toBe("rev-current");
     expect(assetMutationRevisionId("rev-current", "")).toBe("rev-current");
+  });
+
+  it("releases the retained revision after a 409 so a refresh can retry", () => {
+    const selection = {
+      file: {} as File,
+      targetLibrary: "Lib",
+      options: ["A", "B"],
+      selected: "B",
+      expectedRevisionId: "rev-1",
+    };
+    const afterConflict = releaseRetainedRevisionOnConflict(selection, 409);
+    expect(afterConflict?.expectedRevisionId).toBe("");
+    expect(afterConflict?.selected).toBe("B");
+    expect(assetMutationRevisionId("rev-2", afterConflict?.expectedRevisionId)).toBe("rev-2");
+    expect(releaseRetainedRevisionOnConflict(selection, 400)).toEqual(selection);
   });
 });

--- a/frontend/src/components/workspace/library-asset-mutation.test.ts
+++ b/frontend/src/components/workspace/library-asset-mutation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { assetMutationRevisionId } from "./library-asset-mutation";
+
+describe("assetMutationRevisionId", () => {
+  it("keeps the first selection_required revision after the loaded component moves on", () => {
+    expect(assetMutationRevisionId("rev-later", "rev-first")).toBe("rev-first");
+  });
+
+  it("uses the loaded revision when there is no retained picker state", () => {
+    expect(assetMutationRevisionId("rev-current")).toBe("rev-current");
+    expect(assetMutationRevisionId("rev-current", "")).toBe("rev-current");
+  });
+});

--- a/frontend/src/components/workspace/library-asset-mutation.ts
+++ b/frontend/src/components/workspace/library-asset-mutation.ts
@@ -2,11 +2,20 @@
 
 Omitted/empty is the backend's legacy skip. Current editors always send one.
 A selection_required picker keeps the revision from the first POST so a later
-loaded head cannot silently attach.
+loaded head cannot silently attach. A 409 releases that retained id so a
+refresh can retry against the new head without closing the picker.
 */
 export function assetMutationRevisionId(
   currentRevisionId: string,
   retainedFromSelection?: string,
 ): string {
   return retainedFromSelection || currentRevisionId;
+}
+
+export function releaseRetainedRevisionOnConflict<T extends { expectedRevisionId: string }>(
+  selection: T | null,
+  status: number | undefined,
+): T | null {
+  if (!selection || status !== 409) return selection;
+  return { ...selection, expectedRevisionId: "" };
 }

--- a/frontend/src/components/workspace/library-asset-mutation.ts
+++ b/frontend/src/components/workspace/library-asset-mutation.ts
@@ -1,0 +1,12 @@
+/** Revision sent with catalog asset upload/link requests.
+
+Omitted/empty is the backend's legacy skip. Current editors always send one.
+A selection_required picker keeps the revision from the first POST so a later
+loaded head cannot silently attach.
+*/
+export function assetMutationRevisionId(
+  currentRevisionId: string,
+  retainedFromSelection?: string,
+): string {
+  return retainedFromSelection || currentRevisionId;
+}

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -90,6 +90,7 @@ import type {
 import type { Project } from "@/types/project";
 import { LibraryPreviewPair } from "./library-preview-inspector";
 import { LibraryPreviewViewport } from "./library-preview-viewport";
+import { assetMutationRevisionId } from "./library-asset-mutation";
 import { resolveLibraryPreviewPairAssetIds } from "./library-preview-pair";
 
 type ComponentTab = "overview" | "assets" | "revisions" | "review" | "usage" | "audit";
@@ -123,6 +124,7 @@ type AssetImportSelection = {
   targetLibrary: string;
   options: string[];
   selected: string;
+  expectedRevisionId: string;
 };
 
 type ValidationJob = {
@@ -2217,6 +2219,7 @@ export function LibraryComponentWorkspace({
       const form = new FormData();
       form.append("file", sourceFile);
       form.append("target_library", importSelection?.targetLibrary || attachTargetLibrary || currentComponent.name);
+      form.append("expected_revision_id", assetMutationRevisionId(currentComponent.revision_id, importSelection?.expectedRevisionId));
       if (attachCounterpartId) form.append("counterpart_asset_id", attachCounterpartId);
       if (importSelection?.selected) {
         form.append(attachAssetType === "symbol" ? "selected_symbol" : "selected_footprint", importSelection.selected);
@@ -2229,7 +2232,7 @@ export function LibraryComponentWorkspace({
       const response = await fetchJson<SelectionRequiredResponse | ImportCompletedResponse | { component: CatalogComponent }>(endpoint, { method: "POST", body: form });
       if ("mode" in response && response.mode === "selection_required") {
         const options = response.discovered_symbols || response.discovered_footprints || [];
-        setImportSelection({ file: sourceFile, targetLibrary: attachTargetLibrary || currentComponent.name, options, selected: options[0] || "" });
+        setImportSelection({ file: sourceFile, targetLibrary: attachTargetLibrary || currentComponent.name, options, selected: options[0] || "", expectedRevisionId: assetMutationRevisionId(currentComponent.revision_id, importSelection?.expectedRevisionId) });
         return;
       }
       toast.success(`${ASSET_LABELS[attachAssetType]} attached as a new revision.`);
@@ -2254,6 +2257,7 @@ export function LibraryComponentWorkspace({
           target_library: attachTargetLibrary.trim() || currentComponent.name,
           target_name: attachTargetName.trim(),
           counterpart_asset_id: attachCounterpartId,
+          expected_revision_id: currentComponent.revision_id,
         }),
       });
       toast.success(`${ASSET_LABELS[attachAssetType]} linked as a new revision.`);

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -63,7 +63,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
-import { fetchJson } from "@/lib/api";
+import { ApiHttpError, fetchJson } from "@/lib/api";
 import { allowedWorkflowTransitions, canWriteCatalog, workflowStage } from "@/lib/roles";
 import { cn } from "@/lib/utils";
 import { useCommittedRef } from "@/hooks/use-committed-ref";
@@ -90,7 +90,7 @@ import type {
 import type { Project } from "@/types/project";
 import { LibraryPreviewPair } from "./library-preview-inspector";
 import { LibraryPreviewViewport } from "./library-preview-viewport";
-import { assetMutationRevisionId } from "./library-asset-mutation";
+import { assetMutationRevisionId, releaseRetainedRevisionOnConflict } from "./library-asset-mutation";
 import { resolveLibraryPreviewPairAssetIds } from "./library-preview-pair";
 
 type ComponentTab = "overview" | "assets" | "revisions" | "review" | "usage" | "audit";
@@ -2241,6 +2241,8 @@ export function LibraryComponentWorkspace({
       setRefreshKey((value) => value + 1);
     } catch (reason) {
       toast.error(reason instanceof Error ? reason.message : String(reason));
+      const status = reason instanceof ApiHttpError ? reason.status : undefined;
+      setImportSelection((current) => releaseRetainedRevisionOnConflict(current, status));
     } finally {
       setBusyAction("");
     }


### PR DESCRIPTION
## Summary
- Carry `expected_revision_id` through catalog symbol/footprint/auxiliary uploads and asset links so a stale editor gets **409** instead of attaching to a newer head.
- Check the precondition before `selection_required` discovery as well as before clone; identical already-linked attachments also 409 when the editor is stale.
- Empty/omitted `expected_revision_id` remains the legacy skip. The library workspace always sends the loaded revision and retains it across a multi-symbol picker.

## Test plan
- [ ] Two editors: advance the head, then submit a stale symbol, footprint, auxiliary upload, or link → 409, no new revision or attachment
- [ ] Fresh upload, link, auxiliary attach, and multi-symbol `selection_required` then second POST still succeed
- [ ] Omitting `expected_revision_id` still attaches (legacy callers)
- [ ] Conflict toast appears in the attach dialog after another editor saves first


Made with [Cursor](https://cursor.com)