### PR TITLE
Expose panel pagination instead of truncating search and category lists

### DIFF
--- a/frontend/src/panel/PanelApp.tsx
+++ b/frontend/src/panel/PanelApp.tsx
@@ -11,7 +11,11 @@ import {
 } from "@/panel/lib/kicad-bridge";
 import { getCategories, isAuthError, setApiToken } from "@/panel/lib/panel-api";
 import type { PanelComponent } from "@/panel/lib/panel-api";
-import type { FinderViewState } from "@/panel/lib/view-state";
+import {
+  emptyCategoryBrowse,
+  emptyFinderView,
+  type CategoryBrowseState,
+} from "@/panel/lib/view-state";
 
 import { PanelLoginScreen } from "@/panel/screens/PanelLoginScreen";
 import { SymbolFinderScreen } from "@/panel/screens/SymbolFinderScreen";
@@ -35,10 +39,10 @@ type Screen =
 
 export function PanelApp() {
   const [screen, setScreen] = useState<Screen>({ kind: "login" });
-  const [finderView, setFinderView] = useState<FinderViewState>({
-    query: "",
-    searchResults: [],
-  });
+  const [finderView, setFinderView] = useState(emptyFinderView);
+  const [categoryView, setCategoryView] = useState<CategoryBrowseState>(
+    () => emptyCategoryBrowse(""),
+  );
   const [logEntries, setLogEntries] = useState<string[]>([]);
   const [sessionReady, setSessionReady] = useState(false);
   const [loginLoading, setLoginLoading] = useState(false);
@@ -155,10 +159,12 @@ export function PanelApp() {
   const goToFinder = useCallback(() => setScreen({ kind: "finder" }), []);
   const goToLogin = useCallback(() => setScreen({ kind: "login" }), []);
 
-  const goToCategory = useCallback(
-    (name: string) => setScreen({ kind: "category", name }),
-    []
-  );
+  const goToCategory = useCallback((name: string, total?: number | null) => {
+    setCategoryView((prev) =>
+      prev.name === name ? prev : emptyCategoryBrowse(name, total ?? null),
+    );
+    setScreen({ kind: "category", name });
+  }, []);
 
   const goToDetailFromFinder = useCallback((comp: PanelComponent) => {
     setScreen({
@@ -222,6 +228,8 @@ export function PanelApp() {
         {screen.kind === "category" && (
           <CategoryListScreen
             category={screen.name}
+            viewState={categoryView}
+            onViewStateChange={setCategoryView}
             onBack={goToFinder}
             onSelectComponent={goToDetailFromCategory}
             onAuthRequired={goToLogin}

--- a/frontend/src/panel/lib/panel-api.test.ts
+++ b/frontend/src/panel/lib/panel-api.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   getComponent,
+  getComponentsByCategory,
   getInlineBundle,
   getPartManifest,
   primaryLocalSource,
+  searchComponents,
   type PanelComponent,
   type PanelSupplySource,
 } from "./panel-api";
@@ -98,5 +100,76 @@ describe("panel representation requests", () => {
       "/api/remote-provider/parts/component-1",
       "/api/remote-provider/components/component-1/inline",
     ]);
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("panel page fetches", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns one typed search page and does not walk remaining pages", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        items: [{ id: "a" }],
+        total: null,
+        has_more: true,
+        page: 1,
+        pages: null,
+        page_size: 50,
+      }),
+    );
+
+    await expect(searchComponents("resistor")).resolves.toEqual({
+      items: [{ id: "a" }],
+      total: null,
+      has_more: true,
+      page: 1,
+      pages: null,
+      page_size: 50,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "/api/remote-provider/search?q=resistor&page=1&page_size=50",
+    );
+  });
+
+  it("requests a later category page without raising page_size past the server limit", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        items: [],
+        total: 501,
+        has_more: true,
+        page: 2,
+        pages: 11,
+        page_size: 50,
+      }),
+    );
+
+    await getComponentsByCategory("Resistors", { page: 2, pageSize: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "/api/remote-provider/components-by-category?category=Resistors&page=2&page_size=200",
+    );
+  });
+
+  it("propagates cancellation of an in-flight page", async () => {
+    const controller = new AbortController();
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("Aborted"), { name: "AbortError" }));
+        });
+      }),
+    );
+
+    const pending = searchComponents("cap", { signal: controller.signal });
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
   });
 });

--- a/frontend/src/panel/lib/panel-api.ts
+++ b/frontend/src/panel/lib/panel-api.ts
@@ -2,6 +2,8 @@
  * Panel API client — typed fetch helpers for the remote-provider endpoints.
  */
 
