### PR TITLE
refactor(catalog): give edit dialogs their own sessions

### DIFF
--- a/frontend/src/components/workspace/AGENTS.md
+++ b/frontend/src/components/workspace/AGENTS.md
@@ -30,7 +30,9 @@ URL ownership and current/historical selection stay here),
 `library-component-chrome.tsx` (shared badges, cards, empty/loading chrome),
 `library-component-evidence.ts` (tab evidence load hooks, no store or query
 library), `library-component-evidence-panels.tsx` (read-only revisions, review,
-usage, and audit evidence), `library-component-quick-view.tsx`,
+usage, and audit evidence), `library-component-metadata-dialog.tsx` and
+`library-component-asset-dialog.tsx` (edit sessions captured at open, one
+success callback), `library-component-quick-view.tsx`,
 `library-asset-link-picker.tsx`, `use-edit-history.ts`.
 
 **Previews** — two paths that share nothing but a subject.

--- a/frontend/src/components/workspace/library-asset-mutation.test.ts
+++ b/frontend/src/components/workspace/library-asset-mutation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   assetMutationRevisionId,
+  isRevisionConflict,
   releaseRetainedRevisionOnConflict,
 } from "./library-asset-mutation";
 
@@ -31,5 +32,9 @@ describe("assetMutationRevisionId", () => {
     expect(releaseRetainedRevisionOnConflict(selection, 409)?.expectedRevisionId).toBe("");
     expect(releaseRetainedRevisionOnConflict(selection, 409, "asset_referenced")).toEqual(selection);
     expect(releaseRetainedRevisionOnConflict(selection, 409, "manifest_conflict")).toEqual(selection);
+    expect(isRevisionConflict(409, "revision_conflict")).toBe(true);
+    expect(isRevisionConflict(409)).toBe(true);
+    expect(isRevisionConflict(409, "asset_referenced")).toBe(false);
+    expect(isRevisionConflict(400, "revision_conflict")).toBe(false);
   });
 });

--- a/frontend/src/components/workspace/library-asset-mutation.ts
+++ b/frontend/src/components/workspace/library-asset-mutation.ts
@@ -2,10 +2,10 @@
 
 Omitted/empty is the backend's legacy skip. Current editors always send one.
 A selection_required picker keeps the revision from the first POST so a later
