### PR TITLE
refactor(catalog): batch remaining list hydration queries

### DIFF
--- a/backend/app/services/catalog/component_queries.py
+++ b/backend/app/services/catalog/component_queries.py
@@ -15,6 +15,7 @@ from app.services.catalog.component_read_models import (
     VALIDATION_STATUS_PASSED,
     VALIDATION_STATUS_SKIPPED,
     VALIDATION_STATUS_WARNING,
+    inventory_payloads_from_source_rows,
 )
 from app.services.catalog.revision_kernel import WORKFLOW_STAGES, normalize_workflow_stage
 
@@ -402,6 +403,20 @@ class CatalogComponentQueries:
                 if asset_id not in revision_runs:
                     revision_runs[asset_id] = dict(inherited_row)
 
+        representations_by_revision: dict[str, list[dict[str, Any]]] = {}
+        inventory_by_component: dict[str, list[dict[str, Any]]] = {}
+        if not plan.lightweight and parsed_rows:
+            representations_by_revision = self._component_read_models.load_representations_for_revisions(
+                conn,
+                revision_ids,
+                assets_by_revision=assets_by_revision,
+                previews_by_revision=previews_by_revision,
+            )
+            inventory_by_component = self._component_read_models.load_inventory_for_components(
+                conn,
+                [str(component_row["id"]) for component_row, _, _, _ in parsed_rows],
+            )
+
         items = []
         for component_row, revision_row, default_symbol_asset_id, default_footprint_asset_id in parsed_rows:
             rev_assets = assets_by_revision.get(str(revision_row["id"]), [])
@@ -424,6 +439,9 @@ class CatalogComponentQueries:
                     )
                 )
                 continue
+            local_inventory, supply_sources = inventory_payloads_from_source_rows(
+                inventory_by_component.get(str(component_row["id"]), [])
+            )
             rev_previews = previews_by_revision.get(str(revision_row["id"]), [])
             items.append(
                 self._component_read_models.component_payload(
@@ -434,6 +452,11 @@ class CatalogComponentQueries:
                     preloaded_assets=rev_assets,
                     preloaded_previews=rev_previews,
                     preloaded_validation_runs=validation_by_revision.get(str(revision_row["id"]), {}),
+                    preloaded_representations=representations_by_revision.get(
+                        str(revision_row["id"]), []
+                    ),
+                    preloaded_local_inventory=local_inventory,
+                    preloaded_supply_sources=supply_sources,
                 )
             )
 

--- a/backend/app/services/catalog/component_read_models.py
+++ b/backend/app/services/catalog/component_read_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 from app.core.config import settings
 from app.services.catalog.asset_types import PLACE_REQUIRED_ASSET_TYPES
@@ -79,6 +79,45 @@ VALIDATION_STATUS_NOT_RUN = "not_run"
 KLC_RELEASE_GATE_VALUES = {"off", "warn", "block"}
 
 
