### PR TITLE
Download released library assets through the owning representation

### DIFF
--- a/frontend/src/components/workspace/AGENTS.md
+++ b/frontend/src/components/workspace/AGENTS.md
@@ -37,7 +37,10 @@ usage, and audit evidence), `library-component-metadata-dialog.tsx` and
 success callback), `library-component-metadata-form.ts` (definition-driven
 values, identity/provisional required rules, storage-key PATCH mapping;
 save validation matches the single PATCH, not bulk-edit shape checks),
-`library-component-metadata-fields.tsx` (typed input adapters), `library-component-quick-view.tsx`,
+`library-component-metadata-fields.tsx` (typed input adapters),
+`library-component-asset-download.ts` (released-revision downloads through the
+matching remote-provider representation, not the default placement pair),
+`library-component-quick-view.tsx`,
 `library-asset-link-picker.tsx`, `use-edit-history.ts`.
 
 **Previews** — two paths that share nothing but a subject.

--- a/frontend/src/components/workspace/library-component-asset-download.test.ts
+++ b/frontend/src/components/workspace/library-component-asset-download.test.ts
@@ -1,0 +1,353 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import type { CatalogAsset, CatalogComponent, CatalogRepresentation } from "@/types/catalog";
+
+import {
+  ASSET_NOT_IN_MANIFEST_MESSAGE,
+  locatePlacementManifestAsset,
+  planReleasedAssetDownload,
+  RELEASED_DOWNLOAD_BLOCKED_MESSAGE,
+  releasedAssetManifestUrl,
+  releasedRevisionDownloadsAllowed,
+  resolveReleasedRepresentationForAsset,
+  useReleasedAssetDownload,
+  type FetchPlacementManifest,
+  type PlacementManifest,
+} from "./library-component-asset-download";
+
+const asset = (
+  id: string,
+  asset_type: CatalogAsset["asset_type"],
+  extras: Partial<CatalogAsset> = {},
+): CatalogAsset => ({
+  id,
+  asset_type,
+  name: extras.name ?? `${id}.kicad`,
+  target_library: extras.target_library ?? "Test",
+  target_name: extras.target_name ?? id,
+  content_type: extras.content_type ?? "text/plain",
+  required: extras.required ?? true,
+  sha256: extras.sha256 ?? `raw-${id}`,
+  size_bytes: extras.size_bytes,
+});
+
+const representation = (
+  id: string,
+  symbol: CatalogAsset | null,
+  footprint: CatalogAsset | null,
+  options: { isDefault?: boolean; order?: number } = {},
+): CatalogRepresentation => ({
+  id,
+  label: id,
+  symbol,
+  footprint,
+  is_default: options.isDefault ?? false,
+  display_order: options.order ?? 0,
+  source_internal_part_number: "",
+  provenance: {},
+});
+
+const symbolA = asset("symbol-a", "symbol", { name: "default.kicad_sym", sha256: "raw-symbol-a" });
+const footprintA = asset("footprint-a", "footprint", { name: "default.kicad_mod", sha256: "raw-footprint-a" });
+const symbolB = asset("symbol-b", "symbol", { name: "alt.kicad_sym", sha256: "raw-symbol-b" });
+const footprintB = asset("footprint-b", "footprint", { name: "alt.kicad_mod", sha256: "raw-footprint-b" });
+const model = asset("model-1", "3dmodel", { name: "part.step", sha256: "raw-model" });
+
+const defaultPair = representation("representation-a", symbolA, footprintA, {
+  isDefault: true,
+  order: 0,
+});
+const secondPair = representation("representation-b", symbolB, footprintB, { order: 1 });
+
+function releasedComponent(
+  extras: Partial<CatalogComponent> = {},
+): CatalogComponent {
+  return {
+    id: "comp-1",
+    revision_id: "rev-released",
+    released_revision_id: "rev-released",
+    representations: [defaultPair, secondPair],
+    assets: [symbolA, footprintA, symbolB, footprintB, model],
+    ...extras,
+  } as CatalogComponent;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("releasedRevisionDownloadsAllowed", () => {
+  it("allows only the released revision", () => {
+    const released = releasedComponent();
+    expect(releasedRevisionDownloadsAllowed(released, released)).toBe(true);
+  });
+
+  it("blocks historical and unreleased content", () => {
+    const current = releasedComponent();
+    const historical = releasedComponent({ revision_id: "rev-old" });
+    const unreleased = releasedComponent({
+      revision_id: "rev-draft",
+      released_revision_id: undefined,
+    });
+    expect(releasedRevisionDownloadsAllowed(current, historical)).toBe(false);
+    expect(releasedRevisionDownloadsAllowed(unreleased, unreleased)).toBe(false);
+    expect(releasedRevisionDownloadsAllowed(null, current)).toBe(false);
+  });
+});
+
+describe("resolveReleasedRepresentationForAsset", () => {
+  const representations = [defaultPair, secondPair];
+
+  it("resolves the default pair", () => {
+    expect(resolveReleasedRepresentationForAsset(representations, symbolA)?.id).toBe(
+      "representation-a",
+    );
+    expect(resolveReleasedRepresentationForAsset(representations, footprintA)?.id).toBe(
+      "representation-a",
+    );
+  });
+
+  it("resolves the second pair", () => {
+    expect(resolveReleasedRepresentationForAsset(representations, symbolB)?.id).toBe(
+      "representation-b",
+    );
+    expect(resolveReleasedRepresentationForAsset(representations, footprintB)?.id).toBe(
+      "representation-b",
+    );
+  });
+
+  it("resolves an auxiliary onto the default complete pair", () => {
+    expect(resolveReleasedRepresentationForAsset(representations, model)?.id).toBe(
+      "representation-a",
+    );
+  });
+
+  it("uses the first complete pair when the default pair is incomplete", () => {
+    const incompleteDefault = representation("representation-a", symbolA, null, {
+      isDefault: true,
+    });
+    expect(
+      resolveReleasedRepresentationForAsset([incompleteDefault, secondPair], model)?.id,
+    ).toBe("representation-b");
+  });
+});
+
+describe("planReleasedAssetDownload", () => {
+  it("requests the matching representation for each pair and for auxiliaries", () => {
+    const released = releasedComponent();
+    const defaultPlan = planReleasedAssetDownload("comp-1", released, released, symbolA);
+    const secondPlan = planReleasedAssetDownload("comp-1", released, released, symbolB);
+    const auxiliaryPlan = planReleasedAssetDownload("comp-1", released, released, model);
+
+    expect(defaultPlan).toMatchObject({
+      status: "ready",
+      representationId: "representation-a",
+      manifestUrl: releasedAssetManifestUrl("comp-1", "representation-a"),
+    });
+    expect(secondPlan).toMatchObject({
+      status: "ready",
+      representationId: "representation-b",
+      manifestUrl: releasedAssetManifestUrl("comp-1", "representation-b"),
+    });
+    expect(auxiliaryPlan).toMatchObject({
+      status: "ready",
+      representationId: "representation-a",
+      manifestUrl: releasedAssetManifestUrl("comp-1", "representation-a"),
+    });
+    expect(defaultPlan.status === "ready" && defaultPlan.manifestUrl).toContain(
+      "representation=representation-a",
+    );
+    expect(secondPlan.status === "ready" && secondPlan.manifestUrl).toContain(
+      "representation=representation-b",
+    );
+  });
+
+  it("keeps historical unreleased downloads blocked", () => {
+    const current = releasedComponent();
+    const historical = releasedComponent({ revision_id: "rev-old" });
+    expect(planReleasedAssetDownload("comp-1", current, historical, symbolB)).toEqual({
+      status: "blocked",
+      message: RELEASED_DOWNLOAD_BLOCKED_MESSAGE,
+    });
+  });
+});
+
+describe("locatePlacementManifestAsset", () => {
+  it("prefers asset id and does not require raw sha256 to equal the placement hash", () => {
+    const placement = locatePlacementManifestAsset(
+      [
+        {
+          id: "symbol-b",
+          asset_type: "symbol",
+          name: "other.kicad_sym",
+          sha256: "placement-symbol-b",
+          download_url: "/signed/b",
+        },
+      ],
+      symbolB,
+    );
+    expect(placement?.download_url).toBe("/signed/b");
+  });
+
+  it("falls back to type and name when the API omits asset id", () => {
+    const placement = locatePlacementManifestAsset(
+      [
+        {
+          asset_type: "symbol",
+          name: "alt.kicad_sym",
+          sha256: "placement-symbol-b",
+          download_url: "/signed/b-by-name",
+        },
+      ],
+      symbolB,
+    );
+    expect(placement?.download_url).toBe("/signed/b-by-name");
+  });
+
+  it("does not treat a rewritten placement hash as the lookup key", () => {
+    expect(
+      locatePlacementManifestAsset(
+        [
+          {
+            asset_type: "symbol",
+            name: "default.kicad_sym",
+            sha256: "raw-symbol-b",
+            download_url: "/signed/wrong-pair",
+          },
+        ],
+        symbolB,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("useReleasedAssetDownload", () => {
+  beforeEach(() => {
+    vi.mocked(toast.info).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("fetches the representation-specific manifest and starts that download", async () => {
+    const fetchManifest = vi.fn<FetchPlacementManifest>(async (url) => {
+      expect(url).toContain("representation=representation-b");
+      return {
+        representation_id: "representation-b",
+        assets: [
+          {
+            asset_type: "symbol",
+            name: "alt.kicad_sym",
+            sha256: "placement-symbol-b",
+            download_url: "/signed/alt-symbol",
+          },
+        ],
+      };
+    });
+    const startDownload = vi.fn();
+    const released = releasedComponent();
+    const { result } = renderHook(() =>
+      useReleasedAssetDownload("comp-1", { fetchManifest, startDownload }),
+    );
+
+    await act(async () => {
+      await result.current(symbolB, released, released);
+    });
+
+    expect(fetchManifest).toHaveBeenCalledTimes(1);
+    expect(String(fetchManifest.mock.calls[0]?.[0])).toBe(
+      releasedAssetManifestUrl("comp-1", "representation-b"),
+    );
+    expect(fetchManifest.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(startDownload).toHaveBeenCalledWith("/signed/alt-symbol", "alt.kicad_sym");
+  });
+
+  it("does not request a manifest for historical unreleased content", async () => {
+    const fetchManifest = vi.fn();
+    const startDownload = vi.fn();
+    const current = releasedComponent();
+    const historical = releasedComponent({ revision_id: "rev-old" });
+    const { result } = renderHook(() =>
+      useReleasedAssetDownload("comp-1", { fetchManifest, startDownload }),
+    );
+
+    await act(async () => {
+      await result.current(symbolB, current, historical);
+    });
+
+    expect(fetchManifest).not.toHaveBeenCalled();
+    expect(startDownload).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith(RELEASED_DOWNLOAD_BLOCKED_MESSAGE);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("ignores a delayed manifest that arrives after unmount", async () => {
+    let finish: ((value: PlacementManifest) => void) | undefined;
+    const fetchManifest = vi.fn(
+      () =>
+        new Promise<PlacementManifest>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const startDownload = vi.fn();
+    const released = releasedComponent();
+    const { result, unmount } = renderHook(() =>
+      useReleasedAssetDownload("comp-1", { fetchManifest, startDownload }),
+    );
+
+    void result.current(symbolB, released, released);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchManifest).toHaveBeenCalledTimes(1);
+    unmount();
+    finish!({
+      assets: [
+        {
+          asset_type: "symbol",
+          name: "alt.kicad_sym",
+          sha256: "placement-symbol-b",
+          download_url: "/signed/late",
+        },
+      ],
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(startDownload).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a missing placement entry as an error, not a download", async () => {
+    const fetchManifest = vi.fn<FetchPlacementManifest>(async () => ({
+      assets: [
+        {
+          asset_type: "symbol",
+          name: "default.kicad_sym",
+          sha256: "placement-symbol-a",
+          download_url: "/signed/default",
+        },
+      ],
+    }));
+    const startDownload = vi.fn();
+    const released = releasedComponent();
+    const { result } = renderHook(() =>
+      useReleasedAssetDownload("comp-1", { fetchManifest, startDownload }),
+    );
+
+    await act(async () => {
+      await result.current(symbolB, released, released);
+    });
+
+    expect(startDownload).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(ASSET_NOT_IN_MANIFEST_MESSAGE);
+  });
+});

--- a/frontend/src/components/workspace/library-component-asset-download.ts
+++ b/frontend/src/components/workspace/library-component-asset-download.ts
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+import { fetchJson } from "@/lib/api";
+import { useCommittedRef } from "@/hooks/use-committed-ref";
+import type { CatalogAsset, CatalogComponent, CatalogRepresentation } from "@/types/catalog";
+
+/**
+ * Released-revision downloads go through the remote-provider placement
+ * manifest for one representation (`?representation=`).
+ *
+ * Catalog `asset.sha256` is the raw stored hash. Manifest `entry.sha256` is
+ * the KiCad placement hash after `materialize_asset` and need not match.
+ * The signed URL returns those placement bytes, not the raw source file.
+ */
+
+export const AUXILIARY_ASSET_TYPES = new Set<CatalogAsset["asset_type"]>([
+  "3dmodel",
+  "spice",
+]);
+
+export const RELEASED_DOWNLOAD_BLOCKED_MESSAGE =
+  "Direct downloads are available for the released revision. Release this revision or open the released revision first.";
+
+export const ASSET_NOT_IN_MANIFEST_MESSAGE =
+  "This asset is not present in the released download manifest.";
+
+export type PlacementManifestAsset = {
+  id?: string;
+  asset_type: CatalogAsset["asset_type"];
+  name: string;
+  sha256?: string;
+  download_url: string;
+};
+
+export type PlacementManifest = {
+  representation_id?: string;
+  assets: PlacementManifestAsset[];
+};
+
+export type ReleasedAssetDownloadPlan =
+  | { status: "blocked"; message: string }
+  | { status: "unavailable"; message: string }
+  | {
+      status: "ready";
+      componentId: string;
+      representationId: string;
+      manifestUrl: string;
+    };
+
+export type FetchPlacementManifest = (
+  input: string,
+  init?: RequestInit,
+) => Promise<PlacementManifest>;
+
+export type ReleasedAssetDownloadOptions = {
+  fetchManifest?: FetchPlacementManifest;
+  startDownload?: (url: string, filename: string) => void;
+};
+
+type DownloadSubject = Pick<CatalogComponent, "revision_id" | "released_revision_id" | "representations">;
+
+function isAbortError(reason: unknown): boolean {
+  return reason instanceof Error && reason.name === "AbortError";
+}
+
+function isCompleteRepresentation(representation: CatalogRepresentation): boolean {
+  return Boolean(representation.symbol?.id && representation.footprint?.id);
+}
+
+function pickRepresentation(candidates: CatalogRepresentation[]): CatalogRepresentation | null {
+  return (
+    candidates.find((entry) => entry.is_default) ||
+    [...candidates].sort((left, right) => {
+      if (left.display_order !== right.display_order) {
+        return left.display_order - right.display_order;
+      }
+      return left.id.localeCompare(right.id);
+    })[0] ||
+    null
+  );
+}
+
+function representationIncludesAsset(
+  representation: CatalogRepresentation,
+  assetId: string,
+): boolean {
+  return representation.symbol?.id === assetId || representation.footprint?.id === assetId;
+}
+
+export function releasedRevisionDownloadsAllowed(
+  currentComponent: Pick<CatalogComponent, "released_revision_id"> | null | undefined,
+  activeComponent: Pick<CatalogComponent, "revision_id"> | null | undefined,
+): boolean {
+  return Boolean(
+    currentComponent &&
+      activeComponent &&
+      activeComponent.revision_id === currentComponent.released_revision_id,
+  );
+}
+
+export function resolveReleasedRepresentationForAsset(
+  representations: readonly CatalogRepresentation[] | undefined,
+  asset: Pick<CatalogAsset, "id" | "asset_type">,
+): CatalogRepresentation | null {
+  const complete = (representations ?? []).filter(isCompleteRepresentation);
+  if (!complete.length) return null;
+  if (AUXILIARY_ASSET_TYPES.has(asset.asset_type)) {
+    return pickRepresentation(complete);
+  }
+  return pickRepresentation(
+    complete.filter((representation) => representationIncludesAsset(representation, asset.id)),
+  );
+}
+
+export function releasedAssetManifestUrl(componentId: string, representationId: string): string {
+  const params = new URLSearchParams({ representation: representationId });
+  return `/api/remote-provider/parts/${encodeURIComponent(componentId)}?${params.toString()}`;
+}
+
+export function locatePlacementManifestAsset(
+  assets: readonly PlacementManifestAsset[],
+  asset: Pick<CatalogAsset, "id" | "asset_type" | "name">,
+): PlacementManifestAsset | undefined {
+  const byId = assets.find((entry) => entry.id && entry.id === asset.id);
+  if (byId) return byId;
+  return assets.find(
+    (entry) => entry.asset_type === asset.asset_type && entry.name === asset.name,
+  );
+}
+
+export function planReleasedAssetDownload(
+  componentId: string,
+  currentComponent: DownloadSubject | null | undefined,
+  activeComponent: DownloadSubject | null | undefined,
+  asset: Pick<CatalogAsset, "id" | "asset_type">,
+): ReleasedAssetDownloadPlan {
+  if (!releasedRevisionDownloadsAllowed(currentComponent, activeComponent)) {
+    return { status: "blocked", message: RELEASED_DOWNLOAD_BLOCKED_MESSAGE };
+  }
+  const representation = resolveReleasedRepresentationForAsset(
+    activeComponent?.representations,
+    asset,
+  );
+  if (!representation) {
+    return { status: "unavailable", message: ASSET_NOT_IN_MANIFEST_MESSAGE };
+  }
+  return {
+    status: "ready",
+    componentId,
+    representationId: representation.id,
+    manifestUrl: releasedAssetManifestUrl(componentId, representation.id),
+  };
+}
+
+export function startBrowserDownload(url: string, filename: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+export async function fetchReleasedAssetDownload(
+  plan: Extract<ReleasedAssetDownloadPlan, { status: "ready" }>,
+  asset: Pick<CatalogAsset, "id" | "asset_type" | "name">,
+  options: {
+    fetchManifest?: FetchPlacementManifest;
+    signal?: AbortSignal;
+  } = {},
+): Promise<{ downloadUrl: string; filename: string }> {
+  const fetchManifest = options.fetchManifest ?? fetchJson<PlacementManifest>;
+  const manifest = await fetchManifest(plan.manifestUrl, { signal: options.signal });
+  const downloadable = locatePlacementManifestAsset(manifest.assets ?? [], asset);
+  if (!downloadable?.download_url) {
+    throw new Error(ASSET_NOT_IN_MANIFEST_MESSAGE);
+  }
+  return {
+    downloadUrl: downloadable.download_url,
+    filename: asset.name,
+  };
+}
+
+export function useReleasedAssetDownload(
+  componentId: string,
+  options?: ReleasedAssetDownloadOptions,
+) {
+  const optionsRef = useCommittedRef(options);
+  const requestRef = useRef<AbortController | null>(null);
+  const liveRef = useRef(true);
+
+  useEffect(() => {
+    liveRef.current = true;
+    return () => {
+      liveRef.current = false;
+      requestRef.current?.abort();
+      requestRef.current = null;
+    };
+  }, []);
+
+  return useCallback(
+    async (
+      asset: CatalogAsset,
+      currentComponent: CatalogComponent | null,
+      activeComponent: CatalogComponent | null,
+    ) => {
+      const plan = planReleasedAssetDownload(
+        componentId,
+        currentComponent,
+        activeComponent,
+        asset,
+      );
+      if (plan.status === "blocked") {
+        toast.info(plan.message);
+        return;
+      }
+      if (plan.status === "unavailable") {
+        toast.error(plan.message);
+        return;
+      }
+
+      requestRef.current?.abort();
+      const controller = new AbortController();
+      requestRef.current = controller;
+      const { fetchManifest, startDownload = startBrowserDownload } = optionsRef.current ?? {};
+
+      try {
+        const downloaded = await fetchReleasedAssetDownload(plan, asset, {
+          fetchManifest,
+          signal: controller.signal,
+        });
+        if (!liveRef.current || controller.signal.aborted) return;
+        startDownload(downloaded.downloadUrl, downloaded.filename);
+      } catch (reason) {
+        if (!liveRef.current || controller.signal.aborted || isAbortError(reason)) return;
+        toast.error(reason instanceof Error ? reason.message : String(reason));
+      }
+    },
+    [componentId, optionsRef],
+  );
+}

--- a/frontend/src/components/workspace/library-component-workspace.tsx
+++ b/frontend/src/components/workspace/library-component-workspace.tsx
@@ -113,19 +113,11 @@ import {
   metadataEditSessionFrom,
   type MetadataEditSession,
 } from "./library-component-metadata-dialog";
+import { useReleasedAssetDownload } from "./library-component-asset-download";
 import { resolveLibraryPreviewPairAssetIds } from "./library-preview-pair";
 import { useLibraryComponentValidation } from "./library-component-validation";
 
 type ComponentTab = "overview" | "assets" | "revisions" | "review" | "usage" | "audit";
-
-type RemoteProviderManifest = {
-  assets: Array<{
-    asset_type: AssetType;
-    name: string;
-    sha256: string;
-    download_url: string;
-  }>;
-};
 
 const COMPONENT_TABS: Array<{ id: ComponentTab; label: string; icon: typeof Boxes }> = [
   { id: "overview", label: "Overview", icon: Boxes },
@@ -597,6 +589,7 @@ export function LibraryComponentWorkspace({
     onRefresh: () => setRefreshKey((value) => value + 1),
   });
   const activeBusyAction = busyAction || (validationBusy ? "validation" : "");
+  const downloadReleasedAsset = useReleasedAssetDownload(componentId);
 
   const updateParams = useCallback((values: Record<string, string | null>) => {
     setSearchParams((current) => {
@@ -888,27 +881,6 @@ export function LibraryComponentWorkspace({
     void runValidation();
   };
 
-  const handleDownloadAsset = async (asset: CatalogAsset) => {
-    if (!currentComponent || !activeComponent || activeComponent.revision_id !== currentComponent.released_revision_id) {
-      toast.info("Direct downloads are available for the released revision. Release this revision or open the released revision first.");
-      return;
-    }
-    try {
-      const manifest = await fetchJson<RemoteProviderManifest>(`/api/remote-provider/parts/${encodeURIComponent(componentId)}`);
-      const downloadable = manifest.assets.find((entry) => entry.asset_type === asset.asset_type && entry.sha256 === asset.sha256)
-        || manifest.assets.find((entry) => entry.asset_type === asset.asset_type && entry.name === asset.name);
-      if (!downloadable?.download_url) throw new Error("This asset is not present in the released download manifest.");
-      const anchor = document.createElement("a");
-      anchor.href = downloadable.download_url;
-      anchor.download = asset.name;
-      document.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-    } catch (reason) {
-      toast.error(reason instanceof Error ? reason.message : String(reason));
-    }
-  };
-
   const relevantDiffState = diffPair ? diffLoadState : { status: "loaded", error: "" } satisfies EvidenceLoadState;
   const revisionsTabState = combinedEvidenceState([revisionsLoadState, relevantDiffState]);
   const reviewTabState = combinedEvidenceState([revisionsLoadState, reviewsLoadState, releasesLoadState, relevantDiffState]);
@@ -1011,7 +983,9 @@ export function LibraryComponentWorkspace({
               busyAction={activeBusyAction}
               onAttach={openAttachDialog}
               onDetachAsset={setDetachAsset}
-              onDownload={(asset) => void handleDownloadAsset(asset)}
+              onDownload={(asset) => {
+                void downloadReleasedAsset(asset, currentComponent, activeComponent);
+              }}
               onRegeneratePreviews={() => void handleRegeneratePreviews()}
               onValidate={() => void handleValidateComponent()}
               onRepresentationsChanged={() => {


### PR DESCRIPTION
## Summary
- Released library-asset downloads now resolve the asset to a complete representation on the released revision and request `GET /api/remote-provider/parts/{id}?representation=`, instead of the default placement pair.
- Manifest lookup uses asset id when present, otherwise type + name. Raw catalog `sha256` is never required to equal the materialized KiCad placement hash; the signed URL still returns placement bytes.
- Historical and unreleased revisions stay blocked. The coordinator calls `useReleasedAssetDownload` in `library-component-asset-download.ts` and ignores a delayed manifest after unmount.

## Test plan
- [x] Frontend unit tests: default pair, second pair, auxiliary; request includes `representation=`; unreleased/historical blocked; placement hash ≠ raw hash; delayed response after unmount
- [x] `cd frontend && npm run lint && npm run scan:gate && npm test && npm run build && npm run build:panel` (Node 22)
- [x] `python3 scripts/check_agent_docs.py`
- [ ] Download both representations of a released component with two pairs and confirm the chosen filename/bytes
- [ ] Download an auxiliary (3D/SPICE) from that released revision
- [ ] Confirm a historical or unreleased revision still refuses direct download