### PR TITLE
fix(catalog): tie-break paginated lists by component id

### DIFF
--- a/backend/app/services/catalog/AGENTS.md
+++ b/backend/app/services/catalog/AGENTS.md
@@ -50,6 +50,9 @@ rationale are recorded in `docs/CATALOG_DECOMPOSITION_HANDOFF.md`.
 - Write-conflict classification is `CatalogConflict.code`. HTTP 409 bodies are
   `{code, message}` (`conflicts.py`, `backend/app/api/catalog_errors.py`).
 - Canonical asset paths under the store root (`asset_files.py`, `runtime.py`).
+- Paginated catalog and remote-head lists end `ORDER BY` with immutable
+  component identity (`component_queries.py`, `remote_heads.py`). This is a
+  stable-dataset total order, not snapshot isolation across concurrent writes.
 
 ## Navigation
 

--- a/backend/app/services/catalog/component_queries.py
+++ b/backend/app/services/catalog/component_queries.py
@@ -25,6 +25,9 @@ REPRESENTATION_ASSET_COLUMNS = {
     "footprint": "footprint_asset_id",
 }
 
+# OFFSET pages need a total order when timestamps or ranks tie.
+COMPONENT_LIST_TIEBREAKER = "c.id"
+
 
 def default_representation_has_asset(revision_ref: str, asset_type: str, alias: str) -> str:
     """SQL predicate: the default representation has a non-empty asset for ``asset_type``."""
@@ -242,7 +245,10 @@ class CatalogComponentQueries:
             )
 
         if sort_column:
-            order_sql = f"ORDER BY {sort_column} {sort_direction}, {revision_ref}.updated_at DESC"
+            order_sql = (
+                f"ORDER BY {sort_column} {sort_direction}, "
+                f"{revision_ref}.updated_at DESC, {COMPONENT_LIST_TIEBREAKER}"
+            )
             order_params: list[Any] = []
         elif query_text:
             order_sql = (
@@ -250,11 +256,11 @@ class CatalogComponentQueries:
                 f"WHEN LOWER({revision_ref}.mpn) = LOWER(%s) THEN 0 "
                 f"WHEN LOWER({revision_ref}.mpn) LIKE LOWER(%s) THEN 1 "
                 f"WHEN LOWER({revision_ref}.name) LIKE LOWER(%s) THEN 2 "
-                f"ELSE 3 END, {revision_ref}.updated_at DESC"
+                f"ELSE 3 END, {revision_ref}.updated_at DESC, {COMPONENT_LIST_TIEBREAKER}"
             )
             order_params = [query_text, f"{query_text}%", f"{query_text}%"]
         else:
-            order_sql = f"ORDER BY {revision_ref}.updated_at DESC"
+            order_sql = f"ORDER BY {revision_ref}.updated_at DESC, {COMPONENT_LIST_TIEBREAKER}"
             order_params = []
 
         return CatalogComponentListPlan(
@@ -558,6 +564,7 @@ class CatalogComponentQueries:
 
 
 __all__ = [
+    "COMPONENT_LIST_TIEBREAKER",
     "CatalogComponentListPlan",
     "CatalogComponentQueries",
     "REPRESENTATION_ASSET_COLUMNS",

--- a/backend/app/services/catalog/remote_heads.py
+++ b/backend/app/services/catalog/remote_heads.py
@@ -21,6 +21,7 @@ from app.services.catalog.preview_renderer import PREVIEW_STATUS_READY
 
 
 REMOTE_HEADS_MAX_PAGE_SIZE = 200
+REMOTE_HEAD_TIEBREAKER = "component_id"
 _PROJECTION_VERSION_SQL = "SELECT value FROM catalog_meta WHERE key = 'remote_component_heads_version'"
 
 
@@ -139,11 +140,11 @@ class CatalogRemoteHeads:
                 "WHEN LOWER(mpn) = LOWER(%s) THEN 0 "
                 "WHEN LOWER(mpn) LIKE LOWER(%s) THEN 1 "
                 "WHEN LOWER(name) LIKE LOWER(%s) THEN 2 "
-                "ELSE 3 END, updated_at DESC"
+                f"ELSE 3 END, updated_at DESC, {REMOTE_HEAD_TIEBREAKER}"
             )
             order_params: list[Any] = [query_text, f"{query_text}%", f"{query_text}%"]
         else:
-            order_sql = "ORDER BY updated_at DESC"
+            order_sql = f"ORDER BY updated_at DESC, {REMOTE_HEAD_TIEBREAKER}"
             order_params = []
 
         total: int | None = None
@@ -198,4 +199,9 @@ class CatalogRemoteHeads:
         }
 
 