-loaded head cannot silently attach. A revision_conflict 409 releases that
-retained id so a refresh can retry against the new head without closing the
-picker. Other 409 codes (referenced assets, stale manifests) are not retryable
-that way.
+loaded head cannot silently attach. That retained id is the session's open-time
+revision; a revision_conflict 409 cannot retry against it and must close so
+the next open recaptures the head. Other 409 codes (referenced assets, stale
+manifests) are not retryable that way either.
 */
 export function assetMutationRevisionId(
   currentRevisionId: string,
@@ -14,12 +14,15 @@ export function assetMutationRevisionId(
   return retainedFromSelection || currentRevisionId;
 }
 
+export function isRevisionConflict(status: number | undefined, code?: string): boolean {
+  return status === 409 && (!code || code === "revision_conflict");
+}
+
 export function releaseRetainedRevisionOnConflict<T extends { expectedRevisionId: string }>(
   selection: T | null,
   status: number | undefined,
   code?: string,
 ): T | null {
-  if (!selection || status !== 409) return selection;
-  if (code && code !== "revision_conflict") return selection;
+  if (!selection || !isRevisionConflict(status, code)) return selection;
   return { ...selection, expectedRevisionId: "" };
 }

--- a/frontend/src/components/workspace/library-component-asset-dialog.tsx
+++ b/frontend/src/components/workspace/library-component-asset-dialog.tsx
@@ -32,7 +32,7 @@ import type {
 
 import { AsyncSearchPicker } from "./async-search-picker";
 import { formatBytes } from "./library-component-chrome";
-import { assetMutationRevisionId, releaseRetainedRevisionOnConflict } from "./library-asset-mutation";
+import { assetMutationRevisionId, isRevisionConflict } from "./library-asset-mutation";
 
 export type AssetType = CatalogAsset["asset_type"];
 type AssetAttachMode = "upload" | "link";
@@ -194,6 +194,13 @@ export function AssetAttachDialog({
 
   const label = ASSET_LABELS[session.assetType];
 
+  const closeIfRevisionConflict = (reason: unknown) => {
+    if (!(reason instanceof ApiHttpError)) return;
+    // The session revision is frozen at open, so retrying in-dialog still
+    // sends the same stale head. Close and let the next Add recapture.
+    if (isRevisionConflict(reason.status, reason.code)) onClose();
+  };
+
   const handleUpload = async () => {
     const sourceFile = importSelection?.file || file;
     if (!sourceFile) return;
@@ -230,9 +237,7 @@ export function AssetAttachDialog({
     } catch (reason) {
       if (!aliveRef.current) return;
       toast.error(reason instanceof Error ? reason.message : String(reason));
-      const status = reason instanceof ApiHttpError ? reason.status : undefined;
-      const code = reason instanceof ApiHttpError ? reason.code : undefined;
-      setImportSelection((current) => releaseRetainedRevisionOnConflict(current, status, code));
+      closeIfRevisionConflict(reason);
     } finally {
       if (aliveRef.current) setSubmitting(false);
     }
@@ -258,6 +263,7 @@ export function AssetAttachDialog({
     } catch (reason) {
       if (!aliveRef.current) return;
       toast.error(reason instanceof Error ? reason.message : String(reason));
+      closeIfRevisionConflict(reason);
     } finally {
       if (aliveRef.current) setSubmitting(false);
     }

--- a/frontend/src/components/workspace/library-component-asset-dialog.tsx
+++ b/frontend/src/components/workspace/library-component-asset-dialog.tsx
@@ -1,0 +1,360 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, Link2, Loader2, Upload } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FileInput } from "@/components/ui/file-input";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ApiHttpError, fetchJson } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type {
+  CatalogAsset,
+  CatalogComponent,
+  ImportCompletedResponse,
+  SelectionRequiredResponse,
+} from "@/types/catalog";
+
+import { AsyncSearchPicker } from "./async-search-picker";
+import { formatBytes } from "./library-component-chrome";
+import { assetMutationRevisionId, releaseRetainedRevisionOnConflict } from "./library-asset-mutation";
+
+export type AssetType = CatalogAsset["asset_type"];
+type AssetAttachMode = "upload" | "link";
+
+type AssetImportSelection = {
+  file: File;
+  targetLibrary: string;
+  options: string[];
+  selected: string;
+  expectedRevisionId: string;
+};
+
+export type AssetAttachSession = {
+  openedAt: string;
+  componentId: string;
+  expectedRevisionId: string;
+  componentName: string;
+  libraryName: string;
+  assetType: AssetType;
+  counterpartAssets: CatalogAsset[];
+  defaultCounterpartId: string;
+};
+
+export const ASSET_LABELS: Record<AssetType, string> = {
+  symbol: "Symbol",
+  footprint: "Footprint",
+  "3dmodel": "3D model",
+  spice: "SPICE model",
+};
+
+const ASSET_ACCEPT: Record<AssetType, string> = {
+  symbol: ".kicad_sym",
+  footprint: ".kicad_mod,.zip",
+  "3dmodel": ".step,.stp,.wrl",
+  spice: ".sp,.cir,.spice,.lib",
+};
+
+const ASSET_SOURCE_TABS: Array<{ id: AssetAttachMode; label: string; icon: typeof Upload }> = [
+  { id: "upload", label: "Upload file", icon: Upload },
+  { id: "link", label: "Link existing", icon: Link2 },
+];
+
+const STORED_FILE_RESULT_LIMIT = 50;
+
+let nextAttachSession = 0;
+
+export function assetAttachSessionFrom(component: CatalogComponent, assetType: AssetType): AssetAttachSession {
+  nextAttachSession += 1;
+  const defaultRepresentation = component.representations.find((item) => item.is_default);
+  return {
+    openedAt: `attach-${nextAttachSession}`,
+    componentId: component.id,
+    expectedRevisionId: component.revision_id,
+    componentName: component.name,
+    libraryName: component.library_name || component.name,
+    assetType,
+    counterpartAssets: component.assets.filter((asset) => (
+      assetType === "symbol" ? asset.asset_type === "footprint"
+        : assetType === "footprint" ? asset.asset_type === "symbol"
+          : false
+    )),
+    defaultCounterpartId:
+      assetType === "symbol"
+        ? defaultRepresentation?.footprint?.id || ""
+        : assetType === "footprint"
+          ? defaultRepresentation?.symbol?.id || ""
+          : "",
+  };
+}
+
+/** Pick a file already sitting in Prism storage, including ones never registered as an asset. */
+function StoredFilePicker({
+  id,
+  assetType,
+  value,
+  onChange,
+}: {
+  id: string;
+  assetType: AssetType;
+  value: string;
+  onChange: (path: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const kind = ASSET_LABELS[assetType].toLowerCase();
+
+  return (
+    <AsyncSearchPicker<string>
+      id={id}
+      open={open}
+      onOpenChange={setOpen}
+      // Portalled out of the attach dialog, so it needs its own modal layer.
+      modal
+      contentClassName="w-[var(--radix-popover-trigger-width)]"
+      fetchKey={assetType}
+      trigger={
+        <button
+          type="button"
+          id={id}
+          aria-expanded={open}
+          className="border-input dark:bg-input/30 dark:hover:bg-input/50 flex h-9 w-full min-w-0 items-center justify-between gap-1.5 border px-3 py-2 text-left text-xs leading-none transition-colors outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-1"
+        >
+          <span className={cn("min-w-0 truncate", value ? "text-foreground" : "text-muted-foreground")}>{value || "Select a stored file"}</span>
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </button>
+      }
+      fetchPage={(query, signal) =>
+        fetchJson<{ files: string[]; total?: number }>(
+          `/api/catalog/assets/browse?asset_type=${encodeURIComponent(assetType)}&limit=${STORED_FILE_RESULT_LIMIT}&q=${encodeURIComponent(query)}`,
+          { signal },
+          "Stored assets could not be listed.",
+        ).then((response) => ({ items: response.files, total: response.total }))
+      }
+      getKey={(path) => path}
+      isSelected={(path) => path === value}
+      onSelect={onChange}
+      searchPlaceholder={`Search stored ${kind} files`}
+      listLabel={`Stored ${kind} files`}
+      emptyMessage={`No stored ${kind} files match.`}
+      renderItem={(path) => (
+        <>
+          <Check className={cn("h-3.5 w-3.5 shrink-0", path === value ? "text-primary" : "invisible")} />
+          <span className="min-w-0 flex-1 truncate">{path}</span>
+        </>
+      )}
+      renderFooter={({ shown, total }) =>
+        total > shown ? (
+          <p className="border-t px-2.5 py-1.5 text-[11px] text-muted-foreground">Showing {shown} of {total} stored files — refine the search to narrow.</p>
+        ) : null
+      }
+    />
+  );
+}
+
+export function AssetAttachDialog({
+  session,
+  onClose,
+  onSuccess,
+}: {
+  session: AssetAttachSession;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [mode, setMode] = useState<AssetAttachMode>("upload");
+  const [file, setFile] = useState<File | null>(null);
+  const [targetLibrary, setTargetLibrary] = useState(session.libraryName);
+  const [targetName, setTargetName] = useState("");
+  const [counterpartAssetId, setCounterpartAssetId] = useState(session.defaultCounterpartId);
+  const [selectedLink, setSelectedLink] = useState("");
+  const [importSelection, setImportSelection] = useState<AssetImportSelection | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const label = ASSET_LABELS[session.assetType];
+
+  const handleUpload = async () => {
+    const sourceFile = importSelection?.file || file;
+    if (!sourceFile) return;
+    setSubmitting(true);
+    try {
+      const form = new FormData();
+      form.append("file", sourceFile);
+      form.append("target_library", importSelection?.targetLibrary || targetLibrary || session.componentName);
+      form.append("expected_revision_id", assetMutationRevisionId(session.expectedRevisionId, importSelection?.expectedRevisionId));
+      if (counterpartAssetId) form.append("counterpart_asset_id", counterpartAssetId);
+      if (importSelection?.selected) {
+        form.append(session.assetType === "symbol" ? "selected_symbol" : "selected_footprint", importSelection.selected);
+      }
+      const endpoint = session.assetType === "symbol"
+        ? `/api/catalog/components/${encodeURIComponent(session.componentId)}/symbol-import`
+        : session.assetType === "footprint"
+          ? `/api/catalog/components/${encodeURIComponent(session.componentId)}/footprint-import`
+          : `/api/catalog/components/${encodeURIComponent(session.componentId)}/assets/${encodeURIComponent(session.assetType)}`;
+      const response = await fetchJson<SelectionRequiredResponse | ImportCompletedResponse | { component: CatalogComponent }>(endpoint, { method: "POST", body: form });
+      if (!aliveRef.current) return;
+      if ("mode" in response && response.mode === "selection_required") {
+        const options = response.discovered_symbols || response.discovered_footprints || [];
+        setImportSelection({
+          file: sourceFile,
+          targetLibrary: targetLibrary || session.componentName,
+          options,
+          selected: options[0] || "",
+          expectedRevisionId: assetMutationRevisionId(session.expectedRevisionId, importSelection?.expectedRevisionId),
+        });
+        return;
+      }
+      toast.success(`${label} attached as a new revision.`);
+      onSuccess();
+    } catch (reason) {
+      if (!aliveRef.current) return;
+      toast.error(reason instanceof Error ? reason.message : String(reason));
+      const status = reason instanceof ApiHttpError ? reason.status : undefined;
+      const code = reason instanceof ApiHttpError ? reason.code : undefined;
+      setImportSelection((current) => releaseRetainedRevisionOnConflict(current, status, code));
+    } finally {
+      if (aliveRef.current) setSubmitting(false);
+    }
+  };
+
+  const handleLink = async () => {
+    if (!selectedLink) return;
+    setSubmitting(true);
+    try {
+      await fetchJson(`/api/catalog/components/${encodeURIComponent(session.componentId)}/assets/${encodeURIComponent(session.assetType)}/link`, {
+        method: "POST",
+        body: JSON.stringify({
+          file_path: selectedLink,
+          target_library: targetLibrary.trim() || session.componentName,
+          target_name: targetName.trim(),
+          counterpart_asset_id: counterpartAssetId,
+          expected_revision_id: session.expectedRevisionId,
+        }),
+      });
+      if (!aliveRef.current) return;
+      toast.success(`${label} linked as a new revision.`);
+      onSuccess();
+    } catch (reason) {
+      if (!aliveRef.current) return;
+      toast.error(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      if (aliveRef.current) setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(next) => { if (!next && !submitting) onClose(); }}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Add {label.toLowerCase()}</DialogTitle>
+          <DialogDescription>Upload a file or link one already present in Prism storage. Attaching it creates a new immutable component revision.</DialogDescription>
+        </DialogHeader>
+        {importSelection ? (
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <Label>Select the {session.assetType === "symbol" ? "symbol" : "footprint"} to import</Label>
+              <div className="max-h-64 space-y-1 overflow-y-auto border p-2">
+                {importSelection.options.map((option) => (
+                  <button key={option} type="button" className={cn("w-full border px-3 py-2 text-left text-sm hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring", importSelection.selected === option && "border-primary bg-primary/5")} onClick={() => setImportSelection((current) => current ? { ...current, selected: option } : current)}>{option}</button>
+                ))}
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" disabled={submitting} onClick={onClose}>Cancel</Button>
+              <Button disabled={submitting || !importSelection.selected} onClick={() => void handleUpload()}>{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />} Import selected</Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <>
+            <div className="inline-flex items-center gap-1 border bg-muted/30 p-1" role="tablist" aria-label="Asset source">
+              {ASSET_SOURCE_TABS.map(({ id, label: tabLabel, icon: Icon }) => (
+                <button
+                  key={id}
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === id}
+                  disabled={submitting}
+                  className={cn(
+                    "inline-flex h-7 items-center gap-1.5 border border-transparent px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                    mode === id
+                      ? "border-border bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                  onClick={() => setMode(id)}
+                >
+                  <Icon className="h-3.5 w-3.5" />{tabLabel}
+                </button>
+              ))}
+            </div>
+            <div className="space-y-4">
+              {mode === "upload" ? (
+                <div className="space-y-2">
+                  <Label htmlFor="component-asset-file">{label} file</Label>
+                  <FileInput
+                    id="component-asset-file"
+                    accept={ASSET_ACCEPT[session.assetType]}
+                    value={file}
+                    onValueChange={setFile}
+                    disabled={submitting}
+                  />
+                  {file ? <p className="text-xs text-muted-foreground">{formatBytes(file.size)}</p> : null}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <Label htmlFor="component-existing-asset">Existing file</Label>
+                  <StoredFilePicker
+                    id="component-existing-asset"
+                    assetType={session.assetType}
+                    value={selectedLink}
+                    onChange={setSelectedLink}
+                  />
+                </div>
+              )}
+              <div className={cn("grid gap-4", mode === "link" && "sm:grid-cols-2")}>
+                <div className="space-y-2"><Label htmlFor="component-asset-library">Target library</Label><Input id="component-asset-library" value={targetLibrary} onChange={(event) => setTargetLibrary(event.target.value)} placeholder="Prism library" /></div>
+                {mode === "link" ? <div className="space-y-2"><Label htmlFor="component-asset-name">Target item name</Label><Input id="component-asset-name" value={targetName} onChange={(event) => setTargetName(event.target.value)} placeholder="Auto-detect" /></div> : null}
+              </div>
+              {(session.assetType === "symbol" || session.assetType === "footprint") && session.counterpartAssets.length ? (
+                <div className="space-y-2">
+                  <Label htmlFor="component-counterpart-asset">Pair with {session.assetType === "symbol" ? "footprint" : "symbol"}</Label>
+                  <Select value={counterpartAssetId} onValueChange={setCounterpartAssetId}>
+                    <SelectTrigger id="component-counterpart-asset" className="w-full"><SelectValue placeholder="Select the counterpart asset" /></SelectTrigger>
+                    <SelectContent>{session.counterpartAssets.map((asset) => <SelectItem key={asset.id} value={asset.id}>{asset.target_library ? `${asset.target_library}:` : ""}{asset.target_name}</SelectItem>)}</SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">The current default counterpart is preselected. You can edit the resulting pair in Representations.</p>
+                </div>
+              ) : null}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" disabled={submitting} onClick={onClose}>Cancel</Button>
+              <Button disabled={submitting || (mode === "upload" ? !file : !selectedLink)} onClick={mode === "upload" ? () => void handleUpload() : () => void handleLink()}>
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : mode === "upload" ? <Upload className="h-4 w-4" /> : <Link2 className="h-4 w-4" />}{mode === "upload" ? "Attach file" : "Link asset"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
+++ b/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@/lib/api", () => ({
 }));
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn(), message: vi.fn(), warning: vi.fn(), info: vi.fn() } }));
 
-import { fetchJson } from "@/lib/api";
+import { ApiHttpError, fetchJson } from "@/lib/api";
 import type { CatalogComponent } from "@/types/catalog";
 import {
     AssetAttachDialog,
@@ -180,6 +180,36 @@ describe("asset attach session", () => {
         expect(String(request?.[0])).toContain("/symbol-import");
         const body = request?.[1]?.body as FormData;
         expect(body.get("expected_revision_id")).toBe("comp-a-rev1");
+    });
+
+    it("closes on revision_conflict so the next open recaptures the head", async () => {
+        vi.mocked(fetchJson).mockRejectedValue(
+            new ApiHttpError("Refresh the component before saving.", 409, "revision_conflict"),
+        );
+        const onClose = vi.fn();
+        const onSuccess = vi.fn();
+        const session = assetAttachSessionFrom(catalogComponent(), "symbol");
+        render(<AssetAttachDialog session={session} onClose={onClose} onSuccess={onSuccess} />);
+
+        chooseFile(new File(["sym"], "part.kicad_sym"));
+        fireEvent.click(screen.getByRole("button", { name: /attach file/i }));
+        await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("keeps the session open on a non-revision 409", async () => {
+        vi.mocked(fetchJson).mockRejectedValue(
+            new ApiHttpError("That asset is still referenced.", 409, "asset_referenced"),
+        );
+        const onClose = vi.fn();
+        const session = assetAttachSessionFrom(catalogComponent(), "symbol");
+        render(<AssetAttachDialog session={session} onClose={onClose} onSuccess={vi.fn()} />);
+
+        chooseFile(new File(["sym"], "part.kicad_sym"));
+        fireEvent.click(screen.getByRole("button", { name: /attach file/i }));
+        await waitFor(() => expect(fetchJson).toHaveBeenCalled());
+        expect(onClose).not.toHaveBeenCalled();
+        expect(screen.getByRole("heading", { name: "Add symbol" })).toBeInTheDocument();
     });
 });
 

--- a/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
+++ b/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
@@ -9,8 +9,9 @@ vi.mock("@/lib/api", () => ({
     ApiHttpError: class ApiHttpError extends Error {
         status: number;
         code?: string;
-        constructor(message: string, status: number, code?: string) {
+        constructor(status: number, message: string, code?: string) {
             super(message);
+            this.name = "ApiHttpError";
             this.status = status;
             this.code = code;
         }
@@ -184,7 +185,7 @@ describe("asset attach session", () => {
 
     it("closes on revision_conflict so the next open recaptures the head", async () => {
         vi.mocked(fetchJson).mockRejectedValue(
-            new ApiHttpError("Refresh the component before saving.", 409, "revision_conflict"),
+            new ApiHttpError(409, "Refresh the component before saving.", "revision_conflict"),
         );
         const onClose = vi.fn();
         const onSuccess = vi.fn();
@@ -199,7 +200,7 @@ describe("asset attach session", () => {
 
     it("keeps the session open on a non-revision 409", async () => {
         vi.mocked(fetchJson).mockRejectedValue(
-            new ApiHttpError("That asset is still referenced.", 409, "asset_referenced"),
+            new ApiHttpError(409, "That asset is still referenced.", "asset_referenced"),
         );
         const onClose = vi.fn();
         const session = assetAttachSessionFrom(catalogComponent(), "symbol");

--- a/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
+++ b/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
@@ -1,0 +1,217 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+    fetchJson: vi.fn(),
+    fetchApi: vi.fn(),
+    readApiError: vi.fn(async () => "error"),
+    ApiHttpError: class ApiHttpError extends Error {
+        status: number;
+        code?: string;
+        constructor(message: string, status: number, code?: string) {
+            super(message);
+            this.status = status;
+            this.code = code;
+        }
+    },
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn(), message: vi.fn(), warning: vi.fn(), info: vi.fn() } }));
+
+import { fetchJson } from "@/lib/api";
+import type { CatalogComponent } from "@/types/catalog";
+import {
+    AssetAttachDialog,
+    assetAttachSessionFrom,
+} from "./library-component-asset-dialog";
+import { LibraryComponentWorkspace } from "./library-component-workspace";
+import {
+    MetadataEditDialog,
+    metadataEditSessionFrom,
+} from "./library-component-metadata-dialog";
+
+function catalogComponent(id = "comp-a"): CatalogComponent {
+    return {
+        id,
+        slug: id,
+        name: id.toUpperCase(),
+        mpn: "RC0603",
+        value: "10k",
+        manufacturer: "Yageo",
+        description: "Resistor",
+        datasheet_url: "https://example.test/ds",
+        extra_fields: {},
+        library_name: "PrismLib",
+        change_kind: "metadata",
+        change_summary: "Initial",
+        created_by: "someone",
+        manifest_hash: "",
+        workflow_stage: "draft",
+        revision: 1,
+        revision_id: `${id}-rev1`,
+        parent_revision_id: "",
+        version: 1,
+        assets: [],
+        representations: [],
+        extra: {},
+        availability_state: "active",
+        validation_status: "unknown",
+        identity_kind: "mpn",
+        source: "manual",
+        preview_status: {},
+        previews: [],
+        validation: { status: "unknown", error_count: 0, warning_count: 0 },
+        missing_assets: [],
+        place_enabled: false,
+    } as unknown as CatalogComponent;
+}
+
+function chooseFile(file: File) {
+    const input = document.getElementById("component-asset-file");
+    if (!(input instanceof HTMLInputElement)) throw new Error("file input missing");
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    fireEvent.change(input);
+}
+
+describe("metadata edit session", () => {
+    beforeEach(() => {
+        vi.mocked(fetchJson).mockReset();
+    });
+
+    it("opens a fresh buffer after cancel so edited fields do not leak", async () => {
+        const first = metadataEditSessionFrom(catalogComponent());
+        const { rerender } = render(
+            <MetadataEditDialog session={first} onClose={vi.fn()} onSuccess={vi.fn()} />,
+        );
+
+        fireEvent.change(screen.getByLabelText("Value *"), { target: { value: "leaked-value" } });
+        expect(screen.getByLabelText("Value *")).toHaveValue("leaked-value");
+
+        const second = metadataEditSessionFrom(catalogComponent());
+        rerender(
+            <MetadataEditDialog key={second.openedAt} session={second} onClose={vi.fn()} onSuccess={vi.fn()} />,
+        );
+
+        expect(screen.getByLabelText("Value *")).toHaveValue("10k");
+        expect(screen.queryByDisplayValue("leaked-value")).not.toBeInTheDocument();
+    });
+
+    it("sends the revision captured when the session opened", async () => {
+        vi.mocked(fetchJson).mockResolvedValue(catalogComponent() as never);
+        const onSuccess = vi.fn();
+        const session = metadataEditSessionFrom({
+            ...catalogComponent(),
+            revision_id: "rev-at-open",
+        });
+        render(<MetadataEditDialog session={session} onClose={vi.fn()} onSuccess={onSuccess} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /save new revision/i }));
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+        const body = JSON.parse(String(vi.mocked(fetchJson).mock.calls[0]?.[1]?.body));
+        expect(body.expected_revision_id).toBe("rev-at-open");
+    });
+});
+
+describe("asset attach session", () => {
+    beforeEach(() => {
+        vi.mocked(fetchJson).mockReset();
+    });
+
+    it("drops a selected file when a new asset type session opens", async () => {
+        const onClose = vi.fn();
+        const symbol = assetAttachSessionFrom(catalogComponent(), "symbol");
+        const { rerender } = render(
+            <AssetAttachDialog session={symbol} onClose={onClose} onSuccess={vi.fn()} />,
+        );
+
+        chooseFile(new File(["sym"], "part.kicad_sym"));
+        expect(screen.getByText("part.kicad_sym")).toBeInTheDocument();
+
+        const footprint = assetAttachSessionFrom(catalogComponent(), "footprint");
+        rerender(
+            <AssetAttachDialog key={footprint.openedAt} session={footprint} onClose={onClose} onSuccess={vi.fn()} />,
+        );
+
+        expect(screen.getByRole("heading", { name: "Add footprint" })).toBeInTheDocument();
+        expect(screen.queryByText("part.kicad_sym")).not.toBeInTheDocument();
+        expect(screen.getByLabelText("Target library")).toHaveValue("PrismLib");
+    });
+
+    it("does not keep a selection_required picker after cancel and reopen", async () => {
+        vi.mocked(fetchJson).mockResolvedValue({
+            mode: "selection_required",
+            discovered_symbols: ["SYM_A", "SYM_B"],
+        } as never);
+        const first = assetAttachSessionFrom(catalogComponent(), "symbol");
+        const { rerender } = render(
+            <AssetAttachDialog session={first} onClose={vi.fn()} onSuccess={vi.fn()} />,
+        );
+
+        chooseFile(new File(["sym"], "multi.kicad_sym"));
+        fireEvent.click(screen.getByRole("button", { name: /attach file/i }));
+        expect(await screen.findByText("SYM_A")).toBeInTheDocument();
+
+        const second = assetAttachSessionFrom(catalogComponent(), "symbol");
+        rerender(
+            <AssetAttachDialog key={second.openedAt} session={second} onClose={vi.fn()} onSuccess={vi.fn()} />,
+        );
+
+        expect(screen.queryByText("SYM_A")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /attach file/i })).toBeInTheDocument();
+    });
+
+    it("ignores a delayed upload that completes after the session unmounts", async () => {
+        let finish: ((value: { component: CatalogComponent }) => void) | undefined;
+        vi.mocked(fetchJson).mockImplementation(() => new Promise((resolve) => {
+            finish = resolve;
+        }));
+        const onSuccess = vi.fn();
+        const session = assetAttachSessionFrom(catalogComponent(), "symbol");
+        const { unmount } = render(
+            <AssetAttachDialog session={session} onClose={vi.fn()} onSuccess={onSuccess} />,
+        );
+
+        chooseFile(new File(["sym"], "part.kicad_sym"));
+        fireEvent.click(screen.getByRole("button", { name: /attach file/i }));
+        unmount();
+        finish!({ component: catalogComponent() });
+        await waitFor(() => expect(onSuccess).not.toHaveBeenCalled());
+        const request = vi.mocked(fetchJson).mock.calls[0];
+        expect(String(request?.[0])).toContain("/symbol-import");
+        const body = request?.[1]?.body as FormData;
+        expect(body.get("expected_revision_id")).toBe("comp-a-rev1");
+    });
+});
+
+describe("workspace dialog sessions", () => {
+    beforeEach(() => {
+        vi.mocked(fetchJson).mockImplementation(async (input) => {
+            const url = String(input);
+            if (url === "/api/catalog/components/comp-a") return catalogComponent() as never;
+            return { items: [] } as never;
+        });
+    });
+    afterEach(() => vi.clearAllMocks());
+
+    it("reopens metadata from the current component, not the cancelled buffer", async () => {
+        render(
+            <MemoryRouter initialEntries={["/?section=library-manager"]}>
+                <LibraryComponentWorkspace
+                    componentId="comp-a"
+                    user={{ id: "u1", email: "a@b.c", role: "admin" } as never}
+                    projects={[]}
+                    onBack={vi.fn()}
+                />
+            </MemoryRouter>,
+        );
+
+        fireEvent.click(await screen.findByRole("button", { name: /edit metadata/i }));
+        fireEvent.change(screen.getByLabelText("Value *"), { target: { value: "cancelled-edit" } });
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        await waitFor(() => expect(screen.queryByRole("heading", { name: "Edit component metadata" })).not.toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole("button", { name: /edit metadata/i }));
+        expect(screen.getByLabelText("Value *")).toHaveValue("10k");
+        expect(screen.queryByDisplayValue("cancelled-edit")).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/workspace/library-component-metadata-dialog.tsx
+++ b/frontend/src/components/workspace/library-component-metadata-dialog.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from "react";
+import { Edit3, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { fetchJson } from "@/lib/api";
+import type { CatalogComponent } from "@/types/catalog";
+
+type MetadataForm = {
+  value: string;
+  description: string;
+  datasheetUrl: string;
+  manufacturer: string;
+  mpn: string;
+  category: string;
+  packageName: string;
+  vendor: string;
+  vendorPartNumber: string;
+  massG: string;
+  rqjcCW: string;
+  rqjcTopCW: string;
+  tempMaxC: string;
+  tempMinC: string;
+  powerDissipationW: string;
+  rate: string;
+  sapCode: string;
+  extraFieldsJson: string;
+  changeSummary: string;
+};
+
+export type MetadataEditSession = {
+  openedAt: string;
+  componentId: string;
+  expectedRevisionId: string;
+  form: MetadataForm;
+};
+
+let nextMetadataSession = 0;
+
+const metadataFormFromComponent = (component: CatalogComponent): MetadataForm => ({
+  value: component.value || "",
+  description: component.description || "",
+  datasheetUrl: component.datasheet_url || "",
+  manufacturer: component.manufacturer || "",
+  mpn: component.mpn || "",
+  category: component.category || "",
+  packageName: component.package_name || "",
+  vendor: component.vendor || "",
+  vendorPartNumber: component.vendor_part_number || "",
+  massG: component.mass_g || "",
+  rqjcCW: component.rqjc_c_w || "",
+  rqjcTopCW: component.rqjc_top_c_w || "",
+  tempMaxC: component.temp_max_c || "",
+  tempMinC: component.temp_min_c || "",
+  powerDissipationW: component.power_dissipation_w || "",
+  rate: component.rate || "",
+  sapCode: component.sap_code || "",
+  extraFieldsJson: JSON.stringify(component.extra_fields ?? {}, null, 2),
+  changeSummary: "Update component metadata",
+});
+
+export function metadataEditSessionFrom(component: CatalogComponent): MetadataEditSession {
+  nextMetadataSession += 1;
+  return {
+    openedAt: `metadata-${nextMetadataSession}`,
+    componentId: component.id,
+    expectedRevisionId: component.revision_id,
+    form: metadataFormFromComponent(component),
+  };
+}
+
+const METADATA_FIELDS: Array<{ field: keyof MetadataForm; label: string; type?: string; placeholder?: string }> = [
+  { field: "value", label: "Value", placeholder: "10 kΩ, TPS55289…" },
+  { field: "manufacturer", label: "Manufacturer" },
+  { field: "mpn", label: "Manufacturer part number" },
+  { field: "datasheetUrl", label: "Datasheet URL", type: "url" },
+  { field: "category", label: "Category" },
+  { field: "packageName", label: "Package" },
+  { field: "vendor", label: "Vendor" },
+  { field: "vendorPartNumber", label: "Vendor part number" },
+  { field: "massG", label: "Mass (g)" },
+  { field: "rqjcCW", label: "RθJC (°C/W)" },
+  { field: "rqjcTopCW", label: "RθJC top (°C/W)" },
+  { field: "tempMaxC", label: "Maximum temperature (°C)" },
+  { field: "tempMinC", label: "Minimum temperature (°C)" },
+  { field: "powerDissipationW", label: "Power dissipation (W)" },
+  { field: "rate", label: "Rate" },
+  { field: "sapCode", label: "SAP code" },
+];
+
+export function MetadataEditDialog({
+  session,
+  onClose,
+  onSuccess,
+}: {
+  session: MetadataEditSession;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [form, setForm] = useState<MetadataForm>(session.form);
+  const [submitting, setSubmitting] = useState(false);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const setField = (field: keyof MetadataForm, value: string) => setForm({ ...form, [field]: value });
+  const requiredComplete = Boolean(
+    form.value.trim()
+    && form.manufacturer.trim()
+    && form.mpn.trim()
+    && form.description.trim()
+    && form.datasheetUrl.trim()
+    && form.changeSummary.trim(),
+  );
+
+  const handleSubmit = async () => {
+    let extraFields: Record<string, string>;
+    try {
+      const parsed: unknown = JSON.parse(form.extraFieldsJson || "{}");
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Extended fields must be a JSON object.");
+      extraFields = Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value ?? "")]));
+    } catch (reason) {
+      toast.error(reason instanceof Error ? reason.message : "Extended fields contain invalid JSON.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await fetchJson<CatalogComponent>(`/api/catalog/components/${encodeURIComponent(session.componentId)}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          value: form.value.trim(),
+          description: form.description.trim(),
+          datasheet_url: form.datasheetUrl.trim(),
+          manufacturer: form.manufacturer.trim(),
+          mpn: form.mpn.trim(),
+          category: form.category.trim(),
+          package_name: form.packageName.trim(),
+          vendor: form.vendor.trim(),
+          vendor_part_number: form.vendorPartNumber.trim(),
+          mass_g: form.massG.trim(),
+          rqjc_c_w: form.rqjcCW.trim(),
+          rqjc_top_c_w: form.rqjcTopCW.trim(),
+          temp_max_c: form.tempMaxC.trim(),
+          temp_min_c: form.tempMinC.trim(),
+          power_dissipation_w: form.powerDissipationW.trim(),
+          rate: form.rate.trim(),
+          sap_code: form.sapCode.trim(),
+          extra_fields: extraFields,
+          change_summary: form.changeSummary.trim(),
+          expected_revision_id: session.expectedRevisionId,
+        }),
+      });
+      if (!aliveRef.current) return;
+      toast.success("Metadata saved as a new revision.");
+      onSuccess();
+    } catch (reason) {
+      if (!aliveRef.current) return;
+      toast.error(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      if (aliveRef.current) setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(next) => { if (!next && !submitting) onClose(); }}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Edit component metadata</DialogTitle>
+          <DialogDescription>Saving creates a new immutable revision. The current revision ID is checked to prevent overwriting concurrent work.</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {METADATA_FIELDS.map(({ field, label, type, placeholder }) => (
+            <div key={field} className="space-y-2">
+              <Label htmlFor={`component-edit-${field}`}>{label}{["value", "manufacturer", "mpn", "datasheetUrl"].includes(field) ? " *" : ""}</Label>
+              <Input id={`component-edit-${field}`} type={type} required={["value", "manufacturer", "mpn", "datasheetUrl"].includes(field)} value={form[field]} placeholder={placeholder} onChange={(event) => setField(field, event.target.value)} />
+            </div>
+          ))}
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="component-edit-description">Description *</Label>
+            <Textarea id="component-edit-description" required value={form.description} rows={3} onChange={(event) => setField("description", event.target.value)} />
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="component-edit-extra-fields">Extended symbol fields (JSON object)</Label>
+            <Textarea id="component-edit-extra-fields" className="font-mono text-xs" value={form.extraFieldsJson} rows={6} spellCheck={false} onChange={(event) => setField("extraFieldsJson", event.target.value)} />
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="component-edit-summary">Change summary *</Label>
+            <Input id="component-edit-summary" required value={form.changeSummary} placeholder="Describe why this revision is needed" onChange={(event) => setField("changeSummary", event.target.value)} />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" disabled={submitting} onClick={onClose}>Cancel</Button>
+          <Button disabled={submitting || !requiredComplete} onClick={() => void handleSubmit()}>{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Edit3 className="h-4 w-4" />} Save new revision</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -3,8 +3,6 @@ import {
   Archive,
   ArrowLeft,
   Boxes,
-  Check,
-  ChevronDown,
   ChevronRight,
   CircleAlert,
   CircleDashed,
@@ -44,10 +42,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { FileInput } from "@/components/ui/file-input";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { AsyncSearchPicker } from "./async-search-picker";
 import {
   Select,
   SelectContent,
@@ -56,7 +52,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { ApiHttpError, fetchJson } from "@/lib/api";
+import { fetchJson } from "@/lib/api";
 import { canWriteCatalog, workflowStage } from "@/lib/roles";
 import { cn } from "@/lib/utils";
 import type { User } from "@/types/auth";
@@ -73,8 +69,6 @@ import type {
   CatalogRevisionDiff,
   CatalogRevisionSummary,
   CatalogValidationStatus,
-  ImportCompletedResponse,
-  SelectionRequiredResponse,
   WorkflowStage,
 } from "@/types/catalog";
 import type { Project } from "@/types/project";
@@ -107,42 +101,21 @@ import {
   WhereUsedPanel,
 } from "./library-component-evidence-panels";
 import { LibraryPreviewPair } from "./library-preview-inspector";
-import { assetMutationRevisionId, releaseRetainedRevisionOnConflict } from "./library-asset-mutation";
+import {
+  ASSET_LABELS,
+  AssetAttachDialog,
+  assetAttachSessionFrom,
+  type AssetAttachSession,
+  type AssetType,
+} from "./library-component-asset-dialog";
+import {
+  MetadataEditDialog,
+  metadataEditSessionFrom,
+  type MetadataEditSession,
+} from "./library-component-metadata-dialog";
 import { resolveLibraryPreviewPairAssetIds } from "./library-preview-pair";
 
 type ComponentTab = "overview" | "assets" | "revisions" | "review" | "usage" | "audit";
-type AssetType = CatalogAsset["asset_type"];
-type AssetAttachMode = "upload" | "link";
-
-type MetadataForm = {
-  value: string;
-  description: string;
-  datasheetUrl: string;
-  manufacturer: string;
-  mpn: string;
-  category: string;
-  packageName: string;
-  vendor: string;
-  vendorPartNumber: string;
-  massG: string;
-  rqjcCW: string;
-  rqjcTopCW: string;
-  tempMaxC: string;
-  tempMinC: string;
-  powerDissipationW: string;
-  rate: string;
-  sapCode: string;
-  extraFieldsJson: string;
-  changeSummary: string;
-};
-
-type AssetImportSelection = {
-  file: File;
-  targetLibrary: string;
-  options: string[];
-  selected: string;
-  expectedRevisionId: string;
-};
 
 type ValidationJob = {
   status: "queued" | "running" | "completed" | "failed";
@@ -169,20 +142,6 @@ const COMPONENT_TABS: Array<{ id: ComponentTab; label: string; icon: typeof Boxe
   { id: "usage", label: "Where Used", icon: Link2 },
   { id: "audit", label: "Audit", icon: ShieldCheck },
 ];
-
-const ASSET_LABELS: Record<AssetType, string> = {
-  symbol: "Symbol",
-  footprint: "Footprint",
-  "3dmodel": "3D model",
-  spice: "SPICE model",
-};
-
-const ASSET_ACCEPT: Record<AssetType, string> = {
-  symbol: ".kicad_sym",
-  footprint: ".kicad_mod,.zip",
-  "3dmodel": ".step,.stp,.wrl",
-  spice: ".sp,.cir,.spice,.lib",
-};
 
 const WORKFLOW_LABELS: Record<WorkflowStage, string> = {
   open: "Open",
@@ -233,28 +192,6 @@ function isCatalogComponent(value: unknown): value is CatalogComponent {
     && typeof candidate.validation === "object"
     && candidate.validation !== null;
 }
-
-const metadataFormFromComponent = (component: CatalogComponent): MetadataForm => ({
-  value: component.value,
-  description: component.description,
-  datasheetUrl: component.datasheet_url,
-  manufacturer: component.manufacturer,
-  mpn: component.mpn,
-  category: component.category,
-  packageName: component.package_name,
-  vendor: component.vendor,
-  vendorPartNumber: component.vendor_part_number,
-  massG: component.mass_g,
-  rqjcCW: component.rqjc_c_w,
-  rqjcTopCW: component.rqjc_top_c_w,
-  tempMaxC: component.temp_max_c,
-  tempMinC: component.temp_min_c,
-  powerDissipationW: component.power_dissipation_w,
-  rate: component.rate,
-  sapCode: component.sap_code,
-  extraFieldsJson: JSON.stringify(component.extra_fields, null, 2),
-  changeSummary: "Update component metadata",
-});
 
 function OverviewPanel({ component, canMutate, onEdit }: { component: CatalogComponent; canMutate: boolean; onEdit: () => void }) {
   const requiredAttached = component.assets.filter((asset) => asset.required).length;
@@ -602,293 +539,6 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
   );
 }
 
-function MetadataEditDialog({
-  open,
-  form,
-  submitting,
-  onOpenChange,
-  onChange,
-  onSubmit,
-}: {
-  open: boolean;
-  form: MetadataForm | null;
-  submitting: boolean;
-  onOpenChange: (open: boolean) => void;
-  onChange: (form: MetadataForm) => void;
-  onSubmit: () => void;
-}) {
-  if (!form) return null;
-  const setField = (field: keyof MetadataForm, value: string) => onChange({ ...form, [field]: value });
-  const requiredComplete = Boolean(form.value.trim() && form.manufacturer.trim() && form.mpn.trim() && form.description.trim() && form.datasheetUrl.trim() && form.changeSummary.trim());
-  return (
-    <Dialog open={open} onOpenChange={(next) => { if (!submitting) onOpenChange(next); }}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
-        <DialogHeader>
-          <DialogTitle>Edit component metadata</DialogTitle>
-          <DialogDescription>Saving creates a new immutable revision. The current revision ID is checked to prevent overwriting concurrent work.</DialogDescription>
-        </DialogHeader>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {METADATA_FIELDS.map(({ field, label, type, placeholder }) => (
-            <div key={field} className="space-y-2">
-              <Label htmlFor={`component-edit-${field}`}>{label}{["value", "manufacturer", "mpn", "datasheetUrl"].includes(field) ? " *" : ""}</Label>
-              <Input id={`component-edit-${field}`} type={type} required={["value", "manufacturer", "mpn", "datasheetUrl"].includes(field)} value={form[field]} placeholder={placeholder} onChange={(event) => setField(field, event.target.value)} />
-            </div>
-          ))}
-          <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="component-edit-description">Description *</Label>
-            <Textarea id="component-edit-description" required value={form.description} rows={3} onChange={(event) => setField("description", event.target.value)} />
-          </div>
-          <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="component-edit-extra-fields">Extended symbol fields (JSON object)</Label>
-            <Textarea id="component-edit-extra-fields" className="font-mono text-xs" value={form.extraFieldsJson} rows={6} spellCheck={false} onChange={(event) => setField("extraFieldsJson", event.target.value)} />
-          </div>
-          <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="component-edit-summary">Change summary *</Label>
-            <Input id="component-edit-summary" required value={form.changeSummary} placeholder="Describe why this revision is needed" onChange={(event) => setField("changeSummary", event.target.value)} />
-          </div>
-        </div>
-        <DialogFooter>
-          <Button variant="outline" disabled={submitting} onClick={() => onOpenChange(false)}>Cancel</Button>
-          <Button disabled={submitting || !requiredComplete} onClick={onSubmit}>{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Edit3 className="h-4 w-4" />} Save new revision</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-const STORED_FILE_RESULT_LIMIT = 50;
-
-/** Pick a file already sitting in Prism storage, including ones never registered as an asset. */
-function StoredFilePicker({
-  id,
-  assetType,
-  value,
-  onChange,
-}: {
-  id: string;
-  assetType: AssetType;
-  value: string;
-  onChange: (path: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const kind = ASSET_LABELS[assetType].toLowerCase();
-
-  return (
-    <AsyncSearchPicker<string>
-      id={id}
-      open={open}
-      onOpenChange={setOpen}
-      // Portalled out of the attach dialog, so it needs its own modal layer.
-      modal
-      contentClassName="w-[var(--radix-popover-trigger-width)]"
-      fetchKey={assetType}
-      trigger={
-        <button
-          type="button"
-          id={id}
-          aria-expanded={open}
-          className="border-input dark:bg-input/30 dark:hover:bg-input/50 flex h-9 w-full min-w-0 items-center justify-between gap-1.5 border px-3 py-2 text-left text-xs leading-none transition-colors outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-1"
-        >
-          <span className={cn("min-w-0 truncate", value ? "text-foreground" : "text-muted-foreground")}>{value || "Select a stored file"}</span>
-          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-        </button>
-      }
-      fetchPage={(query, signal) =>
-        fetchJson<{ files: string[]; total?: number }>(
-          `/api/catalog/assets/browse?asset_type=${encodeURIComponent(assetType)}&limit=${STORED_FILE_RESULT_LIMIT}&q=${encodeURIComponent(query)}`,
-          { signal },
-          "Stored assets could not be listed.",
-        ).then((response) => ({ items: response.files, total: response.total }))
-      }
-      getKey={(path) => path}
-      isSelected={(path) => path === value}
-      onSelect={onChange}
-      searchPlaceholder={`Search stored ${kind} files`}
-      listLabel={`Stored ${kind} files`}
-      emptyMessage={`No stored ${kind} files match.`}
-      renderItem={(path) => (
-        <>
-          <Check className={cn("h-3.5 w-3.5 shrink-0", path === value ? "text-primary" : "invisible")} />
-          <span className="min-w-0 flex-1 truncate">{path}</span>
-        </>
-      )}
-      renderFooter={({ shown, total }) =>
-        total > shown ? (
-          <p className="border-t px-2.5 py-1.5 text-[11px] text-muted-foreground">Showing {shown} of {total} stored files — refine the search to narrow.</p>
-        ) : null
-      }
-    />
-  );
-}
-
-function AssetAttachDialog({
-  assetType,
-  mode,
-  file,
-  targetLibrary,
-  targetName,
-  counterpartAssets,
-  counterpartAssetId,
-  selectedLink,
-  selection,
-  submitting,
-  onOpenChange,
-  onModeChange,
-  onFileChange,
-  onTargetLibraryChange,
-  onTargetNameChange,
-  onCounterpartAssetChange,
-  onSelectedLinkChange,
-  onSelectionChange,
-  onUpload,
-  onLink,
-}: {
-  assetType: AssetType | null;
-  mode: AssetAttachMode;
-  file: File | null;
-  targetLibrary: string;
-  targetName: string;
-  counterpartAssets: CatalogAsset[];
-  counterpartAssetId: string;
-  selectedLink: string;
-  selection: AssetImportSelection | null;
-  submitting: boolean;
-  onOpenChange: (open: boolean) => void;
-  onModeChange: (mode: AssetAttachMode) => void;
-  onFileChange: (file: File | null) => void;
-  onTargetLibraryChange: (value: string) => void;
-  onTargetNameChange: (value: string) => void;
-  onCounterpartAssetChange: (value: string) => void;
-  onSelectedLinkChange: (value: string) => void;
-  onSelectionChange: (value: string) => void;
-  onUpload: () => void;
-  onLink: () => void;
-}) {
-  const label = assetType ? ASSET_LABELS[assetType] : "asset";
-  return (
-    <Dialog open={assetType !== null} onOpenChange={(next) => { if (!submitting) onOpenChange(next); }}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
-        <DialogHeader>
-          <DialogTitle>Add {label.toLowerCase()}</DialogTitle>
-          <DialogDescription>Upload a file or link one already present in Prism storage. Attaching it creates a new immutable component revision.</DialogDescription>
-        </DialogHeader>
-        {selection ? (
-          <div className="space-y-4">
-            <div className="space-y-1">
-              <Label>Select the {assetType === "symbol" ? "symbol" : "footprint"} to import</Label>
-              <div className="max-h-64 space-y-1 overflow-y-auto border p-2">
-                {selection.options.map((option) => (
-                  <button key={option} type="button" className={cn("w-full border px-3 py-2 text-left text-sm hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring", selection.selected === option && "border-primary bg-primary/5")} onClick={() => onSelectionChange(option)}>{option}</button>
-                ))}
-              </div>
-            </div>
-            <DialogFooter>
-              <Button variant="outline" disabled={submitting} onClick={() => onOpenChange(false)}>Cancel</Button>
-              <Button disabled={submitting || !selection.selected} onClick={onUpload}>{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />} Import selected</Button>
-            </DialogFooter>
-          </div>
-        ) : (
-          <>
-            <div className="inline-flex items-center gap-1 border bg-muted/30 p-1" role="tablist" aria-label="Asset source">
-              {ASSET_SOURCE_TABS.map(({ id, label: tabLabel, icon: Icon }) => (
-                <button
-                  key={id}
-                  type="button"
-                  role="tab"
-                  aria-selected={mode === id}
-                  disabled={submitting}
-                  className={cn(
-                    "inline-flex h-7 items-center gap-1.5 border border-transparent px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                    mode === id
-                      ? "border-border bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  )}
-                  onClick={() => onModeChange(id)}
-                >
-                  <Icon className="h-3.5 w-3.5" />{tabLabel}
-                </button>
-              ))}
-            </div>
-            <div className="space-y-4">
-              {mode === "upload" ? (
-                <div className="space-y-2">
-                  <Label htmlFor="component-asset-file">{label} file</Label>
-                  <FileInput
-                    id="component-asset-file"
-                    accept={assetType ? ASSET_ACCEPT[assetType] : undefined}
-                    value={file}
-                    onValueChange={onFileChange}
-                    disabled={submitting}
-                  />
-                  {file ? <p className="text-xs text-muted-foreground">{formatBytes(file.size)}</p> : null}
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <Label htmlFor="component-existing-asset">Existing file</Label>
-                  {assetType ? (
-                    <StoredFilePicker
-                      id="component-existing-asset"
-                      assetType={assetType}
-                      value={selectedLink}
-                      onChange={onSelectedLinkChange}
-                    />
-                  ) : null}
-                </div>
-              )}
-              <div className={cn("grid gap-4", mode === "link" && "sm:grid-cols-2")}>
-                <div className="space-y-2"><Label htmlFor="component-asset-library">Target library</Label><Input id="component-asset-library" value={targetLibrary} onChange={(event) => onTargetLibraryChange(event.target.value)} placeholder="Prism library" /></div>
-                {mode === "link" ? <div className="space-y-2"><Label htmlFor="component-asset-name">Target item name</Label><Input id="component-asset-name" value={targetName} onChange={(event) => onTargetNameChange(event.target.value)} placeholder="Auto-detect" /></div> : null}
-              </div>
-              {(assetType === "symbol" || assetType === "footprint") && counterpartAssets.length ? (
-                <div className="space-y-2">
-                  <Label htmlFor="component-counterpart-asset">Pair with {assetType === "symbol" ? "footprint" : "symbol"}</Label>
-                  <Select value={counterpartAssetId} onValueChange={onCounterpartAssetChange}>
-                    <SelectTrigger id="component-counterpart-asset" className="w-full"><SelectValue placeholder="Select the counterpart asset" /></SelectTrigger>
-                    <SelectContent>{counterpartAssets.map((asset) => <SelectItem key={asset.id} value={asset.id}>{asset.target_library ? `${asset.target_library}:` : ""}{asset.target_name}</SelectItem>)}</SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">The current default counterpart is preselected. You can edit the resulting pair in Representations.</p>
-                </div>
-              ) : null}
-            </div>
-            <DialogFooter>
-              <Button variant="outline" disabled={submitting} onClick={() => onOpenChange(false)}>Cancel</Button>
-              <Button disabled={submitting || (mode === "upload" ? !file : !selectedLink)} onClick={mode === "upload" ? onUpload : onLink}>
-                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : mode === "upload" ? <Upload className="h-4 w-4" /> : <Link2 className="h-4 w-4" />}{mode === "upload" ? "Attach file" : "Link asset"}
-              </Button>
-            </DialogFooter>
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-// Fixed table, no closure over props: build it once.
-const METADATA_FIELDS: Array<{ field: keyof MetadataForm; label: string; type?: string; placeholder?: string }> = [
-  { field: "value", label: "Value", placeholder: "10 kΩ, TPS55289…" },
-  { field: "manufacturer", label: "Manufacturer" },
-  { field: "mpn", label: "Manufacturer part number" },
-  { field: "datasheetUrl", label: "Datasheet URL", type: "url" },
-  { field: "category", label: "Category" },
-  { field: "packageName", label: "Package" },
-  { field: "vendor", label: "Vendor" },
-  { field: "vendorPartNumber", label: "Vendor part number" },
-  { field: "massG", label: "Mass (g)" },
-  { field: "rqjcCW", label: "RθJC (°C/W)" },
-  { field: "rqjcTopCW", label: "RθJC top (°C/W)" },
-  { field: "tempMaxC", label: "Maximum temperature (°C)" },
-  { field: "tempMinC", label: "Minimum temperature (°C)" },
-  { field: "powerDissipationW", label: "Power dissipation (W)" },
-  { field: "rate", label: "Rate" },
-  { field: "sapCode", label: "SAP code" },
-];
-
-// Fixed table, no closure over props: build it once.
-const ASSET_SOURCE_TABS: Array<{ id: AssetAttachMode; label: string; icon: typeof Upload }> = [
-  { id: "upload", label: "Upload file", icon: Upload },
-  { id: "link", label: "Link existing", icon: Link2 },
-];
-
 // react-doctor-disable-next-line no-giant-component - tabs, evidence, and release queue share one component resource
 export function LibraryComponentWorkspace({
   componentId,
@@ -947,16 +597,8 @@ export function LibraryComponentWorkspace({
   const [reviewNote, setReviewNote] = useState("");
   const [overrideReason, setOverrideReason] = useState("");
   const [transitioning, setTransitioning] = useState(false);
-  const [metadataOpen, setMetadataOpen] = useState(false);
-  const [metadataForm, setMetadataForm] = useState<MetadataForm | null>(null);
-  const [attachAssetType, setAttachAssetType] = useState<AssetType | null>(null);
-  const [attachMode, setAttachMode] = useState<AssetAttachMode>("upload");
-  const [attachFile, setAttachFile] = useState<File | null>(null);
-  const [attachTargetLibrary, setAttachTargetLibrary] = useState("");
-  const [attachTargetName, setAttachTargetName] = useState("");
-  const [attachCounterpartId, setAttachCounterpartId] = useState("");
-  const [selectedLink, setSelectedLink] = useState("");
-  const [importSelection, setImportSelection] = useState<AssetImportSelection | null>(null);
+  const [metadataSession, setMetadataSession] = useState<MetadataEditSession | null>(null);
+  const [attachSession, setAttachSession] = useState<AssetAttachSession | null>(null);
   const [detachAsset, setDetachAsset] = useState<CatalogAsset | null>(null);
   const [busyAction, setBusyAction] = useState("");
 
@@ -1194,156 +836,21 @@ export function LibraryComponentWorkspace({
     }
   };
 
+  const refreshAfterMutation = () => {
+    updateParams({ revision: null, compare: null });
+    setRefreshKey((value) => value + 1);
+  };
+
   const openMetadataEditor = () => {
     if (!currentComponent || !canMutate) return;
-    setMetadataForm(metadataFormFromComponent(currentComponent));
-    setMetadataOpen(true);
-  };
-
-  const handleMetadataSave = async () => {
-    if (!metadataForm || !currentComponent || !canMutate) return;
-    let extraFields: Record<string, string>;
-    try {
-      const parsed: unknown = JSON.parse(metadataForm.extraFieldsJson || "{}");
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Extended fields must be a JSON object.");
-      extraFields = Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value ?? "")]));
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : "Extended fields contain invalid JSON.");
-      return;
-    }
-    setBusyAction("metadata");
-    try {
-      await fetchJson<CatalogComponent>(`/api/catalog/components/${encodeURIComponent(componentId)}`, {
-        method: "PATCH",
-        body: JSON.stringify({
-          value: metadataForm.value.trim(),
-          description: metadataForm.description.trim(),
-          datasheet_url: metadataForm.datasheetUrl.trim(),
-          manufacturer: metadataForm.manufacturer.trim(),
-          mpn: metadataForm.mpn.trim(),
-          category: metadataForm.category.trim(),
-          package_name: metadataForm.packageName.trim(),
-          vendor: metadataForm.vendor.trim(),
-          vendor_part_number: metadataForm.vendorPartNumber.trim(),
-          mass_g: metadataForm.massG.trim(),
-          rqjc_c_w: metadataForm.rqjcCW.trim(),
-          rqjc_top_c_w: metadataForm.rqjcTopCW.trim(),
-          temp_max_c: metadataForm.tempMaxC.trim(),
-          temp_min_c: metadataForm.tempMinC.trim(),
-          power_dissipation_w: metadataForm.powerDissipationW.trim(),
-          rate: metadataForm.rate.trim(),
-          sap_code: metadataForm.sapCode.trim(),
-          extra_fields: extraFields,
-          change_summary: metadataForm.changeSummary.trim(),
-          expected_revision_id: currentComponent.revision_id,
-        }),
-      });
-      toast.success("Metadata saved as a new revision.");
-      setMetadataOpen(false);
-      setMetadataForm(null);
-      updateParams({ revision: null, compare: null });
-      setRefreshKey((value) => value + 1);
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : String(reason));
-    } finally {
-      setBusyAction("");
-    }
-  };
-
-  const resetAttachDialog = () => {
-    setAttachAssetType(null);
-    setAttachMode("upload");
-    setAttachFile(null);
-    setAttachTargetLibrary("");
-    setAttachTargetName("");
-    setAttachCounterpartId("");
-    setSelectedLink("");
-    setImportSelection(null);
+    setMetadataSession(metadataEditSessionFrom(currentComponent));
   };
 
   const openAttachDialog = (assetType: AssetType) => {
     if (!currentComponent || !canMutate) return;
-    // The dialog opens instantly in upload mode. Stored files are only listed
-    // when the user actually opens the "Link existing" picker.
-    setAttachAssetType(assetType);
-    setAttachMode("upload");
-    setAttachFile(null);
-    setAttachTargetLibrary(currentComponent.library_name || currentComponent.name);
-    setAttachTargetName("");
-    const defaultRepresentation = currentComponent.representations.find((item) => item.is_default);
-    setAttachCounterpartId(
-      assetType === "symbol"
-        ? defaultRepresentation?.footprint?.id || ""
-        : assetType === "footprint"
-          ? defaultRepresentation?.symbol?.id || ""
-          : ""
-    );
-    setSelectedLink("");
-    setImportSelection(null);
-  };
-
-  const handleAssetUpload = async () => {
-    if (!attachAssetType || !currentComponent || !canMutate) return;
-    const sourceFile = importSelection?.file || attachFile;
-    if (!sourceFile) return;
-    setBusyAction("asset");
-    try {
-      const form = new FormData();
-      form.append("file", sourceFile);
-      form.append("target_library", importSelection?.targetLibrary || attachTargetLibrary || currentComponent.name);
-      form.append("expected_revision_id", assetMutationRevisionId(currentComponent.revision_id, importSelection?.expectedRevisionId));
-      if (attachCounterpartId) form.append("counterpart_asset_id", attachCounterpartId);
-      if (importSelection?.selected) {
-        form.append(attachAssetType === "symbol" ? "selected_symbol" : "selected_footprint", importSelection.selected);
-      }
-      const endpoint = attachAssetType === "symbol"
-        ? `/api/catalog/components/${encodeURIComponent(componentId)}/symbol-import`
-        : attachAssetType === "footprint"
-          ? `/api/catalog/components/${encodeURIComponent(componentId)}/footprint-import`
-          : `/api/catalog/components/${encodeURIComponent(componentId)}/assets/${encodeURIComponent(attachAssetType)}`;
-      const response = await fetchJson<SelectionRequiredResponse | ImportCompletedResponse | { component: CatalogComponent }>(endpoint, { method: "POST", body: form });
-      if ("mode" in response && response.mode === "selection_required") {
-        const options = response.discovered_symbols || response.discovered_footprints || [];
-        setImportSelection({ file: sourceFile, targetLibrary: attachTargetLibrary || currentComponent.name, options, selected: options[0] || "", expectedRevisionId: assetMutationRevisionId(currentComponent.revision_id, importSelection?.expectedRevisionId) });
-        return;
-      }
-      toast.success(`${ASSET_LABELS[attachAssetType]} attached as a new revision.`);
-      resetAttachDialog();
-      updateParams({ revision: null, compare: null });
-      setRefreshKey((value) => value + 1);
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : String(reason));
-      const status = reason instanceof ApiHttpError ? reason.status : undefined;
-      const code = reason instanceof ApiHttpError ? reason.code : undefined;
-      setImportSelection((current) => releaseRetainedRevisionOnConflict(current, status, code));
-    } finally {
-      setBusyAction("");
-    }
-  };
-
-  const handleAssetLink = async () => {
-    if (!attachAssetType || !selectedLink || !currentComponent || !canMutate) return;
-    setBusyAction("asset");
-    try {
-      await fetchJson(`/api/catalog/components/${encodeURIComponent(componentId)}/assets/${encodeURIComponent(attachAssetType)}/link`, {
-        method: "POST",
-        body: JSON.stringify({
-          file_path: selectedLink,
-          target_library: attachTargetLibrary.trim() || currentComponent.name,
-          target_name: attachTargetName.trim(),
-          counterpart_asset_id: attachCounterpartId,
-          expected_revision_id: currentComponent.revision_id,
-        }),
-      });
-      toast.success(`${ASSET_LABELS[attachAssetType]} linked as a new revision.`);
-      resetAttachDialog();
-      updateParams({ revision: null, compare: null });
-      setRefreshKey((value) => value + 1);
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : String(reason));
-    } finally {
-      setBusyAction("");
-    }
+    // A new session starts in upload mode. Stored files are only listed when
+    // the user actually opens the "Link existing" picker.
+    setAttachSession(assetAttachSessionFrom(currentComponent, assetType));
   };
 
   const handleAssetDetachById = async () => {
@@ -1611,37 +1118,29 @@ export function LibraryComponentWorkspace({
         </DialogContent>
       </Dialog>
 
-      <MetadataEditDialog
-        open={metadataOpen}
-        form={metadataForm}
-        submitting={busyAction === "metadata"}
-        onOpenChange={(open) => { setMetadataOpen(open); if (!open) setMetadataForm(null); }}
-        onChange={setMetadataForm}
-        onSubmit={() => void handleMetadataSave()}
-      />
+      {metadataSession ? (
+        <MetadataEditDialog
+          key={metadataSession.openedAt}
+          session={metadataSession}
+          onClose={() => setMetadataSession(null)}
+          onSuccess={() => {
+            setMetadataSession(null);
+            refreshAfterMutation();
+          }}
+        />
+      ) : null}
 
-      <AssetAttachDialog
-        assetType={attachAssetType}
-        mode={attachMode}
-        file={attachFile}
-        targetLibrary={attachTargetLibrary}
-        targetName={attachTargetName}
-        counterpartAssets={currentComponent.assets.filter((asset) => attachAssetType === "symbol" ? asset.asset_type === "footprint" : attachAssetType === "footprint" ? asset.asset_type === "symbol" : false)}
-        counterpartAssetId={attachCounterpartId}
-        selectedLink={selectedLink}
-        selection={importSelection}
-        submitting={busyAction === "asset"}
-        onOpenChange={(open) => { if (!open) resetAttachDialog(); }}
-        onModeChange={setAttachMode}
-        onFileChange={setAttachFile}
-        onTargetLibraryChange={setAttachTargetLibrary}
-        onTargetNameChange={setAttachTargetName}
-        onCounterpartAssetChange={setAttachCounterpartId}
-        onSelectedLinkChange={setSelectedLink}
-        onSelectionChange={(selected) => setImportSelection((current) => current ? { ...current, selected } : current)}
-        onUpload={() => void handleAssetUpload()}
-        onLink={() => void handleAssetLink()}
-      />
+      {attachSession ? (
+        <AssetAttachDialog
+          key={attachSession.openedAt}
+          session={attachSession}
+          onClose={() => setAttachSession(null)}
+          onSuccess={() => {
+            setAttachSession(null);
+            refreshAfterMutation();
+          }}
+        />
+      ) : null}
 
       <Dialog open={detachAsset !== null} onOpenChange={(open) => { if (!open && busyAction !== "detach-id") setDetachAsset(null); }}>
         <DialogContent className="sm:max-w-md">


### PR DESCRIPTION
## Summary
- Audit ticket **CW-02**: metadata and asset attach dialogs now own their edit sessions, captured at open, with a single success callback back to the coordinator.
- Cancel/reopen and switching asset type start a fresh session so fields and selected files cannot leak.
- Selection-required upload, revision capture, and `revision_conflict` release stay in the attach dialog.

## Test plan
- [ ] Open metadata, edit a field, cancel, reopen — original values, not the cancelled buffer
- [ ] Open symbol attach, pick a file, then open footprint attach — no leftover file; library resets from the component
- [ ] Upload that returns `selection_required`, cancel, reopen — picker is gone
- [ ] Delayed attach upload completing after unmount does not call success
- [ ] Metadata save sends the revision captured at open
- [ ] Frontend lint, scan:gate, tests, app + panel builds