### PR TITLE
Scope import proposals to the selected session

### DIFF
--- a/frontend/src/components/workspace/AGENTS.md
+++ b/frontend/src/components/workspace/AGENTS.md
@@ -55,6 +55,8 @@ pair draws. Navigation belongs to the viewer, not to the frame around it — see
 `frontend/src/lib/ecad-renderer.ts`.
 
 **Import** — `library-import-center.tsx`,
+`library-import-session-proposals.ts` (proposals keyed by session ID; abort
+superseded reads; non-overlapping scan polling),
 `library-import-remediation-dialog.tsx`, `library-import-remediation-grid.tsx`,
 `library-folder-discovery-dialog.tsx`. Import produces proposals that a human
 remediates before acceptance; the grid is the remediation surface.

--- a/frontend/src/components/workspace/library-import-center.test.tsx
+++ b/frontend/src/components/workspace/library-import-center.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Project } from "@/types/project";
+import type { ProjectComponentImportProposal, ProjectComponentImportSession } from "@/types/catalog";
 import { fetchJson } from "@/lib/api";
 import { LibraryImportCenter } from "./library-import-center";
 
@@ -73,5 +74,81 @@ describe("LibraryImportCenter sources", () => {
       "grid-cols-1",
       "import-source-groups--split",
     );
+  });
+});
+
+function importSession(id: string, status: ProjectComponentImportSession["status"] = "staged"): ProjectComponentImportSession {
+  return {
+    id,
+    scope: "folder",
+    project_id: "",
+    project_ids: [],
+    project_revisions: {},
+    source_revision: "",
+    status,
+    created_by: "admin@example.com",
+    created_at: "2026-08-27T00:00:00Z",
+    updated_at: "2026-08-27T00:00:00Z",
+    error_message: "",
+    proposal_count: 1,
+    selection: { display_name: id },
+  };
+}
+
+function importProposal(sessionId: string, reference: string): ProjectComponentImportProposal {
+  return {
+    id: `${sessionId}-${reference}`,
+    session_id: sessionId,
+    dedupe_key: reference,
+    component_uid: reference,
+    reference,
+    status: "candidate",
+    accepted_component_id: "",
+    metadata: { references: [reference], value: "10k" },
+    assets: [],
+    provenance: [],
+    findings: [],
+  };
+}
+
+describe("LibraryImportCenter session proposals", () => {
+  beforeEach(() => {
+    vi.mocked(fetchJson).mockReset();
+  });
+
+  it("does not show session A proposals after switching to session B", async () => {
+    let finishA: ((value: { items: ProjectComponentImportProposal[] }) => void) | undefined;
+    vi.mocked(fetchJson).mockImplementation(async (input) => {
+      const path = String(input);
+      if (path === "/api/catalog/import-sessions") {
+        return { items: [importSession("session-a"), importSession("session-b")] };
+      }
+      if (path === "/api/catalog/import-sources/folder-roots") return { items: [] };
+      if (path.endsWith("/session-a/proposals")) {
+        return new Promise((resolve) => {
+          finishA = resolve;
+        });
+      }
+      if (path.endsWith("/session-b/proposals")) {
+        return { items: [importProposal("session-b", "R-B")] };
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    render(
+      <LibraryImportCenter
+        projects={[project]}
+        user={{ name: "Admin", email: "admin@example.com", role: "admin" }}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /session-b/i }));
+    expect(await screen.findByText("R-B")).toBeInTheDocument();
+
+    await act(async () => {
+      finishA!({ items: [importProposal("session-a", "R-A")] });
+    });
+    await waitFor(() => expect(screen.queryByText("R-A")).not.toBeInTheDocument());
+    expect(screen.getByText("R-B")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/workspace/library-import-center.tsx
+++ b/frontend/src/components/workspace/library-import-center.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { LibraryImportRemediationDialog, type ProposalRemediation } from "./library-import-remediation-dialog";
 import { LibraryImportRemediationGrid } from "./library-import-remediation-grid";
 import { LibraryFolderDiscoveryDialog } from "./library-folder-discovery-dialog";
+import { isAbortError, useImportSessionProposals, useNonOverlappingPoll } from "./library-import-session-proposals";
 
 interface LibraryImportCenterProps {
   projects: Project[];
@@ -101,7 +102,6 @@ const DIRECTORY_INPUT_PROPS: InputHTMLAttributes<HTMLInputElement> & {
 export function LibraryImportCenter({ projects, user, initialSessionId }: LibraryImportCenterProps) {
   const [sessions, setSessions] = useState<ProjectComponentImportSession[]>([]);
   const [selectedSessionId, setSelectedSessionId] = useState(initialSessionId || "");
-  const [proposals, setProposals] = useState<ProjectComponentImportProposal[]>([]);
   const [projectId, setProjectId] = useState(projects[0]?.id || "");
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
@@ -129,37 +129,41 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
     () => sessions.find((session) => session.id === selectedSessionId),
     [selectedSessionId, sessions]
   );
+  const { proposals, loadProposals } = useImportSessionProposals(selectedSessionId);
+  const hasActiveScan = sessions.some((session) => session.status === "queued" || session.status === "scanning");
 
-  const loadSessions = useCallback(async () => {
-    const response = await fetchJson<{ items: ProjectComponentImportSession[] }>("/api/catalog/import-sessions");
+  const loadSessions = useCallback(async (signal?: AbortSignal) => {
+    const response = await fetchJson<{ items: ProjectComponentImportSession[] }>(
+      "/api/catalog/import-sessions",
+      { signal },
+    );
+    if (signal?.aborted) return;
     setSessions(response.items);
     setSelectedSessionId((current) => current || initialSessionId || response.items[0]?.id || "");
   }, [initialSessionId]);
 
-  const loadProposals = useCallback(async (sessionId: string) => {
-    if (!sessionId) {
-      setProposals([]);
-      return;
-    }
-    const response = await fetchJson<{ items: ProjectComponentImportProposal[] }>(
-      `/api/catalog/import-sessions/${sessionId}/proposals`
-    );
-    setProposals(response.items);
-  }, []);
+  const refreshActiveImport = useCallback(async (signal: AbortSignal) => {
+    await loadSessions(signal);
+    await loadProposals(selectedSessionId, signal);
+  }, [loadProposals, loadSessions, selectedSessionId]);
 
+  // Fetch carries the AbortController signal; setters run only when this
+  // initial session-list request is still the mounted one.
+  // react-doctor-disable-next-line react-doctor/no-set-state-after-await-in-effect
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     const load = async () => {
       try {
-        await loadSessions();
+        await loadSessions(controller.signal);
       } catch (error) {
-        if (!cancelled) toast.error(error instanceof Error ? error.message : "Failed to load import sessions");
+        if (controller.signal.aborted || isAbortError(error)) return;
+        toast.error(error instanceof Error ? error.message : "Failed to load import sessions");
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     };
     void load();
-    return () => { cancelled = true; };
+    return () => controller.abort();
   }, [loadSessions]);
 
   useEffect(() => {
@@ -172,19 +176,7 @@ export function LibraryImportCenter({ projects, user, initialSessionId }: Librar
     }).catch(() => setServerRoots([]));
   }, [canWrite]);
 
-  useEffect(() => {
-    void loadProposals(selectedSessionId).catch((error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to load import proposals");
-    });
-  }, [loadProposals, selectedSessionId]);
-
-  useEffect(() => {
-    if (!sessions.some((session) => session.status === "queued" || session.status === "scanning")) return;
-    const timer = window.setInterval(() => {
-      void loadSessions().then(() => loadProposals(selectedSessionId));
-    }, 2000);
-    return () => window.clearInterval(timer);
-  }, [loadProposals, loadSessions, selectedSessionId, sessions]);
+  useNonOverlappingPoll(hasActiveScan, refreshActiveImport);
 
   const createSession = async (scope: "project" | "all-projects") => {
     if (scope === "project" && !projectId) return;

--- a/frontend/src/components/workspace/library-import-session-proposals.test.ts
+++ b/frontend/src/components/workspace/library-import-session-proposals.test.ts
@@ -1,0 +1,161 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchJson } from "@/lib/api";
+import type { ProjectComponentImportProposal } from "@/types/catalog";
+import { useImportSessionProposals, useNonOverlappingPoll } from "./library-import-session-proposals";
+
+vi.mock("@/lib/api", () => ({
+  fetchJson: vi.fn(),
+  fetchApi: vi.fn(),
+  readApiError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+
+import { toast } from "sonner";
+
+function proposal(sessionId: string, reference: string): ProjectComponentImportProposal {
+  return {
+    id: `${sessionId}-${reference}`,
+    session_id: sessionId,
+    dedupe_key: reference,
+    component_uid: reference,
+    reference,
+    status: "candidate",
+    accepted_component_id: "",
+    metadata: { references: [reference] },
+    assets: [],
+    provenance: [],
+    findings: [],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useImportSessionProposals", () => {
+  beforeEach(() => {
+    vi.mocked(fetchJson).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("keeps a delayed session A result off session B's list", async () => {
+    let finishA: ((value: { items: ProjectComponentImportProposal[] }) => void) | undefined;
+    vi.mocked(fetchJson).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/session-a/proposals")) {
+        return new Promise((resolve) => {
+          finishA = resolve;
+        });
+      }
+      if (url.endsWith("/session-b/proposals")) {
+        return { items: [proposal("session-b", "R-B")] };
+      }
+      throw new Error(`unrouted ${url}`);
+    });
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => useImportSessionProposals(sessionId),
+      { initialProps: { sessionId: "session-a" } },
+    );
+
+    rerender({ sessionId: "session-b" });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.proposals.map((item) => item.reference)).toEqual(["R-B"]);
+
+    await act(async () => {
+      finishA!({ items: [proposal("session-a", "R-A")] });
+      await Promise.resolve();
+    });
+    expect(result.current.proposals.map((item) => item.reference)).toEqual(["R-B"]);
+    expect(result.current.proposals[0]?.session_id).toBe("session-b");
+  });
+
+  it("ignores a delayed proposals response after unmount", async () => {
+    let finish: ((value: { items: ProjectComponentImportProposal[] }) => void) | undefined;
+    vi.mocked(fetchJson).mockImplementation(async () => new Promise((resolve) => {
+      finish = resolve;
+    }));
+    const { unmount } = renderHook(() => useImportSessionProposals("session-a"));
+    unmount();
+    await act(async () => {
+      finish!({ items: [proposal("session-a", "late")] });
+      await Promise.resolve();
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("useNonOverlappingPoll", () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("does not start a second tick while the first is still in flight", async () => {
+    vi.useFakeTimers();
+    let release: (() => void) | undefined;
+    const tick = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+    renderHook(() => useNonOverlappingPoll(true, tick, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(tick).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(tick).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      release?.();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(tick).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a failed tick and recovers on the next interval", async () => {
+    vi.useFakeTimers();
+    const tick = vi.fn()
+      .mockRejectedValueOnce(new Error("scan refresh failed"))
+      .mockResolvedValueOnce(undefined);
+    renderHook(() => useNonOverlappingPoll(true, tick, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(toast.error).toHaveBeenCalledWith("scan refresh failed");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(tick).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(toast.error).mock.calls).toHaveLength(1);
+  });
+
+  it("aborts an in-flight tick on unmount so it cannot publish", async () => {
+    vi.useFakeTimers();
+    const seen: AbortSignal[] = [];
+    const tick = vi.fn(async (signal: AbortSignal) => {
+      seen.push(signal);
+      await new Promise(() => undefined);
+    });
+    const { unmount } = renderHook(() => useNonOverlappingPoll(true, tick, 1000));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    unmount();
+    expect(seen[0]?.aborted).toBe(true);
+  });
+});

--- a/frontend/src/components/workspace/library-import-session-proposals.test.ts
+++ b/frontend/src/components/workspace/library-import-session-proposals.test.ts
@@ -126,6 +126,33 @@ describe("useNonOverlappingPoll", () => {
     expect(tick).toHaveBeenCalledTimes(2);
   });
 
+  it("toasts a repeated outage only once until a tick succeeds", async () => {
+    vi.useFakeTimers();
+    const tick = vi.fn()
+      .mockRejectedValueOnce(new Error("scan refresh failed"))
+      .mockRejectedValueOnce(new Error("scan refresh failed"))
+      .mockRejectedValueOnce(new Error("scan refresh failed"))
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("scan refresh failed"));
+    renderHook(() => useNonOverlappingPoll(true, tick, 1000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(tick).toHaveBeenCalledTimes(3);
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(tick).toHaveBeenCalledTimes(4);
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(tick).toHaveBeenCalledTimes(5);
+    expect(toast.error).toHaveBeenCalledTimes(2);
+  });
+
   it("reports a failed tick and recovers on the next interval", async () => {
     vi.useFakeTimers();
     const tick = vi.fn()

--- a/frontend/src/components/workspace/library-import-session-proposals.ts
+++ b/frontend/src/components/workspace/library-import-session-proposals.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { fetchJson } from "@/lib/api";
+import type { ProjectComponentImportProposal } from "@/types/catalog";
+
+export function isAbortError(reason: unknown): boolean {
+  return (reason instanceof DOMException || reason instanceof Error) && reason.name === "AbortError";
+}
+
+export function useImportSessionProposals(selectedSessionId: string) {
+  const [proposalsBySessionId, setProposalsBySessionId] = useState<
+    Record<string, ProjectComponentImportProposal[]>
+  >({});
+
+  const loadProposals = useCallback(async (sessionId: string, signal?: AbortSignal) => {
+    if (!sessionId) return;
+    const response = await fetchJson<{ items: ProjectComponentImportProposal[] }>(
+      `/api/catalog/import-sessions/${sessionId}/proposals`,
+      { signal },
+    );
+    if (signal?.aborted) return;
+    // Write under the requested session, never the currently selected one, so a
+    // late response from A cannot replace B's visible list.
+    setProposalsBySessionId((current) => ({ ...current, [sessionId]: response.items }));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedSessionId) return;
+    const controller = new AbortController();
+    void loadProposals(selectedSessionId, controller.signal).catch((error) => {
+      if (controller.signal.aborted || isAbortError(error)) return;
+      toast.error(error instanceof Error ? error.message : "Failed to load import proposals");
+    });
+    return () => controller.abort();
+  }, [loadProposals, selectedSessionId]);
+
+  return {
+    proposals: proposalsBySessionId[selectedSessionId] ?? [],
+    loadProposals,
+  };
+}
+
+export function useNonOverlappingPoll(
+  enabled: boolean,
+  tick: (signal: AbortSignal) => Promise<void>,
+  intervalMs = 2000,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const controller = new AbortController();
+    let inFlight = false;
+    const run = async () => {
+      if (inFlight || controller.signal.aborted) return;
+      inFlight = true;
+      try {
+        await tick(controller.signal);
+      } catch (error) {
+        if (controller.signal.aborted || isAbortError(error)) return;
+        toast.error(error instanceof Error ? error.message : "Failed to refresh import sessions");
+      } finally {
+        inFlight = false;
+      }
+    };
+    const timer = window.setInterval(() => {
+      void run();
+    }, intervalMs);
+    return () => {
+      controller.abort();
+      window.clearInterval(timer);
+    };
+  }, [enabled, intervalMs, tick]);
+}

--- a/frontend/src/components/workspace/library-import-session-proposals.ts
+++ b/frontend/src/components/workspace/library-import-session-proposals.ts
@@ -50,14 +50,22 @@ export function useNonOverlappingPoll(
     if (!enabled) return;
     const controller = new AbortController();
     let inFlight = false;
+    let lastFailure = "";
     const run = async () => {
       if (inFlight || controller.signal.aborted) return;
       inFlight = true;
       try {
         await tick(controller.signal);
+        lastFailure = "";
       } catch (error) {
         if (controller.signal.aborted || isAbortError(error)) return;
-        toast.error(error instanceof Error ? error.message : "Failed to refresh import sessions");
+        const notice = error instanceof Error ? error.message : "Failed to refresh import sessions";
+        // One toast per outage, not one per 2s tick, so a 30s restart does not
+        // stack fifteen identical errors. A later success clears the episode.
+        if (notice !== lastFailure) {
+          lastFailure = notice;
+          toast.error(notice);
+        }
       } finally {
         inFlight = false;
       }


### PR DESCRIPTION
## Summary
- Key import proposals by session ID and abort superseded reads so a slow session A cannot replace session B's list or actions.
- Scan polling is non-overlapping, reports failures, retries on the next interval, and stops publishing on unmount.
- Remediation drafts and partial acceptance are unchanged.

## Test plan
- [x] Delayed session A resolving after B leaves only B proposals visible
- [x] A second poll tick does not start while the first is in flight
- [x] A failed poll is toasted and the next interval recovers
- [x] Unmount aborts an in-flight poll
- [x] Frontend quality gate: lint, scan:gate, test, build, build:panel
- [x] `python3 scripts/check_agent_docs.py`
- [ ] GitHub quality gate on this PR