-__all__ = ["REMOTE_HEADS_MAX_PAGE_SIZE", "CatalogRemoteHeads", "remote_head_payload"]
+__all__ = [
+    "REMOTE_HEADS_MAX_PAGE_SIZE",
+    "REMOTE_HEAD_TIEBREAKER",
+    "CatalogRemoteHeads",
+    "remote_head_payload",
+]

--- a/backend/tests/test_catalog_availability.py
+++ b/backend/tests/test_catalog_availability.py
@@ -179,6 +179,7 @@ class CatalogAvailabilityQueryTests(unittest.TestCase):
         self.assertIn("COALESCE(default_rep.footprint_asset_id, '') <> ''", plan.order_sql)
         self.assertNotIn("EXISTS", plan.order_sql)
         self.assertNotIn("revision_assets", plan.order_sql)
+        self.assertTrue(plan.order_sql.endswith(", c.id"))
 
 
 class CatalogAvailabilitySummaryTests(unittest.TestCase):

--- a/backend/tests/test_catalog_list_order.py
+++ b/backend/tests/test_catalog_list_order.py
@@ -1,0 +1,95 @@
+"""Paginated catalog lists end ORDER BY with immutable component identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.catalog.component_queries import (  # noqa: E402
+    COMPONENT_LIST_TIEBREAKER,
+    CatalogComponentQueries,
+)
+from app.services.catalog.remote_heads import (  # noqa: E402
+    REMOTE_HEAD_TIEBREAKER,
+    CatalogRemoteHeads,
+)
+
+
+class _RecordingConn:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def execute(self, sql: str, _params: object = ()) -> "_RecordingConn":
+        self.statements.append(sql)
+        return self
+
+    def fetchone(self) -> dict[str, object]:
+        return {"total": 0, "value": "1"}
+
+    def fetchall(self) -> list[object]:
+        return []
+
+
+def _list_select_sql(statements: list[str]) -> str:
+    for sql in statements:
+        if "LIMIT" in sql and "OFFSET" in sql:
+            return " ".join(sql.split())
+    raise AssertionError(f"no paged SELECT in {statements!r}")
+
+
+class CatalogListOrderPlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.queries = CatalogComponentQueries(component_read_models=object())  # type: ignore[arg-type]
+
+    def test_every_admin_order_branch_ends_with_component_id(self) -> None:
+        cases = (
+            self.queries.prepare_list_components(),
+            self.queries.prepare_list_components(sort_by="name", sort_dir="asc"),
+            self.queries.prepare_list_components(sort_by="name", sort_dir="desc"),
+            self.queries.prepare_list_components(sort_by="availability_state"),
+            self.queries.prepare_list_components(query="PG-R"),
+            self.queries.prepare_list_components(query="PG-R", sort_by="manufacturer"),
+        )
+        for plan in cases:
+            with self.subTest(order_sql=plan.order_sql):
+                self.assertTrue(
+                    plan.order_sql.endswith(f", {COMPONENT_LIST_TIEBREAKER}"),
+                    plan.order_sql,
+                )
+                self.assertIn("ORDER BY", plan.order_sql)
+
+    def test_search_ranking_keeps_prefix_order_before_the_tiebreaker(self) -> None:
+        plan = self.queries.prepare_list_components(query="PG-R")
+        self.assertIn("WHEN LOWER(cr.mpn) = LOWER(%s) THEN 0", plan.order_sql)
+        self.assertIn("WHEN LOWER(cr.mpn) LIKE LOWER(%s) THEN 1", plan.order_sql)
+        self.assertIn("WHEN LOWER(cr.name) LIKE LOWER(%s) THEN 2", plan.order_sql)
+        self.assertTrue(plan.order_sql.endswith(f", {COMPONENT_LIST_TIEBREAKER}"))
+
+
+class RemoteHeadOrderTests(unittest.TestCase):
+    def test_default_and_search_orders_end_with_component_id(self) -> None:
+        default_conn = _RecordingConn()
+        CatalogRemoteHeads.list_heads(default_conn)
+        self.assertIn(
+            f"ORDER BY updated_at DESC, {REMOTE_HEAD_TIEBREAKER}",
+            _list_select_sql(default_conn.statements),
+        )
+
+        search_conn = _RecordingConn()
+        CatalogRemoteHeads.list_heads(search_conn, query="PG-R")
+        search_sql = _list_select_sql(search_conn.statements)
+        self.assertIn("WHEN LOWER(mpn) = LOWER(%s) THEN 0", search_sql)
+        self.assertIn(f"ELSE 3 END, updated_at DESC, {REMOTE_HEAD_TIEBREAKER}", search_sql)
+
+    def test_category_listing_orders_by_category_name(self) -> None:
+        conn = _RecordingConn()
+        CatalogRemoteHeads.list_categories(conn)
+        grouped = next(sql for sql in conn.statements if "GROUP BY" in sql)
+        self.assertIn("ORDER BY category", grouped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 import base64
 import csv
 import hashlib
@@ -1794,6 +1795,80 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
         self.assertEqual(named_ids, ranked_ids)
         self.assertEqual(manufacturer_ids, ranked_ids)
         self.assertEqual(paged_ids(), ranked_ids)
+
+        clock = (
+            patch("app.services.catalog.component_writer.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.revision_kernel._utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.revision_finalization.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.asset_registry.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.asset_links.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.representations.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.release_workflow.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.preview_pipeline.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.preview_store.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.klc_validation.utc_now_iso", return_value=frozen),
+        )
+        released: list[dict] = []
+        with ExitStack() as stack:
+            for frozen_clock in clock:
+                stack.enter_context(frozen_clock)
+            for index, item in enumerate(fixtures):
+                current = self._complete_cad(item, f"Tie{token[-6:]}{index}")
+                self.service.set_release_status(
+                    current["id"], "in_progress", actor="designer@example.com"
+                )
+                review = self.service.set_release_status(
+                    current["id"], "qa_review", actor="designer@example.com"
+                )
+                approved = self.service.set_release_status(
+                    current["id"],
+                    "done",
+                    actor="qa@example.com",
+                    expected_revision_id=review["revision_id"],
+                    expected_manifest_hash=review["manifest_hash"],
+                )
+                released.append(
+                    self.service.set_release_status(
+                        current["id"],
+                        "released",
+                        actor="designer@example.com",
+                        expected_revision_id=approved["revision_id"],
+                        expected_manifest_hash=approved["manifest_hash"],
+                    )
+                )
+        self.assertEqual({str(item["revision_updated_at"]) for item in released}, {frozen})
+
+        def paged_remote_ids() -> list[str]:
+            seen: list[str] = []
+            page = 1
+            while True:
+                result = self.service.list_remote_component_heads(
+                    query=token,
+                    page=page,
+                    page_size=2,
+                )
+                batch = [
+                    str(item["id"])
+                    for item in result["items"]
+                    if str(item["id"]) in expected
+                ]
+                overlap = set(seen) & set(batch)
+                self.assertFalse(overlap, overlap)
+                seen.extend(batch)
+                pages = result["pages"]
+                if pages is None:
+                    if not result["has_more"] or not result["items"]:
+                        break
+                elif page >= int(pages) or not result["items"]:
+                    break
+                page += 1
+            return seen
+
+        remote_ids = paged_remote_ids()
+        self.assertEqual(set(remote_ids), expected)
+        self.assertEqual(len(remote_ids), 4)
+        self.assertEqual(remote_ids, sorted(expected))
+        self.assertEqual(paged_remote_ids(), remote_ids)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_component_catalog_postgres_integration.py
+++ b/backend/tests/test_component_catalog_postgres_integration.py
@@ -1733,6 +1733,68 @@ class ComponentCatalogPostgresIntegrationTests(unittest.TestCase):
             place_enabled=True,
         )
 
+    def test_tied_timestamps_paginate_without_duplicate_or_omitted_ids(self) -> None:
+        token = "tie-" + uuid.uuid4().hex[:8]
+        frozen = "2026-09-12T21:00:00+00:00"
+        fixtures: list[dict] = []
+        with (
+            patch("app.services.catalog.component_writer.utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.revision_kernel._utc_now_iso", return_value=frozen),
+            patch("app.services.catalog.revision_finalization.utc_now_iso", return_value=frozen),
+        ):
+            for index in range(4):
+                component = self.service.create_manual_component(
+                    name="Tied Name",
+                    value="10k",
+                    description=f"Pagination {token}",
+                    datasheet="https://example.com/r.pdf",
+                    manufacturer="Prism Tiebreak",
+                    manufacturer_part_number=f"PG-TIE-{token}-{index}",
+                    actor="author@example.com",
+                )
+                self.component_ids.append(str(component["id"]))
+                fixtures.append(component)
+
+        expected = {str(item["id"]) for item in fixtures}
+        timestamps = {str(item["revision_updated_at"]) for item in fixtures}
+        names = {str(item["name"]) for item in fixtures}
+        self.assertEqual(timestamps, {frozen})
+        self.assertEqual(names, {"Tied Name"})
+
+        def paged_ids(**kwargs: object) -> list[str]:
+            seen: list[str] = []
+            page = 1
+            while True:
+                result = self.service.list_components(
+                    query=token,
+                    page=page,
+                    page_size=2,
+                    lightweight=True,
+                    **kwargs,
+                )
+                batch = [
+                    str(item["id"])
+                    for item in result["items"]
+                    if str(item["id"]) in expected
+                ]
+                overlap = set(seen) & set(batch)
+                self.assertFalse(overlap, overlap)
+                seen.extend(batch)
+                if page >= int(result["pages"]) or not result["items"]:
+                    break
+                page += 1
+            return seen
+
+        ranked_ids = paged_ids()
+        named_ids = paged_ids(sort_by="name", sort_dir="asc")
+        manufacturer_ids = paged_ids(sort_by="manufacturer", sort_dir="asc")
+        self.assertEqual(set(ranked_ids), expected)
+        self.assertEqual(len(ranked_ids), 4)
+        self.assertEqual(ranked_ids, sorted(expected))
+        self.assertEqual(named_ids, ranked_ids)
+        self.assertEqual(manufacturer_ids, ranked_ids)
+        self.assertEqual(paged_ids(), ranked_ids)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- DB-08: catalog list and remote-head `ORDER BY` clauses now end with immutable component identity (`c.id` / `component_id`) so OFFSET pages stay a total order when timestamps or search ranks tie.
- Ranking, explicit sorts, and pagination fields are unchanged. This is a stable-dataset order, not snapshot isolation across concurrent writes.

## Test plan
- [x] Equal-name/equal-timestamp fixtures paginate with `page_size=2` and no duplicate or omitted IDs
- [x] Search ranking, name/manufacturer sorts, and remote category listing keep their existing keys and add the tie-breaker
- [x] `python3 scripts/check_catalog_architecture.py` and `python3 scripts/check_agent_docs.py`
- [x] `backend/venv/bin/python -m unittest backend.tests.test_catalog_list_order backend.tests.test_catalog_availability backend.tests.test_catalog_architecture -v`
- [x] Full backend `unittest discover` (exit 0)
- [x] Postgres integration: 21/21 including the new pagination fixture