### PR TITLE
Watch component validation as a resumable unified job

### DIFF
--- a/frontend/src/components/workspace/AGENTS.md
+++ b/frontend/src/components/workspace/AGENTS.md
@@ -29,7 +29,9 @@ these modules are forms and grids over server data rather than viewer bridges.
 URL ownership and current/historical selection stay here),
 `library-component-chrome.tsx` (shared badges, cards, empty/loading chrome),
 `library-component-evidence.ts` (tab evidence load hooks, no store or query
-library), `library-component-evidence-panels.tsx` (read-only revisions, review,
+library), `library-component-validation.ts` (component-scoped AbortController
+and `watchPrismJob` adapter; the coordinator starts/aborts and applies the
+originating component's result), `library-component-evidence-panels.tsx` (read-only revisions, review,
 usage, and audit evidence), `library-component-metadata-dialog.tsx` and
 `library-component-asset-dialog.tsx` (edit sessions captured at open, one
 success callback), `library-component-metadata-form.ts` (definition-driven

--- a/frontend/src/components/workspace/library-component-validation.test.ts
+++ b/frontend/src/components/workspace/library-component-validation.test.ts
@@ -1,0 +1,391 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  fetchJson: vi.fn(),
+  fetchApi: vi.fn(),
+  readApiError: vi.fn(async () => "request failed"),
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    message: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { fetchApi, fetchJson } from "@/lib/api";
+import type { PrismJobStatus } from "@/lib/jobs";
+import { toast } from "sonner";
+import type { CatalogComponent } from "@/types/catalog";
+import {
+  applyCatalogValidationOutcome,
+  resolveCatalogValidationResult,
+  useLibraryComponentValidation,
+  watchCatalogValidationJob,
+} from "./library-component-validation";
+
+const jobResponse = (payload: Partial<PrismJobStatus> & Pick<PrismJobStatus, "status">): Response =>
+  new Response(JSON.stringify({
+    job_id: "job-1",
+    kind: "catalog_validation",
+    stage: payload.status,
+    message: payload.message ?? "",
+    percent: payload.percent ?? 0,
+    ...payload,
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+function catalogComponent(
+  id: string,
+  status: CatalogComponent["validation"]["status"] = "passed",
+): CatalogComponent {
+  return {
+    id,
+    revision_id: `${id}-rev1`,
+    validation: { status, enabled: true, error_count: 0, warning_count: 0 },
+  } as CatalogComponent;
+}
+
+function prismJob(partial: Partial<PrismJobStatus> & Pick<PrismJobStatus, "status">): PrismJobStatus {
+  return {
+    job_id: "job-1",
+    kind: "catalog_validation",
+    stage: partial.status,
+    message: "",
+    percent: 0,
+    ...partial,
+  };
+}
+
+function abortAwareHang(signal?: AbortSignal | null): Promise<Response> {
+  return new Promise((_, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    signal?.addEventListener("abort", () => {
+      reject(new DOMException("Aborted", "AbortError"));
+    }, { once: true });
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.mocked(fetchApi).mockReset();
+  vi.mocked(fetchJson).mockReset();
+  vi.mocked(toast.error).mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.message).mockReset();
+  vi.mocked(toast.warning).mockReset();
+});
+
+describe("resolveCatalogValidationResult", () => {
+  it("settles failed and cancelled jobs distinctly", async () => {
+    await expect(resolveCatalogValidationResult(prismJob({
+      status: "failed",
+      error_message: "worker boom",
+    }))).resolves.toEqual({ kind: "failed", error: "worker boom" });
+
+    await expect(resolveCatalogValidationResult(prismJob({
+      status: "cancelled",
+      message: "operator cancelled",
+    }))).resolves.toEqual({ kind: "cancelled", message: "operator cancelled" });
+  });
+
+  it("extracts the component from unified result metadata", async () => {
+    const component = catalogComponent("comp-a", "warning");
+    await expect(resolveCatalogValidationResult(prismJob({
+      status: "completed",
+      result_metadata: { component, errors: [] },
+    }))).resolves.toEqual({ kind: "completed", component });
+    expect(fetchJson).not.toHaveBeenCalled();
+  });
+
+  it("reads the catalog job once when metadata has no component", async () => {
+    const component = catalogComponent("comp-a");
+    vi.mocked(fetchJson).mockResolvedValueOnce({ component, errors: [] });
+
+    await expect(resolveCatalogValidationResult(prismJob({
+      status: "completed",
+      result_metadata: { validated: 1, total: 1, errors: [] },
+    }))).resolves.toEqual({ kind: "completed", component });
+
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(fetchJson).toHaveBeenCalledWith("/api/catalog/validation/jobs/job-1", {
+      signal: undefined,
+    });
+  });
+
+  it("uses the first catalog error when a completed job has no component", async () => {
+    vi.mocked(fetchJson).mockRejectedValueOnce(new Error("legacy lookup failed"));
+    await expect(resolveCatalogValidationResult(prismJob({
+      status: "completed",
+      result_metadata: { errors: [{ error: "symbol missing" }] },
+    }))).resolves.toEqual({
+      kind: "completed_without_component",
+      error: "symbol missing",
+    });
+  });
+});
+
+describe("applyCatalogValidationOutcome", () => {
+  it("toasts cancelled as a warning and failed as an error", () => {
+    applyCatalogValidationOutcome({ kind: "cancelled", message: "KLC validation was cancelled." });
+    applyCatalogValidationOutcome({ kind: "failed", error: "KLC validation failed." });
+    expect(toast.warning).toHaveBeenCalledWith("KLC validation was cancelled.");
+    expect(toast.error).toHaveBeenCalledWith("KLC validation failed.");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});
+
+describe("watchCatalogValidationJob", () => {
+  beforeEach(() => {
+    vi.mocked(fetchApi).mockReset();
+  });
+
+  it("keeps polling through retry_wait until the job completes", async () => {
+    const component = catalogComponent("comp-a");
+    vi.mocked(fetchApi)
+      .mockResolvedValueOnce(jobResponse({
+        status: "retry_wait",
+        message: "Waiting to retry",
+      }))
+      .mockResolvedValueOnce(jobResponse({
+        status: "completed",
+        result_metadata: { component },
+      }));
+
+    const updates: string[] = [];
+    const outcome = await watchCatalogValidationJob("job-1", {
+      signal: new AbortController().signal,
+      intervalMs: 0,
+      onUpdate: (job) => updates.push(job.status),
+    });
+
+    expect(updates).toEqual(["retry_wait", "completed"]);
+    expect(outcome).toEqual({ kind: "completed", component });
+    expect(fetchApi).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(fetchApi).mock.calls.every(([url]) => url === "/api/jobs/job-1")).toBe(true);
+  });
+});
+
+describe("useLibraryComponentValidation", () => {
+  it("aborts polling on unmount and does not refresh or toast success", async () => {
+    const signals: AbortSignal[] = [];
+    vi.mocked(fetchJson).mockResolvedValue({ job_id: "job-1" });
+    vi.mocked(fetchApi).mockImplementation((_url, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return abortAwareHang(init?.signal);
+    });
+    const onRefresh = vi.fn();
+    const { result, unmount } = renderHook(() => useLibraryComponentValidation({
+      componentId: "comp-a",
+      onRefresh,
+      intervalMs: 0,
+    }));
+
+    await act(async () => {
+      void result.current.runValidation();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(signals.length).toBeGreaterThan(0);
+
+    unmount();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchApi).mock.calls.some(([url]) => String(url).includes("/cancel"))).toBe(false);
+  });
+
+  it("aborts the previous watcher when the component changes", async () => {
+    const signals: AbortSignal[] = [];
+    vi.mocked(fetchJson).mockResolvedValue({ job_id: "job-1" });
+    vi.mocked(fetchApi).mockImplementation((_url, init) => {
+      if (init?.signal) signals.push(init.signal);
+      return abortAwareHang(init?.signal);
+    });
+    const onRefresh = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ componentId }) => useLibraryComponentValidation({
+        componentId,
+        onRefresh,
+        intervalMs: 0,
+      }),
+      { initialProps: { componentId: "comp-a" } },
+    );
+
+    await act(async () => {
+      void result.current.runValidation();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    rerender({ componentId: "comp-b" });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh B when A's completed job arrives after the UI switched", async () => {
+    let resolveStatus: ((response: Response) => void) | undefined;
+    vi.mocked(fetchJson).mockResolvedValue({ job_id: "job-1" });
+    vi.mocked(fetchApi).mockImplementation(() => new Promise((resolve) => {
+      resolveStatus = resolve;
+    }));
+    const onRefresh = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ componentId }) => useLibraryComponentValidation({
+        componentId,
+        onRefresh,
+        intervalMs: 0,
+      }),
+      { initialProps: { componentId: "comp-a" } },
+    );
+
+    await act(async () => {
+      void result.current.runValidation();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    rerender({ componentId: "comp-b" });
+    await act(async () => {
+      resolveStatus?.(jobResponse({
+        status: "completed",
+        result_metadata: { component: catalogComponent("comp-a") },
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("ignores a delayed completed job after unmount", async () => {
+    let resolveStatus: ((response: Response) => void) | undefined;
+    vi.mocked(fetchJson).mockResolvedValue({ job_id: "job-1" });
+    vi.mocked(fetchApi).mockImplementation(() => new Promise((resolve) => {
+      resolveStatus = resolve;
+    }));
+    const onRefresh = vi.fn();
+    const { result, unmount } = renderHook(() => useLibraryComponentValidation({
+      componentId: "comp-a",
+      onRefresh,
+      intervalMs: 0,
+    }));
+
+    await act(async () => {
+      void result.current.runValidation();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    unmount();
+    await act(async () => {
+      resolveStatus?.(jobResponse({
+        status: "completed",
+        result_metadata: { component: catalogComponent("comp-a") },
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("refreshes only after a completed job for the component still on screen", async () => {
+    const component = catalogComponent("comp-a", "passed");
+    vi.mocked(fetchJson).mockResolvedValue({ job_id: "job-1" });
+    vi.mocked(fetchApi)
+      .mockResolvedValueOnce(jobResponse({
+        status: "retry_wait",
+        message: "Waiting to retry",
+      }))
+      .mockResolvedValueOnce(jobResponse({
+        status: "completed",
+        result_metadata: { component },
+      }));
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => useLibraryComponentValidation({
+      componentId: "comp-a",
+      onRefresh,
+      intervalMs: 0,
+    }));
+
+    await act(async () => {
+      await result.current.runValidation();
+    });
+
+    expect(fetchApi).toHaveBeenCalledTimes(2);
+    expect(toast.success).toHaveBeenCalledWith("KLC validation passed.");
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("toasts a cancelled job as a warning, not a failure", async () => {
+    vi.mocked(fetchJson).mockResolvedValue({ job_id: "job-1" });
+    vi.mocked(fetchApi).mockResolvedValueOnce(jobResponse({
+      status: "cancelled",
+      message: "operator cancelled",
+    }));
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => useLibraryComponentValidation({
+      componentId: "comp-a",
+      onRefresh,
+      intervalMs: 0,
+    }));
+
+    await act(async () => {
+      await result.current.runValidation();
+    });
+
+    expect(toast.warning).toHaveBeenCalledWith("operator cancelled");
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("toasts a failed job as an error and does not refresh", async () => {
+    vi.mocked(fetchJson).mockResolvedValue({ job_id: "job-1" });
+    vi.mocked(fetchApi).mockResolvedValueOnce(jobResponse({
+      status: "failed",
+      error_message: "worker boom",
+    }));
+    const onRefresh = vi.fn();
+    const { result } = renderHook(() => useLibraryComponentValidation({
+      componentId: "comp-a",
+      onRefresh,
+      intervalMs: 0,
+    }));
+
+    await act(async () => {
+      await result.current.runValidation();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("worker boom");
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/workspace/library-component-validation.ts
+++ b/frontend/src/components/workspace/library-component-validation.ts
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { fetchJson } from "@/lib/api";
+import { useCommittedRef } from "@/hooks/use-committed-ref";
+import { watchPrismJob, type PrismJobStatus } from "@/lib/jobs";
+import type { CatalogComponent } from "@/types/catalog";
+
+/**
+ * Catalog KLC validation is a resumable fenced job. The browser watches the
+ * unified job endpoint and must never cancel backend work because a view
+ * closed. `retry_wait` is not terminal — `watchPrismJob` keeps polling.
+ */
+
+export type CatalogValidationOutcome =
+  | { kind: "completed"; component: CatalogComponent }
+  | { kind: "completed_without_component"; error: string }
+  | { kind: "failed"; error: string }
+  | { kind: "cancelled"; message: string };
+
+type CatalogValidationJobPayload = {
+  component?: unknown;
+  errors?: unknown;
+  result?: {
+    component?: unknown;
+    errors?: unknown;
+  };
+};
+
+const MISSING_COMPONENT_ERROR = "Validation did not return an updated component.";
+
+export function isValidationWatchAbort(reason: unknown): boolean {
+  return reason instanceof DOMException && reason.name === "AbortError";
+}
+
+function isCatalogComponent(value: unknown): value is CatalogComponent {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<CatalogComponent>;
+  return typeof candidate.id === "string"
+    && typeof candidate.revision_id === "string"
+    && typeof candidate.validation === "object"
+    && candidate.validation !== null;
+}
+
+function readErrors(source: unknown): Array<{ error: string }> {
+  if (!Array.isArray(source)) return [];
+  return source.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const error = (entry as { error?: unknown }).error;
+    return typeof error === "string" && error ? [{ error }] : [];
+  });
+}
+
+function readComponent(source: unknown): CatalogComponent | null {
+  if (isCatalogComponent(source)) return source;
+  if (!source || typeof source !== "object") return null;
+  const payload = source as CatalogValidationJobPayload;
+  if (isCatalogComponent(payload.component)) return payload.component;
+  if (isCatalogComponent(payload.result?.component)) return payload.result.component;
+  return null;
+}
+
+function collectErrors(source: unknown): Array<{ error: string }> {
+  const fromRoot = readErrors((source as CatalogValidationJobPayload | undefined)?.errors);
+  if (fromRoot.length) return fromRoot;
+  return readErrors((source as CatalogValidationJobPayload | undefined)?.result?.errors);
+}
+
+function jobFailureMessage(job: PrismJobStatus, fallback: string): string {
+  return job.error_message || job.message || fallback;
+}
+
+export async function resolveCatalogValidationResult(
+  job: PrismJobStatus,
+  signal?: AbortSignal,
+): Promise<CatalogValidationOutcome> {
+  if (job.status === "cancelled") {
+    return {
+      kind: "cancelled",
+      message: jobFailureMessage(job, "KLC validation was cancelled."),
+    };
+  }
+  if (job.status === "failed") {
+    return {
+      kind: "failed",
+      error: jobFailureMessage(job, "KLC validation failed."),
+    };
+  }
+
+  let component = readComponent(job.result_metadata);
+  let errors = collectErrors(job.result_metadata);
+  if (!component) {
+    try {
+      const legacy = await fetchJson<CatalogValidationJobPayload>(
+        `/api/catalog/validation/jobs/${encodeURIComponent(job.job_id)}`,
+        { signal },
+      );
+      component = readComponent(legacy);
+      if (!errors.length) errors = collectErrors(legacy);
+    } catch (reason) {
+      if (isValidationWatchAbort(reason)) throw reason;
+    }
+  }
+  if (component) return { kind: "completed", component };
+  return {
+    kind: "completed_without_component",
+    error: errors[0]?.error || MISSING_COMPONENT_ERROR,
+  };
+}
+
+export async function watchCatalogValidationJob(
+  jobId: string,
+  {
+    signal,
+    intervalMs,
+    onUpdate,
+  }: {
+    signal: AbortSignal;
+    intervalMs?: number;
+    onUpdate?: (job: PrismJobStatus) => void;
+  },
+): Promise<CatalogValidationOutcome> {
+  const job = await watchPrismJob(jobId, { signal, intervalMs, onUpdate });
+  return resolveCatalogValidationResult(job, signal);
+}
+
+export function applyCatalogValidationOutcome(outcome: CatalogValidationOutcome): void {
+  if (outcome.kind === "failed" || outcome.kind === "completed_without_component") {
+    toast.error(outcome.error);
+    return;
+  }
+  if (outcome.kind === "cancelled") {
+    toast.warning(outcome.message);
+    return;
+  }
+  if (outcome.component.validation.status === "failed") {
+    toast.error("KLC validation found blocking errors.");
+    return;
+  }
+  if (outcome.component.validation.status === "warning") {
+    toast.warning("KLC validation completed with warnings.");
+    return;
+  }
+  toast.success("KLC validation passed.");
+}
+
+export function useLibraryComponentValidation({
+  componentId,
+  onRefresh,
+  intervalMs,
+}: {
+  componentId: string;
+  onRefresh: () => void;
+  intervalMs?: number;
+}) {
+  const [validationBusy, setValidationBusy] = useState(false);
+  const controllerRef = useRef<AbortController | null>(null);
+  const originatingIdRef = useRef<string | null>(null);
+  const componentIdRef = useCommittedRef(componentId);
+  const onRefreshRef = useCommittedRef(onRefresh);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    return () => {
+      // Close the browser watcher only. The backend job stays resumable.
+      controller.abort();
+      if (controllerRef.current === controller) controllerRef.current = null;
+    };
+  }, [componentId]);
+
+  const runValidation = useCallback(async () => {
+    const originatingId = componentId;
+    const controller = controllerRef.current;
+    if (!controller || controller.signal.aborted) return;
+    originatingIdRef.current = originatingId;
+    setValidationBusy(true);
+    try {
+      const queued = await fetchJson<{ job_id: string }>(
+        `/api/catalog/components/${encodeURIComponent(originatingId)}/validate`,
+        { method: "POST", signal: controller.signal },
+      );
+      toast.message("KLC validation started.");
+      let lastNotice = "";
+      const outcome = await watchCatalogValidationJob(queued.job_id, {
+        signal: controller.signal,
+        intervalMs,
+        onUpdate: (job) => {
+          if (job.status === "completed" || job.status === "failed" || job.status === "cancelled") {
+            return;
+          }
+          const notice = job.message || "KLC validation is still running.";
+          if (notice === lastNotice) return;
+          lastNotice = notice;
+          toast.message(notice);
+        },
+      });
+      if (controller.signal.aborted || componentIdRef.current !== originatingId) return;
+      applyCatalogValidationOutcome(outcome);
+      if (outcome.kind === "completed") onRefreshRef.current();
+    } catch (reason) {
+      if (isValidationWatchAbort(reason) || controller.signal.aborted) return;
+      if (componentIdRef.current !== originatingId) return;
+      toast.error(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      // An unconditional reset would let an aborted run for A clear B's
+      // in-flight spinner after the user switched components.
+      if (!controller.signal.aborted && componentIdRef.current === originatingId) {
+        originatingIdRef.current = null;
+        // react-doctor-disable-next-line react-doctor/no-loading-flag-reset-outside-finally - aborting a watcher must not clear a later component's validation busy state
+        setValidationBusy(false);
+      }
+    }
+  }, [componentId, componentIdRef, intervalMs, onRefreshRef]);
+
+  return {
+    runValidation,
+    validationBusy: validationBusy && originatingIdRef.current === componentId,
+  };
+}

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -114,16 +114,9 @@ import {
   type MetadataEditSession,
 } from "./library-component-metadata-dialog";
 import { resolveLibraryPreviewPairAssetIds } from "./library-preview-pair";
+import { useLibraryComponentValidation } from "./library-component-validation";
 
 type ComponentTab = "overview" | "assets" | "revisions" | "review" | "usage" | "audit";
-
-type ValidationJob = {
-  status: "queued" | "running" | "completed" | "failed";
-  component?: CatalogComponent | null;
-  errors?: Array<{ error: string }>;
-  error?: string;
-  message?: string;
-};
 
 type RemoteProviderManifest = {
   assets: Array<{
@@ -165,8 +158,6 @@ const VALIDATION_LABELS: Record<CatalogValidationStatus, string> = {
   skipped: "KLC skipped",
   not_run: "KLC not run",
 };
-
-const sleep = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
 /**
  * Is this response actually a component?
@@ -601,6 +592,11 @@ export function LibraryComponentWorkspace({
   const [attachSession, setAttachSession] = useState<AssetAttachSession | null>(null);
   const [detachAsset, setDetachAsset] = useState<CatalogAsset | null>(null);
   const [busyAction, setBusyAction] = useState("");
+  const { runValidation, validationBusy } = useLibraryComponentValidation({
+    componentId,
+    onRefresh: () => setRefreshKey((value) => value + 1),
+  });
+  const activeBusyAction = busyAction || (validationBusy ? "validation" : "");
 
   const updateParams = useCallback((values: Record<string, string | null>) => {
     setSearchParams((current) => {
@@ -887,30 +883,9 @@ export function LibraryComponentWorkspace({
     }
   };
 
-  const handleValidateComponent = async () => {
+  const handleValidateComponent = () => {
     if (!canMutate || !currentComponent?.validation.enabled) return;
-    setBusyAction("validation");
-    try {
-      const queued = await fetchJson<{ job_id: string }>(`/api/catalog/components/${encodeURIComponent(componentId)}/validate`, { method: "POST" });
-      toast.message("KLC validation started.");
-      let job: ValidationJob | null = null;
-      for (let attempt = 0; attempt < 180; attempt += 1) {
-        await sleep(1000);
-        job = await fetchJson<ValidationJob>(`/api/catalog/validation/jobs/${encodeURIComponent(queued.job_id)}`);
-        if (job.status === "completed" || job.status === "failed") break;
-      }
-      if (!job || job.status === "queued" || job.status === "running") throw new Error("Validation is still running. Refresh later to see its status.");
-      if (job.status === "failed") throw new Error(job.error || job.message || "KLC validation failed.");
-      if (!job.component) throw new Error(job.errors?.[0]?.error || "Validation did not return an updated component.");
-      if (job.component.validation.status === "failed") toast.error("KLC validation found blocking errors.");
-      else if (job.component.validation.status === "warning") toast.warning("KLC validation completed with warnings.");
-      else toast.success("KLC validation passed.");
-      setRefreshKey((value) => value + 1);
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : String(reason));
-    } finally {
-      setBusyAction("");
-    }
+    void runValidation();
   };
 
   const handleDownloadAsset = async (asset: CatalogAsset) => {
@@ -1033,7 +1008,7 @@ export function LibraryComponentWorkspace({
             <AssetsPanel
               component={activeComponent}
               canMutate={canMutate}
-              busyAction={busyAction}
+              busyAction={activeBusyAction}
               onAttach={openAttachDialog}
               onDetachAsset={setDetachAsset}
               onDownload={(asset) => void handleDownloadAsset(asset)}


### PR DESCRIPTION
## Summary
- Replace the 180-second catalog-validation poll loop with `watchPrismJob` and a component-scoped `AbortController` in `library-component-validation.ts`.
- Navigation or a component switch aborts browser polling only; the backend job stays resumable and is never cancelled from unmount.
- `retry_wait` keeps polling, cancelled and failed jobs settle as distinct toasts, and a completed result refreshes only the originating component.

## Test plan
- [ ] Run KLC validation on a component and confirm started / in-progress toasts while the unified job is `queued`, `running`, or `retry_wait`.
- [ ] Leave the component (or switch to another) while validation is running: polling stops, no failure toast, no refresh of the new component, and the backend job keeps running.
- [ ] Confirm a cancelled job shows a warning toast and a failed job shows an error toast.
- [ ] Confirm a completed job toasts from `component.validation.status` and refreshes only if that same component is still open.
- [ ] `export PATH="/opt/homebrew/opt/node@22/bin:$PATH" && cd frontend && npm test -- src/components/workspace/library-component-validation.test.ts`