+# Distinguishes "inventory was not preloaded" from a legitimate empty result.
+_PRELOAD_UNSET = object()
+
+_INVENTORY_AGGREGATE_COLUMNS = (
+    "source, SUM(quantity) AS quantity, MIN(uom) AS uom, "
+    "MIN(inventory_status) AS inventory_status, "
+    "MIN(fetch_status) AS fetch_status, MAX(fetched_at) AS fetched_at"
+)
+_INVENTORY_SOURCE_ORDER = (
+    "CASE source WHEN 'inventree' THEN 1 WHEN 'csv' THEN 2 ELSE 99 END, source"
+)
+
+
+def local_inventory_payload(row: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Shape the preferred inventory aggregate used by component payloads."""
+
+    if row is None:
+        return None
+    return {
+        "source": str(row["source"]),
+        "quantity": float(row["quantity"] or 0),
+        "uom": str(row["uom"] or ""),
+        "inventory_status": str(row["inventory_status"] or ""),
+        "fetch_status": str(row.get("fetch_status") or "ok"),
+        "fetched_at": str(row["fetched_at"] or ""),
+    }
+
+
+def inventory_payloads_from_source_rows(
+    rows: list[Mapping[str, Any]],
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """Return ``(local_inventory, supply_sources)`` from prioritized source rows."""
+
+    return (
+        local_inventory_payload(rows[0]) if rows else None,
+        [supply_source_payload(dict(row)) for row in rows],
+    )
+
+
 def supply_source_payload(row: dict[str, Any]) -> dict[str, Any]:
     """Shape one inventory source for the stable component payload."""
 
@@ -132,6 +171,51 @@ class CatalogComponentReadModels:
             if previews is not None
             else self.load_previews_for_revision(conn, revision_id)
         )
+        rows = conn.execute(
+            "SELECT * FROM revision_representations WHERE revision_id = %s "
+            "ORDER BY display_order, id",
+            (revision_id,),
+        ).fetchall()
+        return self._shape_representation_rows(rows, assets=assets, previews=previews)
+
+    def load_representations_for_revisions(
+        self,
+        conn: Any,
+        revision_ids: list[str],
+        *,
+        assets_by_revision: dict[str, list[dict[str, Any]]] | None = None,
+        previews_by_revision: dict[str, list[dict[str, Any]]] | None = None,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Load every representation for ``revision_ids`` in one query."""
+
+        assets_by_revision = assets_by_revision or {}
+        previews_by_revision = previews_by_revision or {}
+        shaped: dict[str, list[dict[str, Any]]] = {revision_id: [] for revision_id in revision_ids}
+        if not revision_ids:
+            return shaped
+        placeholders = ",".join("%s" for _ in revision_ids)
+        rows_by_revision: dict[str, list[Any]] = {revision_id: [] for revision_id in revision_ids}
+        for row in conn.execute(
+            f"SELECT * FROM revision_representations WHERE revision_id IN ({placeholders}) "
+            "ORDER BY revision_id, display_order, id",
+            tuple(revision_ids),
+        ).fetchall():
+            rows_by_revision.setdefault(str(row["revision_id"]), []).append(row)
+        for revision_id, rows in rows_by_revision.items():
+            shaped[revision_id] = self._shape_representation_rows(
+                rows,
+                assets=assets_by_revision.get(revision_id, []),
+                previews=previews_by_revision.get(revision_id, []),
+            )
+        return shaped
+
+    @staticmethod
+    def _shape_representation_rows(
+        rows: list[Any],
+        *,
+        assets: list[dict[str, Any]],
+        previews: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         assets_by_id = {str(asset["id"]): asset for asset in assets}
         previews_by_asset: dict[str, list[dict[str, Any]]] = {}
         for preview in previews:
@@ -159,11 +243,6 @@ class CatalogComponentReadModels:
                 "preview_id": str(ready_preview["id"]) if ready_preview else "",
             }
 
-        rows = conn.execute(
-            "SELECT * FROM revision_representations WHERE revision_id = %s "
-            "ORDER BY display_order, id",
-            (revision_id,),
-        ).fetchall()
         return [
             {
                 "id": str(row["id"]),
@@ -181,43 +260,53 @@ class CatalogComponentReadModels:
 
     def local_inventory(self, conn: Any, component_id: str) -> dict[str, Any] | None:
         row = conn.execute(
-            """
-            SELECT source, SUM(quantity) AS quantity, MIN(uom) AS uom,
-                   MIN(inventory_status) AS inventory_status,
-                   MIN(fetch_status) AS fetch_status, MAX(fetched_at) AS fetched_at
+            f"""
+            SELECT {_INVENTORY_AGGREGATE_COLUMNS}
             FROM inventory_levels
             WHERE component_id = %s
             GROUP BY source
-            ORDER BY CASE source WHEN 'inventree' THEN 1 WHEN 'csv' THEN 2 ELSE 99 END, source
+            ORDER BY {_INVENTORY_SOURCE_ORDER}
             LIMIT 1
             """,
             (component_id,),
         ).fetchone()
-        if not row:
-            return None
-        return {
-            "source": str(row["source"]),
-            "quantity": float(row["quantity"] or 0),
-            "uom": str(row["uom"] or ""),
-            "inventory_status": str(row["inventory_status"] or ""),
-            "fetch_status": str(row["fetch_status"] or "ok"),
-            "fetched_at": str(row["fetched_at"] or ""),
-        }
+        return local_inventory_payload(row)
 
     def supply_sources(self, conn: Any, component_id: str) -> list[dict[str, Any]]:
         rows = conn.execute(
-            """
-            SELECT source, SUM(quantity) AS quantity, MIN(uom) AS uom,
-                   MIN(inventory_status) AS inventory_status,
-                   MIN(fetch_status) AS fetch_status, MAX(fetched_at) AS fetched_at
+            f"""
+            SELECT {_INVENTORY_AGGREGATE_COLUMNS}
             FROM inventory_levels
             WHERE component_id = %s
             GROUP BY source
-            ORDER BY CASE source WHEN 'inventree' THEN 1 WHEN 'csv' THEN 2 ELSE 99 END, source
+            ORDER BY {_INVENTORY_SOURCE_ORDER}
             """,
             (component_id,),
         ).fetchall()
         return [supply_source_payload(dict(row)) for row in rows]
+
+    def load_inventory_for_components(
+        self, conn: Any, component_ids: list[str]
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Load inventory aggregates for many components in one query."""
+
+        grouped: dict[str, list[dict[str, Any]]] = {component_id: [] for component_id in component_ids}
+        if not component_ids:
+            return grouped
+        placeholders = ",".join("%s" for _ in component_ids)
+        rows = conn.execute(
+            f"""
+            SELECT component_id, {_INVENTORY_AGGREGATE_COLUMNS}
+            FROM inventory_levels
+            WHERE component_id IN ({placeholders})
+            GROUP BY component_id, source
+            ORDER BY component_id, {_INVENTORY_SOURCE_ORDER}
+            """,
+            tuple(component_ids),
+        ).fetchall()
+        for row in rows:
+            grouped.setdefault(str(row["component_id"]), []).append(dict(row))
+        return grouped
 
     def load_previews_for_assets(self, conn: Any, asset_ids: list[str]) -> list[dict[str, Any]]:
         if not asset_ids:
@@ -539,6 +628,9 @@ class CatalogComponentReadModels:
         preloaded_assets: list[dict[str, Any]] | None = None,
         preloaded_previews: list[dict[str, Any]] | None = None,
         preloaded_validation_runs: dict[str, dict[str, Any]] | None = None,
+        preloaded_representations: list[dict[str, Any]] | None = None,
+        preloaded_local_inventory: Any = _PRELOAD_UNSET,
+        preloaded_supply_sources: list[dict[str, Any]] | None = None,
         representation_id: str = "",
     ) -> dict[str, Any]:
         assets = (
@@ -551,8 +643,12 @@ class CatalogComponentReadModels:
             if preloaded_previews is not None
             else self.load_previews_for_revision(conn, str(revision_row["id"]))
         )
-        representations = self.load_representations_for_revision(
-            conn, str(revision_row["id"]), assets=assets, previews=previews
+        representations = (
+            preloaded_representations
+            if preloaded_representations is not None
+            else self.load_representations_for_revision(
+                conn, str(revision_row["id"]), assets=assets, previews=previews
+            )
         )
         default_representation = next((item for item in representations if item["is_default"]), None)
         effective_representation = default_representation
@@ -573,8 +669,15 @@ class CatalogComponentReadModels:
             is_active=bool(component_row["is_active"]),
             identity_kind=str(component_row.get("identity_kind") or IDENTITY_KIND_MPN),
         )
-        local_inventory = self.local_inventory(conn, str(component_row["id"]))
-        supply_sources = self.supply_sources(conn, str(component_row["id"]))
+        if preloaded_local_inventory is _PRELOAD_UNSET:
+            local_inventory = self.local_inventory(conn, str(component_row["id"]))
+        else:
+            local_inventory = preloaded_local_inventory
+        supply_sources = (
+            preloaded_supply_sources
+            if preloaded_supply_sources is not None
+            else self.supply_sources(conn, str(component_row["id"]))
+        )
         validation_summary = self.component_validation_summary(
             conn,
             str(revision_row["id"]),
@@ -816,6 +919,8 @@ class CatalogComponentReadModels:
 __all__ = [
     "CatalogComponentReadModels",
     "cad_availability",
+    "inventory_payloads_from_source_rows",
+    "local_inventory_payload",
     "remote_place_enabled",
     "representation_slot_present",
     "supply_source_payload",

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from app.services.catalog.asset_imports import CatalogAssetImports  # noqa: E402
 from app.services.catalog.asset_registry import CatalogAssetRegistry  # noqa: E402
+from app.services.catalog.postgres_runtime import CatalogPostgresConnection  # noqa: E402
 from app.services.catalog.preview_pipeline import CatalogPreviewPipeline  # noqa: E402
 from app.services.catalog.preview_renderer import CatalogPreviewRenderer  # noqa: E402
 from app.services.catalog_schema_migrations import (  # noqa: E402
@@ -403,6 +404,78 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
         errored = self.service.get_component(component["id"])
         assert errored is not None
         self.assertEqual(errored["local_inventory"]["fetch_status"], "error")
+
+    def _capture_list_sql(self, **kwargs: object) -> tuple[list[str], dict]:
+        captured: list[str] = []
+        original = CatalogPostgresConnection.execute
+
+        def execute(conn: object, sql: str, params: object = None) -> object:
+            captured.append(str(sql))
+            return original(conn, sql, params)
+
+        with patch.object(CatalogPostgresConnection, "execute", execute):
+            page = self.service.list_components(**kwargs)
+        return captured, page
+
+    @staticmethod
+    def _is_representation_hydration(sql: str) -> bool:
+        compact = " ".join(sql.split()).lower()
+        return "from revision_representations" in compact and "where revision_id in" in compact
+
+    @staticmethod
+    def _is_inventory_hydration(sql: str) -> bool:
+        compact = " ".join(sql.split()).lower()
+        return "from inventory_levels" in compact
+
+    def test_full_list_hydration_query_count_is_bounded_for_page_size(self) -> None:
+        token = "hydrate-" + uuid.uuid4().hex[:8]
+        fixtures: list[dict] = []
+        for index in range(50):
+            component = self.service.create_manual_component(
+                value="10k",
+                description="List hydration fixture",
+                datasheet="https://example.com/hydrate.pdf",
+                manufacturer=f"Hydrate {token}",
+                manufacturer_part_number=f"HYD-{token}-{index:02d}",
+                actor="author@example.com",
+            )
+            self.component_ids.append(str(component["id"]))
+            fixtures.append(component)
+        csv_rows = [
+            "component_id,manufacturer,mpn,quantity,uom,inventory_status",
+            f"{fixtures[0]['id']},{fixtures[0]['manufacturer']},{fixtures[0]['mpn']},12,pcs,available",
+            f"{fixtures[-1]['id']},{fixtures[-1]['manufacturer']},{fixtures[-1]['mpn']},3,pcs,available",
+        ]
+        self.assertEqual(self.service.import_inventory_csv("\n".join(csv_rows))["updated"], 2)
+
+        one_sql, one_page = self._capture_list_sql(query=token, page=1, page_size=1)
+        fifty_sql, fifty_page = self._capture_list_sql(query=token, page=1, page_size=50)
+        self.assertEqual(one_page["total"], 50)
+        self.assertEqual(len(one_page["items"]), 1)
+        self.assertEqual(len(fifty_page["items"]), 50)
+        self.assertEqual(len(one_sql), len(fifty_sql))
+        self.assertEqual(sum(1 for sql in fifty_sql if self._is_representation_hydration(sql)), 1)
+        self.assertEqual(sum(1 for sql in fifty_sql if self._is_inventory_hydration(sql)), 1)
+
+        listed_by_id = {item["id"]: item for item in fifty_page["items"]}
+        for fixture in (fixtures[0], fixtures[24], fixtures[-1]):
+            detail = self.service.get_component(str(fixture["id"]))
+            listed = listed_by_id[str(fixture["id"])]
+            assert detail is not None
+            self.assertEqual(listed["representations"], detail["representations"])
+            self.assertEqual(listed["local_inventory"], detail["local_inventory"])
+            self.assertEqual(listed["supply"], detail["supply"])
+        self.assertEqual(listed_by_id[str(fixtures[0]["id"])]["stock_quantity"], 12)
+        self.assertEqual(listed_by_id[str(fixtures[-1]["id"])]["stock_quantity"], 3)
+        self.assertFalse(listed_by_id[str(fixtures[24]["id"])]["stock_known"])
+
+        light_sql, light_page = self._capture_list_sql(
+            query=token, page=1, page_size=50, lightweight=True
+        )
+        self.assertEqual(len(light_page["items"]), 50)
+        self.assertFalse(any(self._is_representation_hydration(sql) for sql in light_sql))
+        self.assertFalse(any(self._is_inventory_hydration(sql) for sql in light_sql))
+        self.assertIsNone(light_page["items"][0]["local_inventory"])
 
     def test_mpn_correction_updates_identity_and_rejects_conflicts(self) -> None:
         first = self._component("correction-a-" + uuid.uuid4().hex[:8])

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -441,6 +441,8 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
             )
             self.component_ids.append(str(component["id"]))
             fixtures.append(component)
+        self._install_deterministic_preview_renderer()
+        fixtures[24] = self._complete_cad(fixtures[24], f"HydrateCad{token[:8]}")
         csv_rows = [
             "component_id,manufacturer,mpn,quantity,uom,inventory_status",
             f"{fixtures[0]['id']},{fixtures[0]['manufacturer']},{fixtures[0]['mpn']},12,pcs,available",
@@ -463,8 +465,18 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
             listed = listed_by_id[str(fixture["id"])]
             assert detail is not None
             self.assertEqual(listed["representations"], detail["representations"])
+            self.assertEqual(listed["previews"], detail["previews"])
             self.assertEqual(listed["local_inventory"], detail["local_inventory"])
             self.assertEqual(listed["supply"], detail["supply"])
+        cad_rep = next(
+            item
+            for item in listed_by_id[str(fixtures[24]["id"])]["representations"]
+            if item["is_default"]
+        )
+        self.assertTrue(cad_rep["symbol"]["id"])
+        self.assertTrue(cad_rep["footprint"]["id"])
+        self.assertTrue(cad_rep["symbol"]["preview_id"])
+        self.assertTrue(cad_rep["footprint"]["preview_id"])
         self.assertEqual(listed_by_id[str(fixtures[0]["id"])]["stock_quantity"], 12)
         self.assertEqual(listed_by_id[str(fixtures[-1]["id"])]["stock_quantity"], 3)
         self.assertFalse(listed_by_id[str(fixtures[24]["id"])]["stock_known"])

--- a/backend/tests/test_supply_source_payload.py
+++ b/backend/tests/test_supply_source_payload.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from app.services.catalog.component_read_models import (  # noqa: E402
+    inventory_payloads_from_source_rows,
+)
 from app.services.component_catalog_domain import _supply_source_payload  # noqa: E402
 from app.services.component_catalog_service_postgres import (  # noqa: E402
     ComponentCatalogPostgresService,
@@ -116,6 +119,40 @@ class SupplySourcesQueryTests(unittest.TestCase):
 
     def test_empty_when_no_rows(self) -> None:
         sources = self.service._supply_sources(_FakeConn([]), "component-1")
+        self.assertEqual(sources, [])
+
+
+class InventoryPayloadsFromSourceRowsTests(unittest.TestCase):
+    def test_first_row_is_local_inventory_and_all_rows_are_supply(self) -> None:
+        local, sources = inventory_payloads_from_source_rows(
+            [
+                {
+                    "source": "inventree",
+                    "quantity": 10,
+                    "uom": "pcs",
+                    "inventory_status": "available",
+                    "fetch_status": "ok",
+                    "fetched_at": "2026-01-01T00:00:00Z",
+                },
+                {
+                    "source": "csv",
+                    "quantity": 2,
+                    "uom": "pcs",
+                    "inventory_status": "",
+                    "fetch_status": "error",
+                    "fetched_at": "2026-01-02T00:00:00Z",
+                },
+            ]
+        )
+        assert local is not None
+        self.assertEqual(local["source"], "inventree")
+        self.assertEqual(local["quantity"], 10.0)
+        self.assertEqual([item["id"] for item in sources], ["inventree", "csv"])
+        self.assertEqual([item["fetch_status"] for item in sources], ["ok", "error"])
+
+    def test_empty_rows_mean_unknown_stock(self) -> None:
+        local, sources = inventory_payloads_from_source_rows([])
+        self.assertIsNone(local)
         self.assertEqual(sources, [])
 
 


### PR DESCRIPTION
## Summary
- Full catalog list payloads still queried representations and inventory once per row after assets/validation were already batched. Those reads now run once per page and are passed into payload shaping.
- Lightweight list and released projection stay on their existing paths; detail `get_component` still uses the single-row queries.
- Audit ticket **DB-05**. Neighboring tickets (inventory aggregation policy, pagination tie-breakers) are unchanged.

## Test plan
- [x] `python3 scripts/check_catalog_architecture.py` and `python3 scripts/check_agent_docs.py`
- [x] `backend/venv/bin/python -m unittest backend.tests.test_supply_source_payload backend.tests.test_catalog_availability backend.tests.test_catalog_architecture -v`
- [x] `backend/venv/bin/python -m unittest discover -s backend/tests -p 'test_*.py'` (1188 tests, 89 skipped)
- [x] `TEST_POSTGRES_URL=postgresql://postgres:ci-test@127.0.0.1:55432/kicad_prism_catalog_test backend/venv/bin/python -m unittest backend.tests.test_component_catalog_postgres_integration backend.tests.test_component_catalog_postgres_compat backend.tests.test_remote_provider_metadata -v` (22 tests, including 1-vs-50 query-count and payload parity)


Made with [Cursor](https://cursor.com)