+import { normalizePanelPageSize, PANEL_PAGE_SIZE } from "@/panel/lib/panel-page";
+
 export interface PanelComponent {
   id: string;
   slug: string;
@@ -135,37 +137,55 @@ export function isAuthError(err: unknown): boolean {
   return err instanceof PanelApiError && (err.status === 401 || err.status === 403);
 }
 
-async function fetchComponentPages(
+export interface PanelPageResult {
+  items: PanelComponent[];
+  total: number | null;
+  has_more: boolean;
+  page: number;
+  pages: number | null;
+  page_size: number;
+}
+
+export interface PanelPageQuery {
+  page?: number;
+  pageSize?: number;
+  signal?: AbortSignal;
+}
+
+function asPageResult(data: Partial<PanelPageResult>, fallbackPage: number, fallbackSize: number): PanelPageResult {
+  return {
+    items: data.items ?? [],
+    total: data.total ?? null,
+    has_more: Boolean(data.has_more),
+    page: data.page ?? fallbackPage,
+    pages: data.pages ?? null,
+    page_size: data.page_size ?? fallbackSize,
+  };
+}
+
+async function fetchComponentPage(
   endpoint: string,
   params: URLSearchParams,
-  pageSize: number,
-  maxItems: number,
-  signal?: AbortSignal
-): Promise<PanelComponent[]> {
-  const items: PanelComponent[] = [];
-  let page = 1;
-  let pages = 1;
-  do {
-    params.set("page", String(page));
-    params.set("page_size", String(pageSize));
-    const data = await panelFetch<{ items: PanelComponent[]; pages: number }>(
-      `${endpoint}?${params.toString()}`,
-      signal
-    );
-    items.push(...data.items);
-    pages = data.pages;
-    page += 1;
-  } while (page <= pages && items.length < maxItems && !signal?.aborted);
-  return items.slice(0, maxItems);
+  query: PanelPageQuery = {},
+): Promise<PanelPageResult> {
+  const page = query.page ?? 1;
+  const pageSize = normalizePanelPageSize(query.pageSize ?? PANEL_PAGE_SIZE);
+  params.set("page", String(page));
+  params.set("page_size", String(pageSize));
+  const data = await panelFetch<Partial<PanelPageResult>>(
+    `${endpoint}?${params.toString()}`,
+    query.signal,
+  );
+  return asPageResult(data, page, pageSize);
 }
 
 export async function searchComponents(
   query: string,
-  signal?: AbortSignal
-): Promise<PanelComponent[]> {
+  pageQuery: PanelPageQuery = {},
+): Promise<PanelPageResult> {
   const params = new URLSearchParams();
   if (query) params.set("q", query);
-  return fetchComponentPages("/api/remote-provider/search", params, 50, 50, signal);
+  return fetchComponentPage("/api/remote-provider/search", params, pageQuery);
 }
 
 export async function getCategories(
@@ -180,10 +200,10 @@ export async function getCategories(
 
 export async function getComponentsByCategory(
   category: string,
-  signal?: AbortSignal
-): Promise<PanelComponent[]> {
+  pageQuery: PanelPageQuery = {},
+): Promise<PanelPageResult> {
   const params = new URLSearchParams({ category });
-  return fetchComponentPages("/api/remote-provider/components-by-category", params, 200, 500, signal);
+  return fetchComponentPage("/api/remote-provider/components-by-category", params, pageQuery);
 }
 
 export async function getComponent(

--- a/frontend/src/panel/lib/panel-page.test.ts
+++ b/frontend/src/panel/lib/panel-page.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import type { PanelComponent } from "./panel-api";
+import {
+  appendUniquePageItems,
+  formatPanelLoadedCount,
+  normalizePanelPageSize,
+  PANEL_PAGE_SIZE,
+  REMOTE_MAX_PAGE_SIZE,
+} from "./panel-page";
+
+function item(id: string): PanelComponent {
+  return { id } as PanelComponent;
+}
+
+describe("normalizePanelPageSize", () => {
+  it("keeps the default page size and clamps to the server maximum", () => {
+    expect(normalizePanelPageSize()).toBe(PANEL_PAGE_SIZE);
+    expect(normalizePanelPageSize(0)).toBe(1);
+    expect(normalizePanelPageSize(500)).toBe(REMOTE_MAX_PAGE_SIZE);
+  });
+});
+
+describe("formatPanelLoadedCount", () => {
+  it("distinguishes a known total from an unknown remaining page", () => {
+    expect(formatPanelLoadedCount(50, 501, true)).toBe("50 of 501 parts");
+    expect(formatPanelLoadedCount(1, 1, false)).toBe("1 of 1 part");
+    expect(formatPanelLoadedCount(50, null, true, "result")).toBe("50 results loaded");
+    expect(formatPanelLoadedCount(12, null, false, "result")).toBe("12 results");
+  });
+});
+
+describe("appendUniquePageItems", () => {
+  it("appends unseen ids and ignores duplicates from a shifted page", () => {
+    expect(appendUniquePageItems([item("a")], [item("a"), item("b")])).toEqual([
+      item("a"),
+      item("b"),
+    ]);
+  });
+});

--- a/frontend/src/panel/lib/panel-page.ts
+++ b/frontend/src/panel/lib/panel-page.ts
@@ -1,0 +1,44 @@
+import type { PanelComponent } from "@/panel/lib/panel-api";
+
+/** Client page size. Must stay at or below the remote-provider maximum of 200. */
+export const PANEL_PAGE_SIZE = 50;
+export const REMOTE_MAX_PAGE_SIZE = 200;
+
+export function normalizePanelPageSize(pageSize = PANEL_PAGE_SIZE): number {
+  return Math.min(Math.max(1, pageSize), REMOTE_MAX_PAGE_SIZE);
+}
+
+export function formatPanelLoadedCount(
+  loaded: number,
+  total: number | null,
+  hasMore: boolean,
+  noun = "part",
+): string {
+  const pluralNoun = (count: number) => (count === 1 ? noun : `${noun}s`);
+  if (total != null) {
+    return `${loaded} of ${total} ${pluralNoun(total)}`;
+  }
+  if (hasMore) {
+    return `${loaded} ${pluralNoun(loaded)} loaded`;
+  }
+  return `${loaded} ${pluralNoun(loaded)}`;
+}
+
+export function appendUniquePageItems(
+  existing: PanelComponent[],
+  incoming: PanelComponent[],
+): PanelComponent[] {
+  if (incoming.length === 0) {
+    return existing;
+  }
+  const seen = new Set(existing.map((item) => item.id));
+  const appended: PanelComponent[] = [];
+  for (const item of incoming) {
+    if (seen.has(item.id)) {
+      continue;
+    }
+    seen.add(item.id);
+    appended.push(item);
+  }
+  return appended.length === 0 ? existing : existing.concat(appended);
+}

--- a/frontend/src/panel/lib/view-state.ts
+++ b/frontend/src/panel/lib/view-state.ts
@@ -1,6 +1,33 @@
 import type { PanelComponent } from "@/panel/lib/panel-api";
 
+export type PagedComponentList = {
+  items: PanelComponent[];
+  page: number;
+  hasMore: boolean;
+  total: number | null;
+};
+
 export type FinderViewState = {
   query: string;
-  searchResults: PanelComponent[];
+  fetchedQuery: string;
+  search: PagedComponentList;
 };
+
+export type CategoryBrowseState = {
+  name: string;
+} & PagedComponentList;
+
+export function emptyPagedList(total: number | null = null): PagedComponentList {
+  return { items: [], page: 0, hasMore: false, total };
+}
+
+export function emptyFinderView(): FinderViewState {
+  return { query: "", fetchedQuery: "", search: emptyPagedList() };
+}
+
+export function emptyCategoryBrowse(
+  name: string,
+  total: number | null = null,
+): CategoryBrowseState {
+  return { name, ...emptyPagedList(total) };
+}

--- a/frontend/src/panel/screens/CategoryListScreen.tsx
+++ b/frontend/src/panel/screens/CategoryListScreen.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { ArrowLeft, ChevronRight } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { ArrowLeft, ChevronRight, Loader2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,9 +8,13 @@ import { inventoryWarnings } from "@/lib/inventory-presentation";
 
 import type { PanelComponent } from "@/panel/lib/panel-api";
 import { getComponentsByCategory, isAuthError, primaryLocalSource } from "@/panel/lib/panel-api";
+import { appendUniquePageItems, formatPanelLoadedCount } from "@/panel/lib/panel-page";
+import type { CategoryBrowseState } from "@/panel/lib/view-state";
 
 interface CategoryListScreenProps {
   category: string;
+  viewState: CategoryBrowseState;
+  onViewStateChange: React.Dispatch<React.SetStateAction<CategoryBrowseState>>;
   onBack: () => void;
   onSelectComponent: (component: PanelComponent) => void;
   onAuthRequired: () => void;
@@ -19,23 +23,38 @@ interface CategoryListScreenProps {
 
 export function CategoryListScreen({
   category,
+  viewState,
+  onViewStateChange,
   onBack,
   onSelectComponent,
   onAuthRequired,
   appendLog,
 }: CategoryListScreenProps) {
-  const [components, setComponents] = useState<PanelComponent[]>([]);
-  const [loading, setLoading] = useState(true);
+  const restored = viewState.name === category && viewState.page > 0;
+  const [loading, setLoading] = useState(!restored);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadMoreAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
+    if (viewState.name === category && viewState.page > 0) {
+      setLoading(false);
+      return;
+    }
+
     const controller = new AbortController();
-    getComponentsByCategory(category, controller.signal)
-      .then((items) => {
-        if (!controller.signal.aborted) {
-          setComponents(items);
-          setLoading(false);
-          appendLog(`Loaded ${items.length} parts in "${category}"`);
-        }
+    setLoading(true);
+    getComponentsByCategory(category, { page: 1, signal: controller.signal })
+      .then((page) => {
+        if (controller.signal.aborted) return;
+        onViewStateChange((prev) => ({
+          name: category,
+          items: page.items,
+          page: page.page,
+          hasMore: page.has_more,
+          total: page.total ?? (prev.name === category ? prev.total : null),
+        }));
+        setLoading(false);
+        appendLog(`Loaded ${page.items.length} parts in "${category}"`);
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
@@ -47,7 +66,41 @@ export function CategoryListScreen({
         setLoading(false);
       });
     return () => controller.abort();
-  }, [category, appendLog, onAuthRequired]);
+  }, [category, viewState.name, viewState.page, appendLog, onAuthRequired, onViewStateChange]);
+
+  useEffect(() => () => loadMoreAbortRef.current?.abort(), []);
+
+  const loadMore = () => {
+    if (!viewState.hasMore || loadingMore) return;
+    loadMoreAbortRef.current?.abort();
+    const controller = new AbortController();
+    loadMoreAbortRef.current = controller;
+    setLoadingMore(true);
+    getComponentsByCategory(category, { page: viewState.page + 1, signal: controller.signal })
+      .then((page) => {
+        if (controller.signal.aborted) return;
+        onViewStateChange((prev) => ({
+          name: category,
+          items: appendUniquePageItems(prev.name === category ? prev.items : [], page.items),
+          page: page.page,
+          hasMore: page.has_more,
+          total: page.total ?? (prev.name === category ? prev.total : null),
+        }));
+        setLoadingMore(false);
+        appendLog(`Loaded ${page.items.length} more parts in "${category}"`);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        if (isAuthError(err)) {
+          onAuthRequired();
+          return;
+        }
+        appendLog(`Failed to load more: ${(err as Error).message}`);
+        setLoadingMore(false);
+      });
+  };
+
+  const components = viewState.name === category ? viewState.items : [];
 
   return (
     <div className="flex flex-col gap-2">
@@ -58,6 +111,7 @@ export function CategoryListScreen({
           size="icon-xs"
           onClick={onBack}
           className="shrink-0"
+          aria-label="Back to categories"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
         </Button>
@@ -65,7 +119,7 @@ export function CategoryListScreen({
           <h2 className="truncate text-sm font-semibold">{category || "Uncategorized"}</h2>
           {!loading && (
             <p className="text-[10px] text-muted-foreground">
-              {components.length} part{components.length !== 1 ? "s" : ""}
+              {formatPanelLoadedCount(components.length, viewState.total, viewState.hasMore)}
             </p>
           )}
         </div>
@@ -110,6 +164,17 @@ export function CategoryListScreen({
             </button>
             );
           })}
+          {viewState.hasMore && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mt-1 w-full"
+              disabled={loadingMore}
+              onClick={loadMore}
+            >
+              {loadingMore ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Load more"}
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/panel/screens/SymbolFinderScreen.tsx
+++ b/frontend/src/panel/screens/SymbolFinderScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronRight, Loader2, Search } from "lucide-react";
+import { ChevronRight, CircleAlert, Loader2, RefreshCw, Search } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -60,9 +60,39 @@ export function SymbolFinderScreen({
   const [loadingCategories, setLoadingCategories] = useState(true);
   const [searching, setSearching] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const searchAbortRef = useRef<AbortController | null>(null);
   const loadMoreAbortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const runFirstPage = useCallback((trimmed: string, signal: AbortSignal) => {
+    searchComponents(trimmed, { page: 1, signal })
+      .then((page) => {
+        if (signal.aborted) return;
+        setSearchError(null);
+        onViewStateChange((prev) => ({
+          ...prev,
+          fetchedQuery: trimmed,
+          search: {
+            items: page.items,
+            page: page.page,
+            hasMore: page.has_more,
+            total: page.total,
+          },
+        }));
+        setSearching(false);
+      })
+      .catch((err) => {
+        if (signal.aborted) return;
+        if (isAuthError(err)) {
+          onAuthRequired();
+          return;
+        }
+        appendLog(`Search failed: ${(err as Error).message}`);
+        setSearchError((err as Error).message);
+        setSearching(false);
+      });
+  }, [appendLog, onAuthRequired, onViewStateChange]);
 
   // Load categories on mount
   useEffect(() => {
@@ -96,6 +126,7 @@ export function SymbolFinderScreen({
     const trimmed = query.trim();
     if (!trimmed) {
       setSearching(false);
+      setSearchError(null);
       onViewStateChange((prev) => {
         if (prev.fetchedQuery === "" && prev.search.page === 0 && prev.search.items.length === 0) {
           return prev;
@@ -107,53 +138,37 @@ export function SymbolFinderScreen({
 
     if (trimmed === fetchedQuery) {
       setSearching(false);
+      setSearchError(null);
       return;
     }
 
     setSearching(true);
+    setSearchError(null);
     debounceRef.current = setTimeout(() => {
       if (searchAbortRef.current) searchAbortRef.current.abort();
       const controller = new AbortController();
       searchAbortRef.current = controller;
-
-      searchComponents(trimmed, { page: 1, signal: controller.signal })
-        .then((page) => {
-          if (controller.signal.aborted) return;
-          onViewStateChange((prev) => ({
-            ...prev,
-            fetchedQuery: trimmed,
-            search: {
-              items: page.items,
-              page: page.page,
-              hasMore: page.has_more,
-              total: page.total,
-            },
-          }));
-          setSearching(false);
-        })
-        .catch((err) => {
-          if (controller.signal.aborted) return;
-          if (isAuthError(err)) {
-            onAuthRequired();
-            return;
-          }
-          appendLog(`Search failed: ${(err as Error).message}`);
-          onViewStateChange((prev) => ({
-            ...prev,
-            fetchedQuery: trimmed,
-            search: emptyPagedList(),
-          }));
-          setSearching(false);
-        });
+      runFirstPage(trimmed, controller.signal);
     }, 150);
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
       searchAbortRef.current?.abort();
     };
-  }, [query, fetchedQuery, appendLog, onAuthRequired, onViewStateChange]);
+  }, [query, fetchedQuery, runFirstPage, onViewStateChange]);
 
   useEffect(() => () => loadMoreAbortRef.current?.abort(), []);
+
+  const retrySearch = () => {
+    const trimmed = query.trim();
+    if (!trimmed || searching) return;
+    searchAbortRef.current?.abort();
+    const controller = new AbortController();
+    searchAbortRef.current = controller;
+    setSearching(true);
+    setSearchError(null);
+    runFirstPage(trimmed, controller.signal);
+  };
 
   const loadMore = () => {
     const trimmed = query.trim();
@@ -256,6 +271,8 @@ export function SymbolFinderScreen({
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Searching…
             </div>
+          ) : searchError ? (
+            <SearchErrorState message={searchError} onRetry={retrySearch} />
           ) : search.items.length === 0 ? (
             <div className="rounded border border-dashed border-border/50 px-3 py-6 text-center text-xs text-muted-foreground">
               No matching components found.
@@ -305,6 +322,19 @@ export function SymbolFinderScreen({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function SearchErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="rounded border border-destructive bg-destructive/10 px-3 py-6 text-center">
+      <CircleAlert className="mx-auto h-4 w-4 text-destructive" />
+      <p className="mt-2 text-xs font-medium">Search failed</p>
+      <p className="mt-1 text-[10px] text-muted-foreground">{message}</p>
+      <Button className="mt-3" size="sm" variant="outline" onClick={onRetry}>
+        <RefreshCw className="h-3 w-3" /> Retry
+      </Button>
     </div>
   );
 }

--- a/frontend/src/panel/screens/SymbolFinderScreen.tsx
+++ b/frontend/src/panel/screens/SymbolFinderScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ChevronRight, Loader2, Search } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { inventoryWarnings } from "@/lib/inventory-presentation";
@@ -13,13 +14,14 @@ import {
   isAuthError,
   primaryLocalSource,
 } from "@/panel/lib/panel-api";
+import { appendUniquePageItems, formatPanelLoadedCount } from "@/panel/lib/panel-page";
 
-import type { FinderViewState } from "@/panel/lib/view-state";
+import { emptyPagedList, type FinderViewState } from "@/panel/lib/view-state";
 
 interface SymbolFinderScreenProps {
   viewState: FinderViewState;
   onViewStateChange: React.Dispatch<React.SetStateAction<FinderViewState>>;
-  onSelectCategory: (category: string) => void;
+  onSelectCategory: (category: string, total?: number | null) => void;
   onSelectComponent: (component: PanelComponent) => void;
   onAuthRequired: () => void;
   appendLog: (msg: string) => void;
@@ -49,20 +51,17 @@ export function SymbolFinderScreen({
   onAuthRequired,
   appendLog,
 }: SymbolFinderScreenProps) {
-  const { query, searchResults } = viewState;
+  const { query, fetchedQuery, search } = viewState;
   const setQuery = useCallback(
     (value: string) => onViewStateChange((prev) => ({ ...prev, query: value })),
-    [onViewStateChange],
-  );
-  const setSearchResults = useCallback(
-    (items: PanelComponent[]) =>
-      onViewStateChange((prev) => ({ ...prev, searchResults: items })),
     [onViewStateChange],
   );
   const [categories, setCategories] = useState<PanelCategory[]>([]);
   const [loadingCategories, setLoadingCategories] = useState(true);
   const [searching, setSearching] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const searchAbortRef = useRef<AbortController | null>(null);
+  const loadMoreAbortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Load categories on mount
@@ -88,13 +87,25 @@ export function SymbolFinderScreen({
     return () => controller.abort();
   }, [appendLog, onAuthRequired]);
 
-  // Debounced search
+  // Debounced first-page search. Remounts keep an already-fetched query.
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    loadMoreAbortRef.current?.abort();
+    setLoadingMore(false);
 
     const trimmed = query.trim();
     if (!trimmed) {
-      setSearchResults([]);
+      setSearching(false);
+      onViewStateChange((prev) => {
+        if (prev.fetchedQuery === "" && prev.search.page === 0 && prev.search.items.length === 0) {
+          return prev;
+        }
+        return { ...prev, fetchedQuery: "", search: emptyPagedList() };
+      });
+      return;
+    }
+
+    if (trimmed === fetchedQuery) {
       setSearching(false);
       return;
     }
@@ -105,10 +116,19 @@ export function SymbolFinderScreen({
       const controller = new AbortController();
       searchAbortRef.current = controller;
 
-      searchComponents(trimmed, controller.signal)
-        .then((items) => {
+      searchComponents(trimmed, { page: 1, signal: controller.signal })
+        .then((page) => {
           if (controller.signal.aborted) return;
-          setSearchResults(items);
+          onViewStateChange((prev) => ({
+            ...prev,
+            fetchedQuery: trimmed,
+            search: {
+              items: page.items,
+              page: page.page,
+              hasMore: page.has_more,
+              total: page.total,
+            },
+          }));
           setSearching(false);
         })
         .catch((err) => {
@@ -118,14 +138,54 @@ export function SymbolFinderScreen({
             return;
           }
           appendLog(`Search failed: ${(err as Error).message}`);
+          onViewStateChange((prev) => ({
+            ...prev,
+            fetchedQuery: trimmed,
+            search: emptyPagedList(),
+          }));
           setSearching(false);
         });
     }, 150);
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      searchAbortRef.current?.abort();
     };
-  }, [query, appendLog, onAuthRequired, setSearchResults]);
+  }, [query, fetchedQuery, appendLog, onAuthRequired, onViewStateChange]);
+
+  useEffect(() => () => loadMoreAbortRef.current?.abort(), []);
+
+  const loadMore = () => {
+    const trimmed = query.trim();
+    if (!trimmed || !search.hasMore || loadingMore) return;
+    loadMoreAbortRef.current?.abort();
+    const controller = new AbortController();
+    loadMoreAbortRef.current = controller;
+    setLoadingMore(true);
+    searchComponents(trimmed, { page: search.page + 1, signal: controller.signal })
+      .then((page) => {
+        if (controller.signal.aborted) return;
+        onViewStateChange((prev) => ({
+          ...prev,
+          search: {
+            items: appendUniquePageItems(prev.search.items, page.items),
+            page: page.page,
+            hasMore: page.has_more,
+            total: page.total ?? prev.search.total,
+          },
+        }));
+        setLoadingMore(false);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        if (isAuthError(err)) {
+          onAuthRequired();
+          return;
+        }
+        appendLog(`Search failed: ${(err as Error).message}`);
+        setLoadingMore(false);
+      });
+  };
 
   const isSearching = query.trim().length > 0;
 
@@ -164,7 +224,7 @@ export function SymbolFinderScreen({
             categories.map((cat) => (
               <button
                 key={cat.name}
-                onClick={() => onSelectCategory(cat.name)}
+                onClick={() => onSelectCategory(cat.name, cat.count)}
                 className="group flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-secondary/60"
               >
                 <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded bg-secondary text-xs font-bold text-muted-foreground">
@@ -196,36 +256,52 @@ export function SymbolFinderScreen({
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
               Searching…
             </div>
-          ) : searchResults.length === 0 ? (
+          ) : search.items.length === 0 ? (
             <div className="rounded border border-dashed border-border/50 px-3 py-6 text-center text-xs text-muted-foreground">
               No matching components found.
             </div>
           ) : (
-            searchResults.map((comp) => {
-              const local = primaryLocalSource(comp);
-              return (
-              <button
-                key={comp.id}
-                onClick={() => onSelectComponent(comp)}
-                className="group flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-secondary/60"
-              >
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-xs font-medium text-foreground">
-                    {comp.name}
+            <>
+              <p className="px-1 pb-1 text-[10px] text-muted-foreground">
+                {formatPanelLoadedCount(search.items.length, search.total, search.hasMore, "result")}
+              </p>
+              {search.items.map((comp) => {
+                const local = primaryLocalSource(comp);
+                return (
+                <button
+                  key={comp.id}
+                  onClick={() => onSelectComponent(comp)}
+                  className="group flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-secondary/60"
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-xs font-medium text-foreground">
+                      {comp.name}
+                    </span>
+                    <span className="block truncate text-[10px] text-muted-foreground">
+                      {comp.manufacturer || "Unknown"} · {comp.mpn || "—"} · {comp.package_name || "—"}
+                    </span>
                   </span>
-                  <span className="block truncate text-[10px] text-muted-foreground">
-                    {comp.manufacturer || "Unknown"} · {comp.mpn || "—"} · {comp.package_name || "—"}
-                  </span>
-                </span>
-                <StockDot
-                  quantity={local?.stock ?? 0}
-                  known={local !== null}
-                  warning={inventoryWarnings(local).join(" · ")}
-                />
-                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform group-hover:translate-x-0.5" />
-              </button>
-              );
-            })
+                  <StockDot
+                    quantity={local?.stock ?? 0}
+                    known={local !== null}
+                    warning={inventoryWarnings(local).join(" · ")}
+                  />
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50 transition-transform group-hover:translate-x-0.5" />
+                </button>
+                );
+              })}
+              {search.hasMore && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-1 w-full"
+                  disabled={loadingMore}
+                  onClick={loadMore}
+                >
+                  {loadingMore ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Load more"}
+                </Button>
+              )}
+            </>
           )}
         </div>
       )}

--- a/frontend/src/panel/screens/inventory-display.test.tsx
+++ b/frontend/src/panel/screens/inventory-display.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { useState } from "react";
+
 import { CategoryListScreen } from "./CategoryListScreen";
 import { PartDetailScreen } from "./PartDetailScreen";
 import { inventoryWarnings } from "@/lib/inventory-presentation";
-import { getComponent, getComponentsByCategory, type PanelComponent, type PanelSupplySource } from "@/panel/lib/panel-api";
+import { getComponent, getComponentsByCategory, type PanelComponent, type PanelPageResult, type PanelSupplySource } from "@/panel/lib/panel-api";
+import { emptyCategoryBrowse } from "@/panel/lib/view-state";
 
 vi.mock("@/panel/lib/panel-api", async (importOriginal) => ({
   ...await importOriginal<typeof import("@/panel/lib/panel-api")>(),
@@ -21,6 +24,15 @@ const source = (overrides: Partial<PanelSupplySource> = {}): PanelSupplySource =
   stock_status: "available", fetch_status: "ok", fetched_at: "2026-01-01T00:00:00Z",
   ...overrides,
 });
+const pageOf = (items: PanelComponent[]): PanelPageResult => ({
+  items,
+  total: null,
+  has_more: false,
+  page: 1,
+  pages: null,
+  page_size: 50,
+});
+
 const component = (inventory: PanelSupplySource): PanelComponent => ({
   id: "part", slug: "part", name: "Inventory test", identity_kind: "mpn",
   manufacturer: "Prism", mpn: "P-1", description: "Inventory fixture", package_name: "", category: "Parts",
@@ -30,6 +42,21 @@ const component = (inventory: PanelSupplySource): PanelComponent => ({
   symbol_preview_url: "", footprint_preview_url: "", manifest_url: "", inline_url: "",
   supply: { sources: [inventory] },
 });
+
+function CategoryHarness() {
+  const [view, setView] = useState(emptyCategoryBrowse("Parts"));
+  return (
+    <CategoryListScreen
+      category="Parts"
+      viewState={view}
+      onViewStateChange={setView}
+      onBack={noop}
+      onSelectComponent={noop}
+      onAuthRequired={noop}
+      appendLog={noop}
+    />
+  );
+}
 
 describe("inventory presentation", () => {
   it("preserves all uncertainty reasons including unknown fetch failures", () => {
@@ -44,9 +71,8 @@ describe("inventory presentation", () => {
     ["Mixed units", { mixed_units: true }],
     ["Mixed status", { mixed_status: true }],
   ] as const)("category stock does not turn green for %s", async (warning, overrides) => {
-    vi.mocked(getComponentsByCategory).mockResolvedValue([component(source(overrides))]);
-    render(<CategoryListScreen category="Parts" onBack={noop} onSelectComponent={noop}
-      onAuthRequired={noop} appendLog={noop} />);
+    vi.mocked(getComponentsByCategory).mockResolvedValue(pageOf([component(source(overrides))]));
+    render(<CategoryHarness />);
     const badge = await screen.findByTitle(warning);
     expect(badge.className).not.toContain("emerald");
     expect(badge).not.toHaveTextContent("200");

--- a/frontend/src/panel/screens/panel-pagination.test.tsx
+++ b/frontend/src/panel/screens/panel-pagination.test.tsx
@@ -243,6 +243,30 @@ describe("search pagination", () => {
     expect(searchComponents).not.toHaveBeenCalled();
   });
 
+  it("shows a failed first page as an error and retries the same query", async () => {
+    vi.mocked(getCategories).mockResolvedValue([]);
+    vi.mocked(searchComponents)
+      .mockRejectedValueOnce(new Error("Network error: 502"))
+      .mockResolvedValueOnce(pageOf([component({ id: "op", name: "LM358 op-amp" })]));
+
+    render(<FinderHarness initial={{ ...emptyFinderView(), query: "LM358" }} />);
+
+    expect(await screen.findByText("Search failed")).toBeInTheDocument();
+    expect(screen.getByText("Network error: 502")).toBeInTheDocument();
+    expect(screen.queryByText("No matching components found.")).not.toBeInTheDocument();
+    expect(searchComponents).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(await screen.findByText("LM358 op-amp")).toBeInTheDocument();
+    expect(screen.queryByText("Search failed")).not.toBeInTheDocument();
+    expect(searchComponents).toHaveBeenCalledTimes(2);
+    expect(searchComponents).toHaveBeenNthCalledWith(
+      2,
+      "LM358",
+      expect.objectContaining({ page: 1 }),
+    );
+  });
+
   it("drops a late page from a superseded query", async () => {
     vi.mocked(getCategories).mockResolvedValue([]);
     let resolveOld: ((value: PanelPageResult) => void) | undefined;

--- a/frontend/src/panel/screens/panel-pagination.test.tsx
+++ b/frontend/src/panel/screens/panel-pagination.test.tsx
@@ -1,0 +1,277 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PanelComponent, PanelPageResult } from "@/panel/lib/panel-api";
+import {
+  getCategories,
+  getComponentsByCategory,
+  searchComponents,
+} from "@/panel/lib/panel-api";
+import { emptyCategoryBrowse, emptyFinderView, type FinderViewState } from "@/panel/lib/view-state";
+
+import { CategoryListScreen } from "./CategoryListScreen";
+import { SymbolFinderScreen } from "./SymbolFinderScreen";
+
+vi.mock("@/panel/lib/panel-api", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/panel/lib/panel-api")>(),
+  getCategories: vi.fn(),
+  getComponentsByCategory: vi.fn(),
+  searchComponents: vi.fn(),
+}));
+
+const noop = () => {};
+
+function component(overrides: Partial<PanelComponent> = {}): PanelComponent {
+  return {
+    id: "part",
+    slug: "part",
+    name: "Inventory test",
+    identity_kind: "mpn",
+    manufacturer: "Prism",
+    mpn: "P-1",
+    description: "Pagination fixture",
+    package_name: "",
+    category: "Parts",
+    datasheet_url: "",
+    summary: "",
+    version: "1",
+    library_name: "",
+    symbol_name: "",
+    representations: [],
+    assets: [],
+    missing_assets: [],
+    availability_state: "metadata_only",
+    place_enabled: false,
+    default_representation_id: "",
+    effective_representation_id: "",
+    preview_status: {},
+    symbol_preview_url: "",
+    footprint_preview_url: "",
+    manifest_url: "",
+    inline_url: "",
+    ...overrides,
+  };
+}
+
+function pageOf(
+  items: PanelComponent[],
+  overrides: Partial<PanelPageResult> = {},
+): PanelPageResult {
+  return {
+    items,
+    total: null,
+    has_more: false,
+    page: 1,
+    pages: null,
+    page_size: 50,
+    ...overrides,
+  };
+}
+
+function CategoryHarness({
+  total = 501,
+  initial = emptyCategoryBrowse("Parts", total),
+}: {
+  total?: number | null;
+  initial?: ReturnType<typeof emptyCategoryBrowse>;
+}) {
+  const [view, setView] = useState(initial);
+  return (
+    <CategoryListScreen
+      category="Parts"
+      viewState={view}
+      onViewStateChange={setView}
+      onBack={noop}
+      onSelectComponent={noop}
+      onAuthRequired={noop}
+      appendLog={noop}
+    />
+  );
+}
+
+function FinderHarness({ initial = emptyFinderView() }: { initial?: FinderViewState }) {
+  const [view, setView] = useState(initial);
+  return (
+    <SymbolFinderScreen
+      viewState={view}
+      onViewStateChange={setView}
+      onSelectCategory={noop}
+      onSelectComponent={noop}
+      onAuthRequired={noop}
+      appendLog={noop}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(getCategories).mockReset();
+  vi.mocked(getComponentsByCategory).mockReset();
+  vi.mocked(searchComponents).mockReset();
+});
+
+describe("category pagination", () => {
+  it("loads one page, then appends the next without walking the catalog", async () => {
+    vi.mocked(getComponentsByCategory)
+      .mockResolvedValueOnce(pageOf([component({ id: "a", name: "First part" })], {
+        has_more: true,
+        total: null,
+      }))
+      .mockResolvedValueOnce(pageOf([component({ id: "b", name: "Last part" })], {
+        page: 2,
+        has_more: false,
+        total: null,
+      }));
+
+    render(<CategoryHarness />);
+
+    expect(await screen.findByText("First part")).toBeInTheDocument();
+    expect(screen.getByText("1 of 501 parts")).toBeInTheDocument();
+    expect(getComponentsByCategory).toHaveBeenCalledTimes(1);
+    expect(getComponentsByCategory).toHaveBeenNthCalledWith(
+      1,
+      "Parts",
+      expect.objectContaining({ page: 1 }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+    expect(await screen.findByText("Last part")).toBeInTheDocument();
+    expect(screen.getByText("2 of 501 parts")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+    expect(getComponentsByCategory).toHaveBeenCalledTimes(2);
+    expect(getComponentsByCategory).toHaveBeenNthCalledWith(
+      2,
+      "Parts",
+      expect.objectContaining({ page: 2 }),
+    );
+  });
+
+  it("keeps a restored category page without refetching", async () => {
+    render(
+      <CategoryHarness
+        initial={{
+          name: "Parts",
+          items: [component({ id: "kept", name: "Kept part" })],
+          page: 3,
+          hasMore: true,
+          total: 501,
+        }}
+      />,
+    );
+
+    expect(await screen.findByText("Kept part")).toBeInTheDocument();
+    expect(screen.getByText("1 of 501 parts")).toBeInTheDocument();
+    expect(getComponentsByCategory).not.toHaveBeenCalled();
+  });
+
+  it("ignores a cancelled first page", async () => {
+    let resolvePage: ((value: PanelPageResult) => void) | undefined;
+    vi.mocked(getComponentsByCategory).mockImplementation((_category, query) =>
+      new Promise((resolve, reject) => {
+        query?.signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("Aborted"), { name: "AbortError" }));
+        });
+        resolvePage = resolve;
+      }),
+    );
+
+    const { unmount } = render(<CategoryHarness total={null} />);
+    await waitFor(() => expect(getComponentsByCategory).toHaveBeenCalled());
+    unmount();
+    await act(async () => {
+      resolvePage?.(pageOf([component({ id: "stale", name: "Stale part" })], { has_more: true }));
+    });
+
+    expect(screen.queryByText("Stale part")).not.toBeInTheDocument();
+  });
+});
+
+describe("search pagination", () => {
+  it("searches one page and can continue through later matches", async () => {
+    vi.mocked(getCategories).mockResolvedValue([]);
+    vi.mocked(searchComponents)
+      .mockResolvedValueOnce(pageOf([component({ id: "a", name: "First match" })], {
+        has_more: true,
+      }))
+      .mockResolvedValueOnce(pageOf([component({ id: "b", name: "Last match" })], {
+        page: 2,
+        has_more: false,
+      }));
+
+    render(<FinderHarness initial={{ ...emptyFinderView(), query: "res" }} />);
+
+    expect(await screen.findByText("First match")).toBeInTheDocument();
+    expect(screen.getByText("1 result loaded")).toBeInTheDocument();
+    expect(searchComponents).toHaveBeenCalledTimes(1);
+    expect(searchComponents).toHaveBeenNthCalledWith(
+      1,
+      "res",
+      expect.objectContaining({ page: 1 }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+    expect(await screen.findByText("Last match")).toBeInTheDocument();
+    expect(screen.getByText("2 results")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+    expect(searchComponents).toHaveBeenNthCalledWith(
+      2,
+      "res",
+      expect.objectContaining({ page: 2 }),
+    );
+  });
+
+  it("does not refetch a search that is already in the preserved view", async () => {
+    vi.mocked(getCategories).mockResolvedValue([]);
+
+    render(
+      <FinderHarness
+        initial={{
+          query: "res",
+          fetchedQuery: "res",
+          search: {
+            items: [component({ id: "kept", name: "Kept match" })],
+            page: 2,
+            hasMore: true,
+            total: null,
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByText("Kept match")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument();
+    expect(searchComponents).not.toHaveBeenCalled();
+  });
+
+  it("drops a late page from a superseded query", async () => {
+    vi.mocked(getCategories).mockResolvedValue([]);
+    let resolveOld: ((value: PanelPageResult) => void) | undefined;
+    vi.mocked(searchComponents).mockImplementation((query, pageQuery) => {
+      if (query === "old") {
+        return new Promise((resolve, reject) => {
+          pageQuery?.signal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("Aborted"), { name: "AbortError" }));
+          });
+          resolveOld = resolve;
+        });
+      }
+      return Promise.resolve(pageOf([component({ id: "new", name: "New match" })]));
+    });
+
+    render(<FinderHarness initial={{ ...emptyFinderView(), query: "old" }} />);
+    await waitFor(() => expect(searchComponents).toHaveBeenCalledWith(
+      "old",
+      expect.objectContaining({ page: 1 }),
+    ));
+
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "new" } });
+    expect(await screen.findByText("New match")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveOld?.(pageOf([component({ id: "stale", name: "Stale match" })], { has_more: true }));
+    });
+
+    expect(screen.queryByText("Stale match")).not.toBeInTheDocument();
+    expect(screen.getByText("New match")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Return a typed page from panel search and category fetches instead of walking pages and discarding `has_more` / `total`.
- Add Load more, show loaded count separately from category total (and support `total=null`), and keep search/category pages when returning from part detail.
- Keep the server page-size cap (client 50, clamp 200) and abort in-flight pages on query change or unmount so the panel never eager-loads the catalog.

## Test plan
- [ ] Search with 51+ matches: first page, then Load more through the last result
- [ ] Category with 501+ parts: header shows loaded of total, then Load more through the last result
- [ ] Open a part and go back: search query/results and category pages are still there
- [ ] Change the search query while a page is in flight: the stale page does not replace the new results