### PR TITLE
Render the component metadata editor from field definitions

### DIFF
--- a/frontend/src/components/workspace/AGENTS.md
+++ b/frontend/src/components/workspace/AGENTS.md
@@ -32,7 +32,9 @@ URL ownership and current/historical selection stay here),
 library), `library-component-evidence-panels.tsx` (read-only revisions, review,
 usage, and audit evidence), `library-component-metadata-dialog.tsx` and
 `library-component-asset-dialog.tsx` (edit sessions captured at open, one
-success callback), `library-component-quick-view.tsx`,
+success callback), `library-component-metadata-form.ts` (definition-driven
+values, identity/provisional required rules, storage-key PATCH mapping),
+`library-component-metadata-fields.tsx` (typed input adapters), `library-component-quick-view.tsx`,
 `library-asset-link-picker.tsx`, `use-edit-history.ts`.
 
 **Previews** — two paths that share nothing but a subject.

--- a/frontend/src/components/workspace/AGENTS.md
+++ b/frontend/src/components/workspace/AGENTS.md
@@ -33,7 +33,8 @@ library), `library-component-evidence-panels.tsx` (read-only revisions, review,
 usage, and audit evidence), `library-component-metadata-dialog.tsx` and
 `library-component-asset-dialog.tsx` (edit sessions captured at open, one
 success callback), `library-component-metadata-form.ts` (definition-driven
-values, identity/provisional required rules, storage-key PATCH mapping),
+values, identity/provisional required rules, storage-key PATCH mapping;
+save validation matches the single PATCH, not bulk-edit shape checks),
 `library-component-metadata-fields.tsx` (typed input adapters), `library-component-quick-view.tsx`,
 `library-asset-link-picker.tsx`, `use-edit-history.ts`.
 
@@ -77,3 +78,7 @@ Its input buffer is genuinely local state; the resolved selection is not.
   before changing its submission path.
 - `library-component-workspace.tsx` is slated for decomposition. Do not add to
   it if the work can live in a sibling module.
+- **Single-editor extras stay writable.** Field definitions are admin-gated, so
+  the metadata dialog always keeps the additional-extras JSON box. Designers
+  can still add ad-hoc keys; defined extras render as typed controls and are
+  omitted from that leftover object.

