### PR TITLE
Make the KiCad panel bridge session-scoped and lifecycle-safe

### DIFF
--- a/frontend/src/panel/PanelApp.tsx
+++ b/frontend/src/panel/PanelApp.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { LogTerminal } from "@/panel/components/LogTerminal";
 import {
   installBridge,
+  uninstallBridge,
   waitForSession,
   getSourceInfo,
   triggerRemoteLogin,
@@ -82,11 +83,12 @@ export function PanelApp() {
 
     setLogCallback(appendLog);
     installBridge();
+    const sessionWait = new AbortController();
 
     (async () => {
       try {
         // 1. Start waiting for KiCad session in background
-        waitForSession().then(async () => {
+        waitForSession({ signal: sessionWait.signal }).then(async () => {
           setSessionReady(true);
           appendLog("KiCad session ready.");
           try {
@@ -106,6 +108,7 @@ export function PanelApp() {
             appendLog(`Source info error: ${(e as Error).message}`);
           }
         }).catch((err) => {
+          if ((err as Error).name === "AbortError") return;
           appendLog(`KiCad init error: ${(err as Error).message}`);
         });
 
@@ -115,6 +118,11 @@ export function PanelApp() {
         appendLog(`Init error: ${(err as Error).message}`);
       }
     })();
+
+    return () => {
+      sessionWait.abort();
+      uninstallBridge();
+    };
   }, [appendLog, testAuthAndRoute]);
 
   // ─── Login handler ──────────────────────────────────────────────

--- a/frontend/src/panel/lib/kicad-bridge.test.ts
+++ b/frontend/src/panel/lib/kicad-bridge.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createKiCadBridge, type KiCadBridge, type KiCadResponse } from "./kicad-bridge";
+
+type Posted = Record<string, unknown>;
+
+function trackingClock() {
+  const live = new Set<number>();
+  return {
+    live,
+    setTimeout(fn: () => void, ms: number) {
+      const id = window.setTimeout(() => {
+        live.delete(id);
+        fn();
+      }, ms) as unknown as number;
+      live.add(id);
+      return id;
+    },
+    clearTimeout(id: number) {
+      live.delete(id);
+      window.clearTimeout(id);
+    },
+  };
+}
+
+function openSession(instance: KiCadBridge, sessionId = "session-1", messageId = 1) {
+  instance.handleIncoming({ command: "NEW_SESSION", session_id: sessionId, message_id: messageId });
+}
+
+describe("KiCadBridge", () => {
+  const instances: KiCadBridge[] = [];
+
+  function makeBridge(options: Parameters<typeof createKiCadBridge>[0] = {}): KiCadBridge {
+    const instance = createKiCadBridge({ log: () => {}, ...options });
+    instances.push(instance);
+    return instance;
+  }
+
+  afterEach(() => {
+    for (const instance of instances.splice(0)) {
+      instance.dispose();
+    }
+    vi.useRealTimers();
+    const w = window as unknown as { kiclient?: { postMessage?: unknown; _msgBacklog?: unknown[] } };
+    delete w.kiclient;
+  });
+
+  it("resolves a command when the transport replies synchronously", async () => {
+    const posted: Posted[] = [];
+    const clock = trackingClock();
+    const instance = makeBridge({
+      clock,
+      transport: {
+        post(payload) {
+          const envelope = JSON.parse(payload) as Posted;
+          posted.push(envelope);
+          if (envelope.command !== "NEW_SESSION") {
+            instance.handleIncoming({
+              response_to: envelope.message_id,
+              session_id: envelope.session_id,
+              status: "OK",
+              command: envelope.command,
+            });
+          }
+          return true;
+        },
+      },
+    });
+
+    openSession(instance);
+    await expect(instance.send("GET_SOURCE_INFO")).resolves.toMatchObject({
+      command: "GET_SOURCE_INFO",
+      status: "OK",
+    });
+    expect(posted.some((item) => item.command === "GET_SOURCE_INFO")).toBe(true);
+    expect(clock.live.size).toBe(0);
+  });
+
+  it("rejects pending work on session reset and ignores a stale reply", async () => {
+    const posted: Posted[] = [];
+    const clock = trackingClock();
+    const instance = makeBridge({
+      clock,
+      transport: {
+        post(payload) {
+          posted.push(JSON.parse(payload) as Posted);
+          return true;
+        },
+      },
+    });
+    openSession(instance, "session-a");
+    const pending = instance.send("PLACE_COMPONENT");
+    openSession(instance, "session-b", 10);
+    await expect(pending).rejects.toThrow("Session reset");
+    expect(clock.live.size).toBe(0);
+
+    const next = instance.send("GET_SOURCE_INFO");
+    const request = posted.find((item) => item.command === "GET_SOURCE_INFO");
+    instance.handleIncoming({
+      response_to: request?.message_id,
+      session_id: "session-a",
+      status: "OK",
+      command: "GET_SOURCE_INFO",
+    });
+    expect(clock.live.size).toBe(1);
+    instance.handleIncoming({
+      response_to: request?.message_id,
+      session_id: "session-b",
+      status: "OK",
+      command: "GET_SOURCE_INFO",
+    });
+    await expect(next).resolves.toMatchObject({ session_id: "session-b" });
+    expect(clock.live.size).toBe(0);
+  });
+
+  it("rejects immediately when the transport is unavailable", async () => {
+    const clock = trackingClock();
+    const instance = makeBridge({
+      clock,
+      transport: { post: () => false },
+    });
+    openSession(instance);
+    await expect(instance.send("GET_SOURCE_INFO")).rejects.toThrow("KiCad transport is unavailable.");
+    expect(clock.live.size).toBe(0);
+  });
+
+  it("times out a missing reply once and ignores a late response", async () => {
+    vi.useFakeTimers();
+    const clock = trackingClock();
+    const instance = makeBridge({
+      clock,
+      transport: { post: () => true },
+    });
+    openSession(instance);
+    const pending = instance.send("GET_SOURCE_INFO", {}, "", 4000);
+    const timedOut = expect(pending).rejects.toThrow("Response timeout");
+    await vi.advanceTimersByTimeAsync(4000);
+    await timedOut;
+    expect(clock.live.size).toBe(0);
+
+    instance.handleIncoming({
+      response_to: 3,
+      session_id: "session-1",
+      status: "OK",
+      command: "GET_SOURCE_INFO",
+    });
+    expect(clock.live.size).toBe(0);
+  });
+
+  it("installs once and drains the backlog without chaining handlers", () => {
+    const replies: Posted[] = [];
+    const instance = makeBridge({
+      transport: {
+        post(payload) {
+          replies.push(JSON.parse(payload) as Posted);
+          return true;
+        },
+      },
+    });
+    const w = window as unknown as { kiclient: { postMessage: (msg: unknown) => void; _msgBacklog: unknown[] } };
+    w.kiclient = {
+      _msgBacklog: [{ command: "NEW_SESSION", session_id: "session-1", message_id: 1 }],
+      postMessage(msg) {
+        w.kiclient._msgBacklog.push(msg);
+      },
+    };
+
+    instance.install();
+    instance.install();
+    w.kiclient.postMessage({ command: "NEW_SESSION", session_id: "session-2", message_id: 4 });
+
+    expect(replies).toHaveLength(2);
+    expect(replies.map((item) => item.session_id)).toEqual(["session-1", "session-2"]);
+    expect(w.kiclient._msgBacklog).toEqual([]);
+    expect(instance.hasSession()).toBe(true);
+
+    instance.uninstall();
+    instance.uninstall();
+  });
+
+  it("settles session waits on handshake, timeout, abort, and dispose", async () => {
+    vi.useFakeTimers();
+    const clock = trackingClock();
+    const instance = makeBridge({
+      clock,
+      transport: { post: () => true },
+    });
+
+    const ready = instance.waitForSession();
+    openSession(instance);
+    await expect(ready).resolves.toBe("session-1");
+    expect(clock.live.size).toBe(0);
+
+    const timedOut = expect(
+      makeBridge({ clock, transport: { post: () => true } }).waitForSession({ timeoutMs: 250 }),
+    ).rejects.toThrow("Session timeout");
+    await vi.advanceTimersByTimeAsync(250);
+    await timedOut;
+    expect(clock.live.size).toBe(0);
+
+    const controller = new AbortController();
+    const cancelled = makeBridge({ clock, transport: { post: () => true } }).waitForSession({
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+    expect(clock.live.size).toBe(0);
+
+    const disposable = makeBridge({ clock, transport: { post: () => true } });
+    const pending = disposable.waitForSession({ timeoutMs: 10_000 });
+    disposable.dispose();
+    await expect(pending).rejects.toThrow("Bridge disposed");
+    expect(clock.live.size).toBe(0);
+  });
+
+  it("rejects a command without a session and surfaces RPC errors", async () => {
+    const clock = trackingClock();
+    let lastCommandId = 0;
+    const instance = makeBridge({
+      clock,
+      transport: {
+        post(payload) {
+          const envelope = JSON.parse(payload) as Posted;
+          if (envelope.command !== "NEW_SESSION") {
+            lastCommandId = envelope.message_id as number;
+          }
+          return true;
+        },
+      },
+    });
+    await expect(instance.send("GET_SOURCE_INFO")).rejects.toThrow(
+      "Session has not been established yet.",
+    );
+
+    openSession(instance);
+    const pending = instance.send("REMOTE_LOGIN");
+    instance.handleIncoming({
+      response_to: lastCommandId,
+      session_id: "session-1",
+      status: "ERROR",
+      error_message: "login failed",
+    } satisfies KiCadResponse);
+    await expect(pending).rejects.toThrow("login failed");
+    expect(clock.live.size).toBe(0);
+  });
+});

--- a/frontend/src/panel/lib/kicad-bridge.test.ts
+++ b/frontend/src/panel/lib/kicad-bridge.test.ts
@@ -124,6 +124,23 @@ describe("KiCadBridge", () => {
     expect(clock.live.size).toBe(0);
   });
 
+  it("rejects a throwing transport through the waiter without a second rejection", async () => {
+    const clock = trackingClock();
+    const instance = makeBridge({
+      clock,
+      transport: {
+        post(payload) {
+          const envelope = JSON.parse(payload) as Posted;
+          if (envelope.command === "NEW_SESSION") return true;
+          throw new Error("boom");
+        },
+      },
+    });
+    openSession(instance);
+    await expect(instance.send("GET_SOURCE_INFO")).rejects.toThrow("boom");
+    expect(clock.live.size).toBe(0);
+  });
+
   it("times out a missing reply once and ignores a late response", async () => {
     vi.useFakeTimers();
     const clock = trackingClock();

--- a/frontend/src/panel/lib/kicad-bridge.ts
+++ b/frontend/src/panel/lib/kicad-bridge.ts
@@ -201,7 +201,6 @@ export class KiCadBridge {
       }
     } catch (error) {
       this.rejectWaiter(waiterKey(sessionId, messageId), error as Error);
-      throw error;
     }
     return pending;
   }

--- a/frontend/src/panel/lib/kicad-bridge.ts
+++ b/frontend/src/panel/lib/kicad-bridge.ts
@@ -1,16 +1,27 @@
 /**
  * Typed KiCad RPC bridge.
  *
- * Extracted from the original vanilla-JS app.js and ported to TypeScript.
- * Handles session negotiation, command dispatch, and response routing.
+ * Session-scoped instance: waiters are registered before send, keyed by
+ * session plus message, and settled exactly once on reset, dispose, timeout,
+ * or a matching response.
  */
 
 const RPC_VERSION = 1;
 const BACKOFF_MS = [500, 1200, 2500];
+const DEFAULT_RESPONSE_TIMEOUT_MS = 4000;
 
 type Waiter = {
   resolve: (payload: KiCadResponse) => void;
   reject: (error: Error) => void;
+  timer: number;
+};
+
+type SessionWaiter = {
+  resolve: (sessionId: string) => void;
+  reject: (error: Error) => void;
+  timer: number | null;
+  signal: AbortSignal | null;
+  onAbort: (() => void) | null;
 };
 
 export interface KiCadResponse {
@@ -27,20 +38,40 @@ export interface KiCadResponse {
 
 type LogFn = (message: string) => void;
 
-const RESPONSE_WAITERS = new Map<string, Waiter>();
-let sessionId: string | null = null;
-let messageCounter = 0;
+export type KiCadTransport = {
+  post(payload: string): boolean;
+};
+
+export type BridgeClock = {
+  setTimeout: (fn: () => void, ms: number) => number;
+  clearTimeout: (id: number) => void;
+};
+
+export type WaitForSessionOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export type KiCadBridgeOptions = {
+  transport?: KiCadTransport;
+  clock?: BridgeClock;
+  log?: LogFn;
+};
+
+type KiClient = {
+  postMessage?: (msg: unknown) => void;
+  _msgBacklog?: unknown[];
+};
+
 let logCallback: LogFn = () => {};
 
 export function setLogCallback(fn: LogFn) {
   logCallback = fn;
 }
 
-function appendLog(message: string) {
+function defaultLog(message: string) {
   logCallback(message);
 }
-
-// ─── Transport ────────────────────────────────────────────────────────
 
 function postToKiCad(payload: string): boolean {
   const w = window as unknown as Record<string, unknown>;
@@ -80,114 +111,293 @@ function postToKiCad(payload: string): boolean {
   return false;
 }
 
-// ─── Message Handling ─────────────────────────────────────────────────
+function waiterKey(sessionId: string, messageId: number): string {
+  return `${sessionId}:${messageId}`;
+}
 
-function handleIncomingMessage(incoming: unknown) {
-  let payload: KiCadResponse | null = null;
-  if (typeof incoming === "string") {
-    try {
-      payload = JSON.parse(incoming) as KiCadResponse;
-    } catch (err) {
-      appendLog(`Invalid KiCad response: ${(err as Error).message}`);
+function abortError(message = "Session wait cancelled"): Error {
+  if (typeof DOMException === "function") {
+    return new DOMException(message, "AbortError");
+  }
+  return Object.assign(new Error(message), { name: "AbortError" });
+}
+
+export class KiCadBridge {
+  private readonly transport: KiCadTransport;
+  private readonly clock: BridgeClock;
+  private readonly log: LogFn;
+  private readonly waiters = new Map<string, Waiter>();
+  private readonly sessionWaiters = new Set<SessionWaiter>();
+  private sessionId: string | null = null;
+  private messageCounter = 0;
+  private installed = false;
+  private boundHandler: ((incoming: unknown) => void) | null = null;
+  private previousPost: ((incoming: unknown) => void) | null = null;
+
+  constructor(options: KiCadBridgeOptions = {}) {
+    this.transport = options.transport ?? { post: postToKiCad };
+    this.clock = options.clock ?? {
+      setTimeout: (fn, ms) => window.setTimeout(fn, ms) as unknown as number,
+      clearTimeout: (id) => window.clearTimeout(id),
+    };
+    this.log = options.log ?? defaultLog;
+  }
+
+  hasSession(): boolean {
+    return this.sessionId !== null;
+  }
+
+  handleIncoming(incoming: unknown) {
+    let payload: KiCadResponse | null = null;
+    if (typeof incoming === "string") {
+      try {
+        payload = JSON.parse(incoming) as KiCadResponse;
+      } catch (err) {
+        this.log(`Invalid KiCad response: ${(err as Error).message}`);
+        return;
+      }
+    } else if (typeof incoming === "object" && incoming !== null) {
+      payload = incoming as KiCadResponse;
+    }
+
+    if (!payload) return;
+
+    if (payload.command === "NEW_SESSION" && payload.response_to === undefined) {
+      this.resetSession(payload);
       return;
     }
-  } else if (typeof incoming === "object" && incoming !== null) {
-    payload = incoming as KiCadResponse;
+
+    if (payload.response_to !== undefined) {
+      this.settleResponse(payload);
+      return;
+    }
+
+    this.log(`KiCad -> ${JSON.stringify(payload)}`);
   }
 
-  if (!payload) return;
-
-  // NEW_SESSION from KiCad
-  if (payload.command === "NEW_SESSION" && payload.response_to === undefined) {
-    sessionId = payload.session_id ?? null;
-    messageCounter = payload.message_id ?? 0;
-    RESPONSE_WAITERS.clear();
-    appendLog(`Session established: ${sessionId}`);
-    sendNewSessionResponse(payload);
-    return;
+  async send(
+    command: string,
+    parameters: Record<string, unknown> = {},
+    data = "",
+    timeoutMs = DEFAULT_RESPONSE_TIMEOUT_MS,
+  ): Promise<KiCadResponse> {
+    if (!this.sessionId) {
+      throw new Error("Session has not been established yet.");
+    }
+    const sessionId = this.sessionId;
+    const messageId = ++this.messageCounter;
+    const envelope = {
+      version: RPC_VERSION,
+      session_id: sessionId,
+      message_id: messageId,
+      command,
+      parameters: structuredClone(parameters),
+      data,
+    };
+    const pending = this.registerWaiter(sessionId, messageId, timeoutMs);
+    try {
+      if (!this.transport.post(JSON.stringify(envelope))) {
+        this.rejectWaiter(waiterKey(sessionId, messageId), new Error("KiCad transport is unavailable."));
+      }
+    } catch (error) {
+      this.rejectWaiter(waiterKey(sessionId, messageId), error as Error);
+      throw error;
+    }
+    return pending;
   }
 
-  // Response to a command we sent
-  if (payload.response_to !== undefined) {
-    const waiter = RESPONSE_WAITERS.get(String(payload.response_to));
-    if (waiter) {
-      RESPONSE_WAITERS.delete(String(payload.response_to));
-      if (payload.status === "ERROR") {
-        waiter.reject(new Error(payload.error_message || "KiCad RPC failed"));
+  waitForSession(options: WaitForSessionOptions = {}): Promise<string> {
+    if (this.sessionId) {
+      return Promise.resolve(this.sessionId);
+    }
+    if (options.signal?.aborted) {
+      return Promise.reject(abortError());
+    }
+
+    return new Promise((resolve, reject) => {
+      const waiter: SessionWaiter = {
+        resolve,
+        reject,
+        timer: null,
+        signal: options.signal ?? null,
+        onAbort: null,
+      };
+      waiter.onAbort = () => this.finishSessionWaiter(waiter, () => reject(abortError()));
+      if (waiter.signal) {
+        waiter.signal.addEventListener("abort", waiter.onAbort, { once: true });
+      }
+      if (options.timeoutMs != null) {
+        waiter.timer = this.clock.setTimeout(() => {
+          this.finishSessionWaiter(waiter, () => reject(new Error("Session timeout")));
+        }, options.timeoutMs);
+      }
+      this.sessionWaiters.add(waiter);
+    });
+  }
+
+  install() {
+    if (this.installed) return;
+    const w = window as unknown as { kiclient?: KiClient };
+    const existing: KiClient = w.kiclient || {};
+    this.previousPost = typeof existing.postMessage === "function" ? existing.postMessage : null;
+    this.boundHandler = (incoming: unknown) => this.handleIncoming(incoming);
+    existing.postMessage = this.boundHandler;
+    w.kiclient = existing;
+    this.installed = true;
+
+    const backlog = Array.isArray(existing._msgBacklog) ? existing._msgBacklog.splice(0) : [];
+    for (const msg of backlog) {
+      this.boundHandler(msg);
+    }
+  }
+
+  uninstall() {
+    if (!this.installed) return;
+    const w = window as unknown as { kiclient?: KiClient };
+    const existing = w.kiclient;
+    if (existing && existing.postMessage === this.boundHandler) {
+      if (this.previousPost) {
+        existing.postMessage = this.previousPost;
       } else {
-        waiter.resolve(payload);
+        delete existing.postMessage;
       }
     }
-    return;
+    this.installed = false;
+    this.boundHandler = null;
+    this.previousPost = null;
   }
 
-  appendLog(`KiCad -> ${JSON.stringify(payload)}`);
+  dispose() {
+    this.rejectPending(new Error("Bridge disposed"));
+    this.rejectSessionWaiters(new Error("Bridge disposed"));
+    this.uninstall();
+    this.sessionId = null;
+    this.messageCounter = 0;
+  }
+
+  private resetSession(request: KiCadResponse) {
+    this.rejectPending(new Error("Session reset"));
+    this.sessionId = request.session_id ?? null;
+    this.messageCounter = request.message_id ?? 0;
+    if (this.sessionId) {
+      this.log(`Session established: ${this.sessionId}`);
+      this.resolveSessionWaiters(this.sessionId);
+      this.sendNewSessionResponse(request);
+    }
+  }
+
+  private sendNewSessionResponse(request: KiCadResponse) {
+    if (!this.sessionId) return;
+    const envelope = {
+      version: RPC_VERSION,
+      session_id: this.sessionId,
+      message_id: ++this.messageCounter,
+      response_to: request.message_id,
+      command: "NEW_SESSION",
+      status: "OK",
+      parameters: {
+        server_name: "KiCAD Prism Remote Provider",
+        server_version: "0.1.0",
+      },
+    };
+    this.transport.post(JSON.stringify(envelope));
+  }
+
+  private registerWaiter(sessionId: string, messageId: number, timeoutMs: number): Promise<KiCadResponse> {
+    const key = waiterKey(sessionId, messageId);
+    return new Promise((resolve, reject) => {
+      const waiter: Waiter = {
+        resolve,
+        reject,
+        timer: this.clock.setTimeout(() => {
+          this.rejectWaiter(key, new Error("Response timeout"));
+        }, timeoutMs),
+      };
+      this.waiters.set(key, waiter);
+    });
+  }
+
+  private settleResponse(payload: KiCadResponse) {
+    const responseSession = payload.session_id ?? this.sessionId;
+    if (!this.sessionId || !responseSession || responseSession !== this.sessionId) {
+      this.log(`Ignoring stale KiCad response for session ${payload.session_id ?? "?"}`);
+      return;
+    }
+    const key = waiterKey(responseSession, payload.response_to as number);
+    const waiter = this.takeWaiter(key);
+    if (!waiter) return;
+    if (payload.status === "ERROR") {
+      waiter.reject(new Error(payload.error_message || "KiCad RPC failed"));
+      return;
+    }
+    waiter.resolve(payload);
+  }
+
+  private takeWaiter(key: string): Waiter | null {
+    const waiter = this.waiters.get(key);
+    if (!waiter) return null;
+    this.waiters.delete(key);
+    this.clock.clearTimeout(waiter.timer);
+    return waiter;
+  }
+
+  private rejectWaiter(key: string, error: Error) {
+    const waiter = this.takeWaiter(key);
+    waiter?.reject(error);
+  }
+
+  private rejectPending(error: Error) {
+    for (const key of [...this.waiters.keys()]) {
+      this.rejectWaiter(key, error);
+    }
+  }
+
+  private resolveSessionWaiters(sessionId: string) {
+    for (const waiter of [...this.sessionWaiters]) {
+      this.finishSessionWaiter(waiter, () => waiter.resolve(sessionId));
+    }
+  }
+
+  private rejectSessionWaiters(error: Error) {
+    for (const waiter of [...this.sessionWaiters]) {
+      this.finishSessionWaiter(waiter, () => waiter.reject(error));
+    }
+  }
+
+  private finishSessionWaiter(waiter: SessionWaiter, action: () => void) {
+    if (!this.sessionWaiters.delete(waiter)) return;
+    if (waiter.timer != null) this.clock.clearTimeout(waiter.timer);
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener("abort", waiter.onAbort);
+    }
+    waiter.onAbort = null;
+    action();
+  }
 }
 
-function sendNewSessionResponse(request: KiCadResponse) {
-  if (!sessionId) return;
-  const envelope = {
-    version: RPC_VERSION,
-    session_id: sessionId,
-    message_id: ++messageCounter,
-    response_to: request.message_id,
-    command: "NEW_SESSION",
-    status: "OK",
-    parameters: {
-      server_name: "KiCAD Prism Remote Provider",
-      server_version: "0.1.0",
-    },
-  };
-  postToKiCad(JSON.stringify(envelope));
+let defaultBridge: KiCadBridge | null = null;
+
+function getDefaultBridge(): KiCadBridge {
+  if (!defaultBridge) {
+    defaultBridge = new KiCadBridge();
+  }
+  return defaultBridge;
 }
 
-// ─── Public API ───────────────────────────────────────────────────────
+export function createKiCadBridge(options?: KiCadBridgeOptions): KiCadBridge {
+  return new KiCadBridge(options);
+}
 
 export function hasSession(): boolean {
-  return sessionId !== null;
+  return getDefaultBridge().hasSession();
 }
 
-export function waitForResponse(
-  messageId: number,
-  timeoutMs = 4000
-): Promise<KiCadResponse> {
-  return new Promise((resolve, reject) => {
-    const key = String(messageId);
-    const timer = window.setTimeout(() => {
-      RESPONSE_WAITERS.delete(key);
-      reject(new Error("Response timeout"));
-    }, timeoutMs);
-    RESPONSE_WAITERS.set(key, {
-      resolve(payload) {
-        window.clearTimeout(timer);
-        resolve(payload);
-      },
-      reject(err) {
-        window.clearTimeout(timer);
-        reject(err);
-      },
-    });
-  });
-}
-
-export async function sendRpcCommand(
+export function sendRpcCommand(
   command: string,
   parameters: Record<string, unknown> = {},
-  data = ""
+  data = "",
 ): Promise<KiCadResponse> {
-  if (!sessionId) {
-    throw new Error("Session has not been established yet.");
-  }
-  const envelope = {
-    version: RPC_VERSION,
-    session_id: sessionId,
-    message_id: ++messageCounter,
-    command,
-    parameters: structuredClone(parameters),
-    data,
-  };
-  postToKiCad(JSON.stringify(envelope));
-  return waitForResponse(envelope.message_id);
+  return getDefaultBridge().send(command, parameters, data);
 }
 
 export async function retry<T>(fn: () => Promise<T>): Promise<T> {
@@ -197,7 +407,7 @@ export async function retry<T>(fn: () => Promise<T>): Promise<T> {
       return await fn();
     } catch (error) {
       lastError = error as Error;
-      appendLog(`Attempt ${index + 1} failed: ${lastError.message}`);
+      defaultLog(`Attempt ${index + 1} failed: ${lastError.message}`);
       if (index < BACKOFF_MS.length - 1) {
         await new Promise((r) => window.setTimeout(r, BACKOFF_MS[index]));
       }
@@ -207,32 +417,15 @@ export async function retry<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 export function installBridge() {
-  const w = window as unknown as Record<string, Record<string, unknown>>;
-  const existing = (w.kiclient as Record<string, unknown>) || {};
-  const previousPost =
-    typeof existing.postMessage === "function"
-      ? (existing.postMessage as (msg: unknown) => void)
-      : null;
-  const backlog: unknown[] = Array.isArray(existing._msgBacklog)
-    ? existing._msgBacklog
-    : [];
-
-  existing.postMessage = function (incoming: unknown) {
-    handleIncomingMessage(incoming);
-    if (previousPost) previousPost(incoming);
-  };
-  w.kiclient = existing;
-
-  backlog.forEach((msg) => {
-    (existing.postMessage as (msg: unknown) => void)(msg);
-  });
+  getDefaultBridge().install();
 }
 
-export async function waitForSession(): Promise<string> {
-  while (!sessionId) {
-    await new Promise((r) => window.setTimeout(r, 100));
-  }
-  return sessionId;
+export function uninstallBridge() {
+  getDefaultBridge().uninstall();
+}
+
+export async function waitForSession(options?: WaitForSessionOptions): Promise<string> {
+  return getDefaultBridge().waitForSession(options);
 }
 
 export async function getSourceInfo(): Promise<KiCadResponse> {


### PR DESCRIPTION
## Summary
- Replace the module-global KiCad RPC helpers with an explicit `KiCadBridge` instance: register the waiter before posting, key it by session plus message, and reject pending work on reset or dispose.
- Make `install`/`uninstall` idempotent (no chained `kiclient` handlers) and let `waitForSession` take an abort signal and deadline so unmount does not leave a poll running.
- Keep RPC v1 envelopes and the existing macOS/Windows/Linux transports. Placement retry policy is unchanged (RP-03).

## Test plan
- [ ] Fake transport replies synchronously: `GET_SOURCE_INFO` resolves
- [ ] NEW_SESSION while a command is in flight rejects that command; a reply from the old session is ignored
- [ ] Unavailable transport and response timeout each settle once with no leftover timers
- [ ] Double `installBridge()` handles one incoming `NEW_SESSION` once
- [ ] Panel unmount aborts `waitForSession` without a KiCad init error in the log