--- a/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
+++ b/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
@@ -233,22 +233,37 @@ describe("metadata edit session", () => {
         expect(await screen.findByLabelText("Application note")).toHaveValue("bias");
         expect(screen.getByLabelText("Dielectric")).toHaveValue("2.2");
         expect(screen.getByLabelText("Tolerance")).toHaveValue("5%");
-        expect(screen.getByLabelText("Unknown extra fields (JSON object)")).toHaveValue(
+        expect(screen.getByLabelText("Additional extra fields (JSON object)")).toHaveValue(
             JSON.stringify({ leftover_note: "keep-me" }, null, 2),
         );
         fireEvent.change(screen.getByLabelText("Dielectric"), { target: { value: "not-a-number" } });
-        expect(screen.getByRole("alert")).toHaveTextContent("Invalid number");
-        expect(screen.getByRole("button", { name: /save new revision/i })).toBeDisabled();
-        fireEvent.change(screen.getByLabelText("Dielectric"), { target: { value: "4.7" } });
         fireEvent.change(screen.getByLabelText("Tolerance"), { target: { value: "1%" } });
         fireEvent.click(screen.getByRole("button", { name: /save new revision/i }));
         await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
         expect(patchCallBody().extra_fields).toEqual({
             leftover_note: "keep-me",
             application_note: "bias",
-            dielectric: "4.7",
+            dielectric: "not-a-number",
             tolerance: "1%",
         });
+    });
+
+    it("keeps additional extras writable when the component has none yet", async () => {
+        const onSuccess = vi.fn();
+        render(
+            <MetadataEditDialog
+                session={metadataEditSessionFrom(catalogComponent())}
+                onClose={vi.fn()}
+                onSuccess={onSuccess}
+            />,
+        );
+
+        fireEvent.change(await screen.findByLabelText("Additional extra fields (JSON object)"), {
+            target: { value: JSON.stringify({ Tolerance: "1%" }) },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /save new revision/i }));
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+        expect(patchCallBody().extra_fields).toEqual({ Tolerance: "1%" });
     });
 
     it("blocks save when a required identity field is cleared", async () => {

--- a/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
+++ b/frontend/src/components/workspace/library-component-edit-sessions.test.tsx
@@ -20,7 +20,7 @@ vi.mock("@/lib/api", () => ({
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn(), message: vi.fn(), warning: vi.fn(), info: vi.fn() } }));
 
 import { ApiHttpError, fetchJson } from "@/lib/api";
-import type { CatalogComponent } from "@/types/catalog";
+import type { CatalogComponent, CatalogMetadataField } from "@/types/catalog";
 import {
     AssetAttachDialog,
     assetAttachSessionFrom,
@@ -67,6 +67,65 @@ function catalogComponent(id = "comp-a"): CatalogComponent {
     } as unknown as CatalogComponent;
 }
 
+function metadataField(
+    partial: Partial<CatalogMetadataField> & Pick<CatalogMetadataField, "key" | "label" | "storage_key">,
+): CatalogMetadataField {
+    return {
+        id: `field-${partial.key}`,
+        description: "",
+        group: "core",
+        type: "text",
+        unit: "",
+        enum_values: [],
+        storage_kind: "column",
+        built_in: true,
+        required: false,
+        display_order: 0,
+        archived: false,
+        created_by: "",
+        updated_by: "",
+        created_at: "",
+        updated_at: "",
+        ...partial,
+    };
+}
+
+function builtinEditorFields(): CatalogMetadataField[] {
+    return [
+        metadataField({ key: "value", label: "Value", storage_key: "value", required: true, display_order: 1 }),
+        metadataField({ key: "manufacturer", label: "Manufacturer", storage_key: "manufacturer", required: true, display_order: 2 }),
+        metadataField({ key: "mpn", label: "Manufacturer Part Number", storage_key: "mpn", required: true, display_order: 3 }),
+        metadataField({ key: "datasheet_url", label: "Datasheet", storage_key: "datasheet_url", type: "url", required: true, display_order: 4 }),
+        metadataField({ key: "description", label: "Description", storage_key: "description", required: true, display_order: 5 }),
+    ];
+}
+
+function patchCallBody() {
+    const request = vi.mocked(fetchJson).mock.calls.find((call) => call[1]?.method === "PATCH");
+    return JSON.parse(String(request?.[1]?.body)) as Record<string, unknown>;
+}
+
+function mockMetadataRoutes(options?: {
+    fields?: CatalogMetadataField[];
+    component?: CatalogComponent;
+    delayFields?: () => Promise<{ items: CatalogMetadataField[] }>;
+    delayPatch?: () => Promise<CatalogComponent>;
+}) {
+    vi.mocked(fetchJson).mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "/api/catalog/metadata/fields") {
+            if (options?.delayFields) return options.delayFields() as never;
+            return { items: options?.fields ?? builtinEditorFields() } as never;
+        }
+        if (url.startsWith("/api/catalog/components/") && init?.method === "PATCH") {
+            if (options?.delayPatch) return options.delayPatch() as never;
+            return (options?.component ?? catalogComponent()) as never;
+        }
+        if (url === "/api/catalog/components/comp-a") return (options?.component ?? catalogComponent()) as never;
+        return { items: [] } as never;
+    });
+}
+
 function chooseFile(file: File) {
     const input = document.getElementById("component-asset-file");
     if (!(input instanceof HTMLInputElement)) throw new Error("file input missing");
@@ -77,6 +136,7 @@ function chooseFile(file: File) {
 describe("metadata edit session", () => {
     beforeEach(() => {
         vi.mocked(fetchJson).mockReset();
+        mockMetadataRoutes();
     });
 
     it("opens a fresh buffer after cancel so edited fields do not leak", async () => {
@@ -85,7 +145,7 @@ describe("metadata edit session", () => {
             <MetadataEditDialog session={first} onClose={vi.fn()} onSuccess={vi.fn()} />,
         );
 
-        fireEvent.change(screen.getByLabelText("Value *"), { target: { value: "leaked-value" } });
+        fireEvent.change(await screen.findByLabelText("Value *"), { target: { value: "leaked-value" } });
         expect(screen.getByLabelText("Value *")).toHaveValue("leaked-value");
 
         const second = metadataEditSessionFrom(catalogComponent());
@@ -93,12 +153,11 @@ describe("metadata edit session", () => {
             <MetadataEditDialog key={second.openedAt} session={second} onClose={vi.fn()} onSuccess={vi.fn()} />,
         );
 
-        expect(screen.getByLabelText("Value *")).toHaveValue("10k");
+        expect(await screen.findByLabelText("Value *")).toHaveValue("10k");
         expect(screen.queryByDisplayValue("leaked-value")).not.toBeInTheDocument();
     });
 
     it("sends the revision captured when the session opened", async () => {
-        vi.mocked(fetchJson).mockResolvedValue(catalogComponent() as never);
         const onSuccess = vi.fn();
         const session = metadataEditSessionFrom({
             ...catalogComponent(),
@@ -106,10 +165,204 @@ describe("metadata edit session", () => {
         });
         render(<MetadataEditDialog session={session} onClose={vi.fn()} onSuccess={onSuccess} />);
 
+        fireEvent.click(await screen.findByRole("button", { name: /save new revision/i }));
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+        expect(patchCallBody().expected_revision_id).toBe("rev-at-open");
+    });
+
+    it("renders a custom enum field from definitions and round-trips unknown extras", async () => {
+        mockMetadataRoutes({
+            fields: [
+                ...builtinEditorFields(),
+                metadataField({
+                    key: "application_note",
+                    label: "Application note",
+                    type: "text",
+                    storage_kind: "extra",
+                    storage_key: "application_note",
+                    built_in: false,
+                    display_order: 6,
+                }),
+                metadataField({
+                    key: "dielectric",
+                    label: "Dielectric",
+                    type: "number",
+                    storage_kind: "extra",
+                    storage_key: "dielectric",
+                    built_in: false,
+                    display_order: 7,
+                }),
+                metadataField({
+                    key: "tolerance",
+                    label: "Tolerance",
+                    type: "enum",
+                    enum_values: ["1%", "5%"],
+                    storage_kind: "extra",
+                    storage_key: "tolerance",
+                    built_in: false,
+                    display_order: 8,
+                }),
+            ],
+            component: {
+                ...catalogComponent(),
+                extra_fields: {
+                    application_note: "bias",
+                    dielectric: "2.2",
+                    tolerance: "5%",
+                    leftover_note: "keep-me",
+                },
+            },
+        });
+        const onSuccess = vi.fn();
+        render(
+            <MetadataEditDialog
+                session={metadataEditSessionFrom({
+                    ...catalogComponent(),
+                    extra_fields: {
+                        application_note: "bias",
+                        dielectric: "2.2",
+                        tolerance: "5%",
+                        leftover_note: "keep-me",
+                    },
+                })}
+                onClose={vi.fn()}
+                onSuccess={onSuccess}
+            />,
+        );
+
+        expect(await screen.findByLabelText("Application note")).toHaveValue("bias");
+        expect(screen.getByLabelText("Dielectric")).toHaveValue("2.2");
+        expect(screen.getByLabelText("Tolerance")).toHaveValue("5%");
+        expect(screen.getByLabelText("Unknown extra fields (JSON object)")).toHaveValue(
+            JSON.stringify({ leftover_note: "keep-me" }, null, 2),
+        );
+        fireEvent.change(screen.getByLabelText("Dielectric"), { target: { value: "not-a-number" } });
+        expect(screen.getByRole("alert")).toHaveTextContent("Invalid number");
+        expect(screen.getByRole("button", { name: /save new revision/i })).toBeDisabled();
+        fireEvent.change(screen.getByLabelText("Dielectric"), { target: { value: "4.7" } });
+        fireEvent.change(screen.getByLabelText("Tolerance"), { target: { value: "1%" } });
         fireEvent.click(screen.getByRole("button", { name: /save new revision/i }));
         await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
-        const body = JSON.parse(String(vi.mocked(fetchJson).mock.calls[0]?.[1]?.body));
-        expect(body.expected_revision_id).toBe("rev-at-open");
+        expect(patchCallBody().extra_fields).toEqual({
+            leftover_note: "keep-me",
+            application_note: "bias",
+            dielectric: "4.7",
+            tolerance: "1%",
+        });
+    });
+
+    it("blocks save when a required identity field is cleared", async () => {
+        render(
+            <MetadataEditDialog
+                session={metadataEditSessionFrom(catalogComponent())}
+                onClose={vi.fn()}
+                onSuccess={vi.fn()}
+            />,
+        );
+
+        fireEvent.change(await screen.findByLabelText("Value *"), { target: { value: "" } });
+        expect(screen.getByRole("alert")).toHaveTextContent("Required");
+        expect(screen.getByRole("button", { name: /save new revision/i })).toBeDisabled();
+    });
+
+    it("does not require MPN for a provisional identity", async () => {
+        const onSuccess = vi.fn();
+        render(
+            <MetadataEditDialog
+                session={metadataEditSessionFrom({
+                    ...catalogComponent(),
+                    identity_kind: "provisional_ipn",
+                    mpn: "",
+                })}
+                onClose={vi.fn()}
+                onSuccess={onSuccess}
+            />,
+        );
+
+        expect(await screen.findByLabelText("Manufacturer Part Number")).toHaveValue("");
+        expect(screen.getByText(/Manufacturer part number is optional/i)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole("button", { name: /save new revision/i }));
+        await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+        expect(patchCallBody().mpn).toBe("");
+    });
+
+    it("ignores field definitions that arrive after the session unmounts", async () => {
+        let finish: ((value: { items: CatalogMetadataField[] }) => void) | undefined;
+        mockMetadataRoutes({
+            delayFields: () => new Promise((resolve) => {
+                finish = resolve;
+            }),
+        });
+        const { unmount } = render(
+            <MetadataEditDialog
+                session={metadataEditSessionFrom(catalogComponent())}
+                onClose={vi.fn()}
+                onSuccess={vi.fn()}
+            />,
+        );
+
+        unmount();
+        finish!({
+            items: [
+                metadataField({ key: "tolerance", label: "Tolerance", storage_key: "tolerance" }),
+            ],
+        });
+        await waitFor(() => expect(fetchJson).toHaveBeenCalled());
+        expect(screen.queryByLabelText("Tolerance")).not.toBeInTheDocument();
+    });
+
+    it("does not apply a delayed definitions payload to a later session", async () => {
+        let finishFirst: ((value: { items: CatalogMetadataField[] }) => void) | undefined;
+        let calls = 0;
+        vi.mocked(fetchJson).mockImplementation(async (input) => {
+            const url = String(input);
+            if (url !== "/api/catalog/metadata/fields") return { items: [] } as never;
+            calls += 1;
+            if (calls === 1) {
+                return new Promise((resolve) => {
+                    finishFirst = resolve;
+                });
+            }
+            return { items: builtinEditorFields() } as never;
+        });
+        const first = metadataEditSessionFrom(catalogComponent());
+        const { rerender } = render(
+            <MetadataEditDialog session={first} onClose={vi.fn()} onSuccess={vi.fn()} />,
+        );
+        const second = metadataEditSessionFrom(catalogComponent());
+        rerender(
+            <MetadataEditDialog key={second.openedAt} session={second} onClose={vi.fn()} onSuccess={vi.fn()} />,
+        );
+
+        expect(await screen.findByLabelText("Value *")).toBeInTheDocument();
+        finishFirst!({
+            items: [metadataField({ key: "tolerance", label: "Tolerance", storage_key: "tolerance" })],
+        });
+        await waitFor(() => expect(screen.queryByLabelText("Tolerance")).not.toBeInTheDocument());
+        expect(screen.getByLabelText("Value *")).toBeInTheDocument();
+    });
+
+    it("ignores a delayed metadata save that completes after unmount", async () => {
+        let finish: ((value: CatalogComponent) => void) | undefined;
+        mockMetadataRoutes({
+            delayPatch: () => new Promise((resolve) => {
+                finish = resolve;
+            }),
+        });
+        const onSuccess = vi.fn();
+        const { unmount } = render(
+            <MetadataEditDialog
+                session={metadataEditSessionFrom(catalogComponent())}
+                onClose={vi.fn()}
+                onSuccess={onSuccess}
+            />,
+        );
+
+        fireEvent.click(await screen.findByRole("button", { name: /save new revision/i }));
+        await waitFor(() => expect(vi.mocked(fetchJson).mock.calls.some((call) => call[1]?.method === "PATCH")).toBe(true));
+        unmount();
+        finish!(catalogComponent());
+        await waitFor(() => expect(onSuccess).not.toHaveBeenCalled());
     });
 });
 
@@ -216,11 +469,7 @@ describe("asset attach session", () => {
 
 describe("workspace dialog sessions", () => {
     beforeEach(() => {
-        vi.mocked(fetchJson).mockImplementation(async (input) => {
-            const url = String(input);
-            if (url === "/api/catalog/components/comp-a") return catalogComponent() as never;
-            return { items: [] } as never;
-        });
+        mockMetadataRoutes();
     });
     afterEach(() => vi.clearAllMocks());
 
@@ -237,12 +486,12 @@ describe("workspace dialog sessions", () => {
         );
 
         fireEvent.click(await screen.findByRole("button", { name: /edit metadata/i }));
-        fireEvent.change(screen.getByLabelText("Value *"), { target: { value: "cancelled-edit" } });
+        fireEvent.change(await screen.findByLabelText("Value *"), { target: { value: "cancelled-edit" } });
         fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
         await waitFor(() => expect(screen.queryByRole("heading", { name: "Edit component metadata" })).not.toBeInTheDocument());
 
         fireEvent.click(screen.getByRole("button", { name: /edit metadata/i }));
-        expect(screen.getByLabelText("Value *")).toHaveValue("10k");
+        expect(await screen.findByLabelText("Value *")).toHaveValue("10k");
         expect(screen.queryByDisplayValue("cancelled-edit")).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/components/workspace/library-component-metadata-dialog.tsx
+++ b/frontend/src/components/workspace/library-component-metadata-dialog.tsx
@@ -15,60 +15,29 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { fetchJson } from "@/lib/api";
-import type { CatalogComponent } from "@/types/catalog";
+import type { CatalogComponent, CatalogMetadataField } from "@/types/catalog";
 
-type MetadataForm = {
-  value: string;
-  description: string;
-  datasheetUrl: string;
-  manufacturer: string;
-  mpn: string;
-  category: string;
-  packageName: string;
-  vendor: string;
-  vendorPartNumber: string;
-  massG: string;
-  rqjcCW: string;
-  rqjcTopCW: string;
-  tempMaxC: string;
-  tempMinC: string;
-  powerDissipationW: string;
-  rate: string;
-  sapCode: string;
-  extraFieldsJson: string;
-  changeSummary: string;
-};
+import { MetadataFieldControl } from "./library-component-metadata-fields";
+import {
+  activeMetadataFields,
+  buildMetadataPatch,
+  isFieldRequired,
+  isMetadataFormComplete,
+  metadataFormErrors,
+  parseUnknownExtraJson,
+  unknownExtraFields,
+  valuesFromComponent,
+} from "./library-component-metadata-form";
 
 export type MetadataEditSession = {
   openedAt: string;
   componentId: string;
   expectedRevisionId: string;
-  form: MetadataForm;
+  identityKind: CatalogComponent["identity_kind"];
+  component: CatalogComponent;
 };
 
 let nextMetadataSession = 0;
-
-const metadataFormFromComponent = (component: CatalogComponent): MetadataForm => ({
-  value: component.value || "",
-  description: component.description || "",
-  datasheetUrl: component.datasheet_url || "",
-  manufacturer: component.manufacturer || "",
-  mpn: component.mpn || "",
-  category: component.category || "",
-  packageName: component.package_name || "",
-  vendor: component.vendor || "",
-  vendorPartNumber: component.vendor_part_number || "",
-  massG: component.mass_g || "",
-  rqjcCW: component.rqjc_c_w || "",
-  rqjcTopCW: component.rqjc_top_c_w || "",
-  tempMaxC: component.temp_max_c || "",
-  tempMinC: component.temp_min_c || "",
-  powerDissipationW: component.power_dissipation_w || "",
-  rate: component.rate || "",
-  sapCode: component.sap_code || "",
-  extraFieldsJson: JSON.stringify(component.extra_fields ?? {}, null, 2),
-  changeSummary: "Update component metadata",
-});
 
 export function metadataEditSessionFrom(component: CatalogComponent): MetadataEditSession {
   nextMetadataSession += 1;
@@ -76,28 +45,10 @@ export function metadataEditSessionFrom(component: CatalogComponent): MetadataEd
     openedAt: `metadata-${nextMetadataSession}`,
     componentId: component.id,
     expectedRevisionId: component.revision_id,
-    form: metadataFormFromComponent(component),
+    identityKind: component.identity_kind,
+    component,
   };
 }
-
-const METADATA_FIELDS: Array<{ field: keyof MetadataForm; label: string; type?: string; placeholder?: string }> = [
-  { field: "value", label: "Value", placeholder: "10 kΩ, TPS55289…" },
-  { field: "manufacturer", label: "Manufacturer" },
-  { field: "mpn", label: "Manufacturer part number" },
-  { field: "datasheetUrl", label: "Datasheet URL", type: "url" },
-  { field: "category", label: "Category" },
-  { field: "packageName", label: "Package" },
-  { field: "vendor", label: "Vendor" },
-  { field: "vendorPartNumber", label: "Vendor part number" },
-  { field: "massG", label: "Mass (g)" },
-  { field: "rqjcCW", label: "RθJC (°C/W)" },
-  { field: "rqjcTopCW", label: "RθJC top (°C/W)" },
-  { field: "tempMaxC", label: "Maximum temperature (°C)" },
-  { field: "tempMinC", label: "Minimum temperature (°C)" },
-  { field: "powerDissipationW", label: "Power dissipation (W)" },
-  { field: "rate", label: "Rate" },
-  { field: "sapCode", label: "SAP code" },
-];
 
 export function MetadataEditDialog({
   session,
@@ -108,7 +59,11 @@ export function MetadataEditDialog({
   onClose: () => void;
   onSuccess: () => void;
 }) {
-  const [form, setForm] = useState<MetadataForm>(session.form);
+  const [fields, setFields] = useState<CatalogMetadataField[] | null>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [unknownExtrasJson, setUnknownExtrasJson] = useState("{}");
+  const [changeSummary, setChangeSummary] = useState("Update component metadata");
+  const [loadError, setLoadError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const aliveRef = useRef(true);
 
@@ -119,52 +74,49 @@ export function MetadataEditDialog({
     };
   }, []);
 
-  const setField = (field: keyof MetadataForm, value: string) => setForm({ ...form, [field]: value });
-  const requiredComplete = Boolean(
-    form.value.trim()
-    && form.manufacturer.trim()
-    && form.mpn.trim()
-    && form.description.trim()
-    && form.datasheetUrl.trim()
-    && form.changeSummary.trim(),
-  );
+  useEffect(() => {
+    let cancelled = false;
+    const loadFields = async () => {
+      try {
+        const payload = await fetchJson<{ items: CatalogMetadataField[] }>("/api/catalog/metadata/fields");
+        if (!aliveRef.current || cancelled) return;
+        const nextFields = activeMetadataFields(payload.items ?? []);
+        setFields(nextFields);
+        setValues(valuesFromComponent(session.component, nextFields));
+        setUnknownExtrasJson(JSON.stringify(unknownExtraFields(session.component, nextFields), null, 2));
+        setLoadError("");
+      } catch (reason) {
+        if (!aliveRef.current || cancelled) return;
+        setLoadError(reason instanceof Error ? reason.message : String(reason));
+      }
+    };
+    void loadFields();
+    return () => {
+      cancelled = true;
+    };
+  }, [session.component]);
+
+  const errors = fields
+    ? metadataFormErrors(fields, values, session.identityKind, changeSummary, unknownExtrasJson)
+    : null;
+  const canSave = Boolean(fields && errors && isMetadataFormComplete(errors) && !loadError);
+  const showUnknownExtras = Object.keys(unknownExtraFields(session.component, fields ?? [])).length > 0;
 
   const handleSubmit = async () => {
-    let extraFields: Record<string, string>;
-    try {
-      const parsed: unknown = JSON.parse(form.extraFieldsJson || "{}");
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Extended fields must be a JSON object.");
-      extraFields = Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value ?? "")]));
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : "Extended fields contain invalid JSON.");
-      return;
-    }
+    if (!fields || !errors || !isMetadataFormComplete(errors)) return;
+    const parsed = parseUnknownExtraJson(unknownExtrasJson);
+    if (!parsed.ok) return;
     setSubmitting(true);
     try {
       await fetchJson<CatalogComponent>(`/api/catalog/components/${encodeURIComponent(session.componentId)}`, {
         method: "PATCH",
-        body: JSON.stringify({
-          value: form.value.trim(),
-          description: form.description.trim(),
-          datasheet_url: form.datasheetUrl.trim(),
-          manufacturer: form.manufacturer.trim(),
-          mpn: form.mpn.trim(),
-          category: form.category.trim(),
-          package_name: form.packageName.trim(),
-          vendor: form.vendor.trim(),
-          vendor_part_number: form.vendorPartNumber.trim(),
-          mass_g: form.massG.trim(),
-          rqjc_c_w: form.rqjcCW.trim(),
-          rqjc_top_c_w: form.rqjcTopCW.trim(),
-          temp_max_c: form.tempMaxC.trim(),
-          temp_min_c: form.tempMinC.trim(),
-          power_dissipation_w: form.powerDissipationW.trim(),
-          rate: form.rate.trim(),
-          sap_code: form.sapCode.trim(),
-          extra_fields: extraFields,
-          change_summary: form.changeSummary.trim(),
-          expected_revision_id: session.expectedRevisionId,
-        }),
+        body: JSON.stringify(buildMetadataPatch({
+          values,
+          fields,
+          unknownExtras: parsed.extras,
+          changeSummary,
+          expectedRevisionId: session.expectedRevisionId,
+        })),
       });
       if (!aliveRef.current) return;
       toast.success("Metadata saved as a new revision.");
@@ -184,29 +136,66 @@ export function MetadataEditDialog({
           <DialogTitle>Edit component metadata</DialogTitle>
           <DialogDescription>Saving creates a new immutable revision. The current revision ID is checked to prevent overwriting concurrent work.</DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {METADATA_FIELDS.map(({ field, label, type, placeholder }) => (
-            <div key={field} className="space-y-2">
-              <Label htmlFor={`component-edit-${field}`}>{label}{["value", "manufacturer", "mpn", "datasheetUrl"].includes(field) ? " *" : ""}</Label>
-              <Input id={`component-edit-${field}`} type={type} required={["value", "manufacturer", "mpn", "datasheetUrl"].includes(field)} value={form[field]} placeholder={placeholder} onChange={(event) => setField(field, event.target.value)} />
+        {session.identityKind === "provisional_ipn" ? (
+          <p className="border border-border bg-muted/50 p-3 text-sm text-muted-foreground">
+            <strong className="text-foreground">Provisional component.</strong> Manufacturer part number is optional until a real MPN replaces this identity.
+          </p>
+        ) : null}
+        {!fields && !loadError ? (
+          <div className="text-muted-foreground flex items-center gap-2 text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading field definitions…
+          </div>
+        ) : null}
+        {loadError ? <p className="text-destructive text-sm" role="alert">{loadError}</p> : null}
+        {fields ? (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {fields.map((field) => (
+              <MetadataFieldControl
+                key={field.key}
+                field={field}
+                value={values[field.key] ?? ""}
+                required={isFieldRequired(field, session.identityKind)}
+                error={errors?.fieldErrors[field.key] ?? ""}
+                onChange={(next) => setValues({ ...values, [field.key]: next })}
+              />
+            ))}
+            {showUnknownExtras ? (
+              <div className="space-y-2 sm:col-span-2">
+                <Label htmlFor="component-edit-unknown-extras">Unknown extra fields (JSON object)</Label>
+                <Textarea
+                  id="component-edit-unknown-extras"
+                  className="font-mono text-xs"
+                  value={unknownExtrasJson}
+                  rows={6}
+                  spellCheck={false}
+                  aria-invalid={Boolean(errors?.unknownExtrasError)}
+                  onChange={(event) => setUnknownExtrasJson(event.target.value)}
+                />
+                {errors?.unknownExtrasError ? (
+                  <p className="text-destructive text-xs" role="alert">{errors.unknownExtrasError}</p>
+                ) : null}
+              </div>
+            ) : null}
+            <div className="space-y-2 sm:col-span-2">
+              <Label htmlFor="component-edit-summary">Change summary *</Label>
+              <Input
+                id="component-edit-summary"
+                required
+                value={changeSummary}
+                placeholder="Describe why this revision is needed"
+                aria-invalid={Boolean(errors?.changeSummaryError)}
+                onChange={(event) => setChangeSummary(event.target.value)}
+              />
             </div>
-          ))}
-          <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="component-edit-description">Description *</Label>
-            <Textarea id="component-edit-description" required value={form.description} rows={3} onChange={(event) => setField("description", event.target.value)} />
           </div>
-          <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="component-edit-extra-fields">Extended symbol fields (JSON object)</Label>
-            <Textarea id="component-edit-extra-fields" className="font-mono text-xs" value={form.extraFieldsJson} rows={6} spellCheck={false} onChange={(event) => setField("extraFieldsJson", event.target.value)} />
-          </div>
-          <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="component-edit-summary">Change summary *</Label>
-            <Input id="component-edit-summary" required value={form.changeSummary} placeholder="Describe why this revision is needed" onChange={(event) => setField("changeSummary", event.target.value)} />
-          </div>
-        </div>
+        ) : null}
         <DialogFooter>
           <Button variant="outline" disabled={submitting} onClick={onClose}>Cancel</Button>
-          <Button disabled={submitting || !requiredComplete} onClick={() => void handleSubmit()}>{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Edit3 className="h-4 w-4" />} Save new revision</Button>
+          <Button disabled={submitting || !canSave} onClick={() => void handleSubmit()}>
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Edit3 className="h-4 w-4" />}
+            Save new revision
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/workspace/library-component-metadata-dialog.tsx
+++ b/frontend/src/components/workspace/library-component-metadata-dialog.tsx
@@ -100,7 +100,6 @@ export function MetadataEditDialog({
     ? metadataFormErrors(fields, values, session.identityKind, changeSummary, unknownExtrasJson)
     : null;
   const canSave = Boolean(fields && errors && isMetadataFormComplete(errors) && !loadError);
-  const showUnknownExtras = Object.keys(unknownExtraFields(session.component, fields ?? [])).length > 0;
 
   const handleSubmit = async () => {
     if (!fields || !errors || !isMetadataFormComplete(errors)) return;
@@ -160,23 +159,21 @@ export function MetadataEditDialog({
                 onChange={(next) => setValues({ ...values, [field.key]: next })}
               />
             ))}
-            {showUnknownExtras ? (
-              <div className="space-y-2 sm:col-span-2">
-                <Label htmlFor="component-edit-unknown-extras">Unknown extra fields (JSON object)</Label>
-                <Textarea
-                  id="component-edit-unknown-extras"
-                  className="font-mono text-xs"
-                  value={unknownExtrasJson}
-                  rows={6}
-                  spellCheck={false}
-                  aria-invalid={Boolean(errors?.unknownExtrasError)}
-                  onChange={(event) => setUnknownExtrasJson(event.target.value)}
-                />
-                {errors?.unknownExtrasError ? (
-                  <p className="text-destructive text-xs" role="alert">{errors.unknownExtrasError}</p>
-                ) : null}
-              </div>
-            ) : null}
+            <div className="space-y-2 sm:col-span-2">
+              <Label htmlFor="component-edit-unknown-extras">Additional extra fields (JSON object)</Label>
+              <Textarea
+                id="component-edit-unknown-extras"
+                className="font-mono text-xs"
+                value={unknownExtrasJson}
+                rows={6}
+                spellCheck={false}
+                aria-invalid={Boolean(errors?.unknownExtrasError)}
+                onChange={(event) => setUnknownExtrasJson(event.target.value)}
+              />
+              {errors?.unknownExtrasError ? (
+                <p className="text-destructive text-xs" role="alert">{errors.unknownExtrasError}</p>
+              ) : null}
+            </div>
             <div className="space-y-2 sm:col-span-2">
               <Label htmlFor="component-edit-summary">Change summary *</Label>
               <Input

--- a/frontend/src/components/workspace/library-component-metadata-fields.tsx
+++ b/frontend/src/components/workspace/library-component-metadata-fields.tsx
@@ -1,0 +1,89 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import type { CatalogMetadataField } from "@/types/catalog";
+
+function fieldControlId(field: CatalogMetadataField): string {
+  return `component-edit-${field.key}`;
+}
+
+function fieldLabel(field: CatalogMetadataField, required: boolean): string {
+  const unit = field.unit ? ` (${field.unit})` : "";
+  return `${field.label}${unit}${required ? " *" : ""}`;
+}
+
+function isChecked(value: string): boolean {
+  return ["true", "1", "yes"].includes(value.toLocaleLowerCase());
+}
+
+export function MetadataFieldControl({
+  field,
+  value,
+  required,
+  error,
+  onChange,
+}: {
+  field: CatalogMetadataField;
+  value: string;
+  required: boolean;
+  error: string;
+  onChange: (value: string) => void;
+}) {
+  const id = fieldControlId(field);
+  const label = fieldLabel(field, required);
+  const wide = field.key === "description";
+
+  return (
+    <div className={cn("space-y-2", wide && "sm:col-span-2")}>
+      <Label htmlFor={id}>{label}</Label>
+      {field.type === "boolean" ? (
+        <div className="flex h-9 items-center">
+          <Checkbox
+            id={id}
+            checked={isChecked(value)}
+            onCheckedChange={(checked) => onChange(checked ? "true" : "false")}
+            aria-invalid={Boolean(error)}
+          />
+        </div>
+      ) : field.type === "enum" ? (
+        <select
+          id={id}
+          aria-label={label}
+          className="border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive h-9 w-full rounded-none border bg-transparent px-3 text-xs outline-none focus-visible:ring-1"
+          value={value}
+          required={required}
+          aria-invalid={Boolean(error)}
+          onChange={(event) => onChange(event.target.value)}
+        >
+          <option value="">—</option>
+          {field.enum_values.map((option) => (
+            <option key={option} value={option}>{option}</option>
+          ))}
+        </select>
+      ) : field.key === "description" ? (
+        <Textarea
+          id={id}
+          required={required}
+          value={value}
+          rows={3}
+          aria-invalid={Boolean(error)}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      ) : (
+        <Input
+          id={id}
+          type={field.type === "url" ? "url" : "text"}
+          inputMode={field.type === "number" ? "decimal" : undefined}
+          required={required}
+          value={value}
+          placeholder={field.description || undefined}
+          aria-invalid={Boolean(error)}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      )}
+      {error ? <p className="text-destructive text-xs" role="alert">{error}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/library-component-metadata-form.test.ts
+++ b/frontend/src/components/workspace/library-component-metadata-form.test.ts
@@ -151,22 +151,40 @@ describe("identity and validation rules", () => {
     expect(validateMetadataField(mpn, "", "mpn")).toBe("Required");
   });
 
-  it("surfaces the same number, URL, and enum messages as the grid", () => {
-    expect(validateMetadataField(
-      metadataField({ key: "mass_g", label: "Mass", type: "number", storage_key: "mass_g" }),
-      "heavy",
+  it("does not block save on legacy number, URL, or enum shapes the PATCH still accepts", () => {
+    const errors = metadataFormErrors(
+      [
+        metadataField({ key: "value", label: "Value", storage_key: "value" }),
+        metadataField({ key: "mass_g", label: "Mass", type: "number", storage_key: "mass_g" }),
+        metadataField({
+          key: "datasheet_url",
+          label: "Datasheet",
+          type: "url",
+          storage_key: "datasheet_url",
+        }),
+        custom,
+      ],
+      {
+        value: "10k",
+        mass_g: "~5",
+        datasheet_url: "example.com/ds.pdf",
+        tolerance: "10%",
+      },
       "mpn",
-    )).toBe("Invalid number");
-    expect(validateMetadataField(
-      metadataField({ key: "datasheet_url", label: "Datasheet", type: "url", storage_key: "datasheet_url" }),
-      "ftp://example.test/ds",
-      "mpn",
-    )).toBe("Use HTTP(S)");
-    expect(validateMetadataField(custom, "10%", "mpn")).toBe("Invalid option");
+      "Update",
+      "{}",
+    );
+    expect(errors.fieldErrors).toEqual({
+      value: "",
+      mass_g: "",
+      datasheet_url: "",
+      tolerance: "",
+    });
+    expect(isMetadataFormComplete(errors)).toBe(true);
     expect(validateMetadataField(custom, "", "mpn")).toBe("Required");
   });
 
-  it("blocks save when unknown extras are not a JSON object", () => {
+  it("blocks save when additional extras are not a JSON object", () => {
     const errors = metadataFormErrors(
       [metadataField({ key: "value", label: "Value", storage_key: "value" })],
       { value: "10k" },
@@ -174,7 +192,7 @@ describe("identity and validation rules", () => {
       "Update",
       "[]",
     );
-    expect(errors.unknownExtrasError).toBe("Unknown extra fields must be a JSON object.");
+    expect(errors.unknownExtrasError).toBe("Additional extra fields must be a JSON object.");
     expect(isMetadataFormComplete(errors)).toBe(false);
     expect(parseUnknownExtraJson('{"note":1}').ok).toBe(true);
   });

--- a/frontend/src/components/workspace/library-component-metadata-form.test.ts
+++ b/frontend/src/components/workspace/library-component-metadata-form.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import type { CatalogComponent, CatalogMetadataField } from "@/types/catalog";
+
+import {
+  activeMetadataFields,
+  buildMetadataPatch,
+  isFieldRequired,
+  isMetadataFormComplete,
+  metadataFormErrors,
+  parseUnknownExtraJson,
+  unknownExtraFields,
+  validateMetadataField,
+  valuesFromComponent,
+} from "./library-component-metadata-form";
+
+function metadataField(
+  partial: Partial<CatalogMetadataField> & Pick<CatalogMetadataField, "key" | "label" | "storage_key">,
+): CatalogMetadataField {
+  return {
+    id: `field-${partial.key}`,
+    description: "",
+    group: "core",
+    type: "text",
+    unit: "",
+    enum_values: [],
+    storage_kind: "column",
+    built_in: false,
+    required: false,
+    display_order: 0,
+    archived: false,
+    created_by: "",
+    updated_by: "",
+    created_at: "",
+    updated_at: "",
+    ...partial,
+  };
+}
+
+function component(extra: Partial<CatalogComponent> = {}): CatalogComponent {
+  return {
+    id: "comp-a",
+    value: "10k",
+    manufacturer: "Yageo",
+    mpn: "RC0603",
+    description: "Resistor",
+    datasheet_url: "https://example.test/ds",
+    identity_kind: "mpn",
+    extra_fields: {},
+    revision_id: "rev-1",
+    ...extra,
+  } as CatalogComponent;
+}
+
+describe("metadata form mapping", () => {
+  it("reads column and extra values through storage_key", () => {
+    const fields = [
+      metadataField({ key: "value", label: "Value", storage_key: "value" }),
+      metadataField({
+        key: "tolerance",
+        label: "Tolerance",
+        storage_kind: "extra",
+        storage_key: "tol_pct",
+      }),
+    ];
+    const values = valuesFromComponent(
+      component({ extra_fields: { tol_pct: "1%", leftover: "keep" } }),
+      fields,
+    );
+    expect(values).toEqual({ value: "10k", tolerance: "1%" });
+    expect(unknownExtraFields(component({ extra_fields: { tol_pct: "1%", leftover: "keep" } }), fields)).toEqual({
+      leftover: "keep",
+    });
+  });
+
+  it("drops archived definitions and keeps their extras unknown", () => {
+    const fields = activeMetadataFields([
+      metadataField({ key: "value", label: "Value", storage_key: "value", display_order: 2 }),
+      metadataField({
+        key: "legacy",
+        label: "Legacy",
+        storage_kind: "extra",
+        storage_key: "legacy",
+        archived: true,
+        display_order: 1,
+      }),
+    ]);
+    expect(fields.map((field) => field.key)).toEqual(["value"]);
+    expect(unknownExtraFields(component({ extra_fields: { legacy: "old" } }), fields)).toEqual({
+      legacy: "old",
+    });
+  });
+
+  it("maps custom extras and unknown leftovers into the PATCH body", () => {
+    const fields = [
+      metadataField({ key: "value", label: "Value", storage_key: "value" }),
+      metadataField({
+        key: "dielectric",
+        label: "Dielectric",
+        type: "number",
+        storage_kind: "extra",
+        storage_key: "dielectric",
+      }),
+      metadataField({
+        key: "tolerance",
+        label: "Tolerance",
+        type: "enum",
+        enum_values: ["1%", "5%"],
+        storage_kind: "extra",
+        storage_key: "tolerance",
+      }),
+    ];
+    expect(buildMetadataPatch({
+      values: { value: " 10k ", dielectric: "2.2", tolerance: "1%" },
+      fields,
+      unknownExtras: { leftover: "keep" },
+      changeSummary: "Add custom fields",
+      expectedRevisionId: "rev-at-open",
+    })).toEqual({
+      value: "10k",
+      extra_fields: { leftover: "keep", dielectric: "2.2", tolerance: "1%" },
+      change_summary: "Add custom fields",
+      expected_revision_id: "rev-at-open",
+    });
+  });
+});
+
+describe("identity and validation rules", () => {
+  const mpn = metadataField({ key: "mpn", label: "MPN", storage_key: "mpn", required: true });
+  const manufacturer = metadataField({
+    key: "manufacturer",
+    label: "Manufacturer",
+    storage_key: "manufacturer",
+    required: false,
+  });
+  const custom = metadataField({
+    key: "tolerance",
+    label: "Tolerance",
+    type: "enum",
+    enum_values: ["1%", "5%"],
+    storage_kind: "extra",
+    storage_key: "tolerance",
+    required: true,
+  });
+
+  it("keeps manufacturer required and MPN optional only for provisional identities", () => {
+    expect(isFieldRequired(manufacturer, "provisional_ipn")).toBe(true);
+    expect(isFieldRequired(mpn, "provisional_ipn")).toBe(false);
+    expect(isFieldRequired(mpn, "mpn")).toBe(true);
+    expect(validateMetadataField(mpn, "", "provisional_ipn")).toBe("");
+    expect(validateMetadataField(mpn, "", "mpn")).toBe("Required");
+  });
+
+  it("surfaces the same number, URL, and enum messages as the grid", () => {
+    expect(validateMetadataField(
+      metadataField({ key: "mass_g", label: "Mass", type: "number", storage_key: "mass_g" }),
+      "heavy",
+      "mpn",
+    )).toBe("Invalid number");
+    expect(validateMetadataField(
+      metadataField({ key: "datasheet_url", label: "Datasheet", type: "url", storage_key: "datasheet_url" }),
+      "ftp://example.test/ds",
+      "mpn",
+    )).toBe("Use HTTP(S)");
+    expect(validateMetadataField(custom, "10%", "mpn")).toBe("Invalid option");
+    expect(validateMetadataField(custom, "", "mpn")).toBe("Required");
+  });
+
+  it("blocks save when unknown extras are not a JSON object", () => {
+    const errors = metadataFormErrors(
+      [metadataField({ key: "value", label: "Value", storage_key: "value" })],
+      { value: "10k" },
+      "mpn",
+      "Update",
+      "[]",
+    );
+    expect(errors.unknownExtrasError).toBe("Unknown extra fields must be a JSON object.");
+    expect(isMetadataFormComplete(errors)).toBe(false);
+    expect(parseUnknownExtraJson('{"note":1}').ok).toBe(true);
+  });
+});

--- a/frontend/src/components/workspace/library-component-metadata-form.ts
+++ b/frontend/src/components/workspace/library-component-metadata-form.ts
@@ -1,0 +1,135 @@
+import type { CatalogComponent, CatalogMetadataField } from "@/types/catalog";
+
+const IDENTITY_REQUIRED_KEYS = new Set(["value", "manufacturer", "description", "datasheet_url"]);
+
+export function activeMetadataFields(items: CatalogMetadataField[]): CatalogMetadataField[] {
+  return items
+    .filter((field) => !field.archived)
+    .sort((left, right) => left.display_order - right.display_order || left.key.localeCompare(right.key));
+}
+
+export function componentFieldValue(component: CatalogComponent, field: CatalogMetadataField): string {
+  if (field.storage_kind === "extra") return String(component.extra_fields?.[field.storage_key] ?? "");
+  return String((component as unknown as Record<string, unknown>)[field.storage_key] ?? "");
+}
+
+export function valuesFromComponent(
+  component: CatalogComponent,
+  fields: CatalogMetadataField[],
+): Record<string, string> {
+  return Object.fromEntries(fields.map((field) => [field.key, componentFieldValue(component, field)]));
+}
+
+export function unknownExtraFields(
+  component: CatalogComponent,
+  fields: CatalogMetadataField[],
+): Record<string, string> {
+  const claimed = new Set<string>();
+  for (const field of fields) {
+    if (field.storage_kind === "extra") claimed.add(field.storage_key);
+  }
+  return Object.fromEntries(
+    Object.entries(component.extra_fields ?? {}).filter(([key]) => !claimed.has(key)),
+  );
+}
+
+export function isFieldRequired(
+  field: CatalogMetadataField,
+  identityKind: CatalogComponent["identity_kind"],
+): boolean {
+  // Built-in `mpn` is marked required in the registry, but provisional parts
+  // are allowed to omit it until a real manufacturer part number exists.
+  if (field.key === "mpn") return identityKind === "mpn";
+  if (IDENTITY_REQUIRED_KEYS.has(field.key)) return true;
+  return field.required;
+}
+
+export function validateMetadataField(
+  field: CatalogMetadataField,
+  value: string,
+  identityKind: CatalogComponent["identity_kind"],
+): string {
+  if (!value.trim()) return isFieldRequired(field, identityKind) ? "Required" : "";
+  if (field.type === "number" && !Number.isFinite(Number(value))) return "Invalid number";
+  if (field.type === "url") {
+    try {
+      const url = new URL(value);
+      if (!["http:", "https:"].includes(url.protocol)) return "Use HTTP(S)";
+    } catch {
+      return "Invalid URL";
+    }
+  }
+  if (field.type === "enum" && !field.enum_values.includes(value)) return "Invalid option";
+  return "";
+}
+
+export function parseUnknownExtraJson(
+  raw: string,
+): { ok: true; extras: Record<string, string> } | { ok: false; message: string } {
+  try {
+    const parsed: unknown = JSON.parse(raw || "{}");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ok: false, message: "Unknown extra fields must be a JSON object." };
+    }
+    return {
+      ok: true,
+      extras: Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value ?? "")])),
+    };
+  } catch (reason) {
+    return {
+      ok: false,
+      message: reason instanceof Error ? reason.message : "Unknown extra fields contain invalid JSON.",
+    };
+  }
+}
+
+export function metadataFormErrors(
+  fields: CatalogMetadataField[],
+  values: Record<string, string>,
+  identityKind: CatalogComponent["identity_kind"],
+  changeSummary: string,
+  unknownExtrasJson: string,
+): { fieldErrors: Record<string, string>; changeSummaryError: string; unknownExtrasError: string } {
+  const parsed = parseUnknownExtraJson(unknownExtrasJson);
+  return {
+    fieldErrors: Object.fromEntries(
+      fields.map((field) => [field.key, validateMetadataField(field, values[field.key] ?? "", identityKind)]),
+    ),
+    changeSummaryError: changeSummary.trim() ? "" : "Required",
+    unknownExtrasError: parsed.ok ? "" : parsed.message,
+  };
+}
+
+export function isMetadataFormComplete(errors: ReturnType<typeof metadataFormErrors>): boolean {
+  return !errors.changeSummaryError
+    && !errors.unknownExtrasError
+    && Object.values(errors.fieldErrors).every((message) => !message);
+}
+
+export function buildMetadataPatch({
+  values,
+  fields,
+  unknownExtras,
+  changeSummary,
+  expectedRevisionId,
+}: {
+  values: Record<string, string>;
+  fields: CatalogMetadataField[];
+  unknownExtras: Record<string, string>;
+  changeSummary: string;
+  expectedRevisionId: string;
+}): Record<string, unknown> {
+  const extraFields = { ...unknownExtras };
+  const columns: Record<string, string> = {};
+  for (const field of fields) {
+    const value = (values[field.key] ?? "").trim();
+    if (field.storage_kind === "extra") extraFields[field.storage_key] = value;
+    else columns[field.storage_key] = value;
+  }
+  return {
+    ...columns,
+    extra_fields: extraFields,
+    change_summary: changeSummary.trim(),
+    expected_revision_id: expectedRevisionId,
+  };
+}

--- a/frontend/src/components/workspace/library-component-metadata-form.ts
+++ b/frontend/src/components/workspace/library-component-metadata-form.ts
@@ -49,17 +49,10 @@ export function validateMetadataField(
   value: string,
   identityKind: CatalogComponent["identity_kind"],
 ): string {
+  // The single-component PATCH accepts the same free-form strings the previous
+  // editor stored. Shape checks belong to bulk edit; blocking them here would
+  // trap saves on legacy values the user did not touch.
   if (!value.trim()) return isFieldRequired(field, identityKind) ? "Required" : "";
-  if (field.type === "number" && !Number.isFinite(Number(value))) return "Invalid number";
-  if (field.type === "url") {
-    try {
-      const url = new URL(value);
-      if (!["http:", "https:"].includes(url.protocol)) return "Use HTTP(S)";
-    } catch {
-      return "Invalid URL";
-    }
-  }
-  if (field.type === "enum" && !field.enum_values.includes(value)) return "Invalid option";
   return "";
 }
 
@@ -69,7 +62,7 @@ export function parseUnknownExtraJson(
   try {
     const parsed: unknown = JSON.parse(raw || "{}");
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return { ok: false, message: "Unknown extra fields must be a JSON object." };
+      return { ok: false, message: "Additional extra fields must be a JSON object." };
     }
     return {
       ok: true,


### PR DESCRIPTION
## Summary
- Drive the single-component metadata editor from `GET /api/catalog/metadata/fields` with typed adapters and `storage_key` mapping, instead of a hard-coded field table.
- Keep manufacturer/value/description/datasheet required, treat MPN as optional only for provisional identities, and always keep the additional-extras JSON box so designers can add ad-hoc keys without an admin field definition.
- Save validation matches the single-component PATCH: required identity fields and valid extras JSON. Number, URL, and enum shape checks stay on bulk edit so legacy values do not block a save.
- Leave bulk edit and stored metadata unchanged.

## Test plan
- [x] Focused mapping and dialog tests cover custom text/number/enum fields, unknown extra round-trips, adding extras from an empty object, required identity fields, provisional MPN, and delayed definition/save responses
- [x] Legacy `mass_g` / datasheet shapes still allow save
- [x] Frontend quality gate: lint, scan:gate, test, build, build:panel
- [x] `python3 scripts/check_agent_docs.py`
- [ ] GitHub quality gate on this PR