### PR TITLE
Stop automatically replaying ambiguous panel placements

### DIFF
--- a/frontend/src/panel/PanelApp.test.tsx
+++ b/frontend/src/panel/PanelApp.test.tsx
@@ -1,0 +1,46 @@
+import { StrictMode } from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { PanelApp } from "./PanelApp";
+import { sendRpcCommand, uninstallBridge } from "./lib/kicad-bridge";
+
+vi.mock("./lib/panel-api", async (importOriginal) => ({
+  ...await importOriginal<typeof import("./lib/panel-api")>(),
+  getCategories: vi.fn(async () => []),
+}));
+vi.mock("./screens/SymbolFinderScreen", () => ({ SymbolFinderScreen: () => <div>Finder</div> }));
+vi.mock("./screens/CategoryListScreen", () => ({ CategoryListScreen: () => null }));
+vi.mock("./screens/PartDetailScreen", () => ({ PartDetailScreen: () => null }));
+
+type Envelope = { command: string; session_id: string; message_id: number; response_to?: number };
+const native = window as unknown as {
+  webkit?: { messageHandlers: { kicad: { postMessage: (payload: string) => void } } };
+  kiclient?: { postMessage?: (payload: unknown) => void; _msgBacklog?: unknown[] };
+};
+
+afterEach(() => {
+  uninstallBridge();
+  delete native.webkit;
+  delete native.kiclient;
+});
+
+it("keeps the native bridge installed through Strict Mode effect replay", async () => {
+  const posted: Envelope[] = [];
+  native.kiclient = { _msgBacklog: [{ command: "NEW_SESSION", session_id: "strict-mode", message_id: 1 }] };
+  native.webkit = { messageHandlers: { kicad: { postMessage(payload) {
+    const request = JSON.parse(payload) as Envelope;
+    posted.push(request);
+    if (request.command === "GET_SOURCE_INFO") {
+      native.kiclient?.postMessage?.({ session_id: request.session_id, response_to: request.message_id, status: "OK", parameters: {} });
+    }
+  } } } };
+  const { unmount } = render(<StrictMode><PanelApp /></StrictMode>);
+  await waitFor(() => expect(posted.filter((request) => request.command === "GET_SOURCE_INFO")).toHaveLength(1));
+  expect(native.kiclient.postMessage).toBeTypeOf("function");
+  let pending!: Promise<unknown>;
+  act(() => { pending = sendRpcCommand("PLACE_COMPONENT"); });
+  const rejected = expect(pending).rejects.toMatchObject({ kind: "unknown_outcome" });
+  unmount();
+  await rejected;
+});

--- a/frontend/src/panel/PanelApp.tsx
+++ b/frontend/src/panel/PanelApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { LogTerminal } from "@/panel/components/LogTerminal";
 import {
@@ -48,7 +48,6 @@ export function PanelApp() {
   const [sessionReady, setSessionReady] = useState(false);
   const [loginLoading, setLoginLoading] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
-  const initializedRef = useRef(false);
 
   const appendLog = useCallback((msg: string) => {
     const stamp = new Date().toLocaleTimeString();
@@ -57,13 +56,15 @@ export function PanelApp() {
 
   const clearLog = useCallback(() => setLogEntries([]), []);
 
-  const testAuthAndRoute = useCallback(async () => {
+  const testAuthAndRoute = useCallback(async (signal?: AbortSignal) => {
     try {
       // This succeeds if we have a valid cookie session or valid token.
-      await getCategories(undefined);
+      await getCategories(signal);
+      if (signal?.aborted) return;
       appendLog("Session authenticated — entering finder.");
       setScreen({ kind: "finder" });
     } catch (err) {
+      if (signal?.aborted) return;
       if (isAuthError(err)) {
         appendLog("Session not authenticated.");
         setScreen({ kind: "login" });
@@ -78,9 +79,6 @@ export function PanelApp() {
   // ─── Initialize bridge ──────────────────────────────────────────
 
   useEffect(() => {
-    if (initializedRef.current) return;
-    initializedRef.current = true;
-
     setLogCallback(appendLog);
     installBridge();
     const sessionWait = new AbortController();
@@ -89,32 +87,36 @@ export function PanelApp() {
       try {
         // 1. Start waiting for KiCad session in background
         waitForSession({ signal: sessionWait.signal }).then(async () => {
+          if (sessionWait.signal.aborted) return;
           setSessionReady(true);
           appendLog("KiCad session ready.");
           try {
             const sourceInfo = await getSourceInfo();
+            if (sessionWait.signal.aborted) return;
             const params = (sourceInfo.parameters || {}) as Record<string, unknown>;
             if (params.token) {
               setApiToken(params.token as string);
               appendLog("Extracted token from KiCad session.");
               // We got a new token, try routing again just in case we were stuck on login
-              testAuthAndRoute();
+              void testAuthAndRoute(sessionWait.signal);
             }
             if (params.auth_type === "oauth2" && !params.authenticated) {
               appendLog("KiCad reports authentication required.");
               // Only override to login if currently in finder (could wait for search failure)
             }
           } catch (e) {
+            if (sessionWait.signal.aborted) return;
             appendLog(`Source info error: ${(e as Error).message}`);
           }
         }).catch((err) => {
-          if ((err as Error).name === "AbortError") return;
+          if (sessionWait.signal.aborted || (err as Error).name === "AbortError") return;
           appendLog(`KiCad init error: ${(err as Error).message}`);
         });
 
         // 2. Immediately check if we have a valid cookie session via the API
-        await testAuthAndRoute();
+        await testAuthAndRoute(sessionWait.signal);
       } catch (err) {
+        if (sessionWait.signal.aborted) return;
         appendLog(`Init error: ${(err as Error).message}`);
       }
     })();

--- a/frontend/src/panel/lib/kicad-bridge.test.ts
+++ b/frontend/src/panel/lib/kicad-bridge.test.ts
@@ -277,4 +277,65 @@ describe("KiCadBridge", () => {
     await expect(pending).rejects.toThrow("login failed");
     expect(clock.live.size).toBe(0);
   });
+
+  it("rejects serialization before dispatch without registering a waiter", async () => {
+    const clock = trackingClock();
+    const post = vi.fn(() => true);
+    const instance = makeBridge({ clock, transport: { post } });
+    openSession(instance);
+    post.mockClear();
+    await expect(instance.send("PLACE_COMPONENT", { unserializable: 1n }))
+      .rejects.toMatchObject({ kind: "pre_dispatch" });
+    expect(post).not.toHaveBeenCalled();
+    expect(clock.live.size).toBe(0);
+  });
+
+  it("does not mistake a throwing Linux transport for no dispatch", async () => {
+    const instance = makeBridge();
+    const invoke = vi.fn();
+    const original = Object.getOwnPropertyDescriptor(window, "external");
+    Object.defineProperty(window, "external", { configurable: true, value: { invoke } });
+    try {
+      openSession(instance);
+      invoke.mockImplementation(() => { throw new Error("reply channel failed"); });
+      await expect(instance.send("PLACE_COMPONENT")).rejects.toMatchObject({ kind: "unknown_outcome" });
+    } finally {
+      if (original) Object.defineProperty(window, "external", original);
+      else Reflect.deleteProperty(window, "external");
+    }
+  });
+
+  it("requires response session identity, including after counter reuse", async () => {
+    const posted: Posted[] = [];
+    const clock = trackingClock();
+    const instance = makeBridge({ clock, transport: { post: (payload) => { posted.push(JSON.parse(payload)); return true; } } });
+    openSession(instance, "old");
+    const previous = instance.send("PLACE_COMPONENT");
+    const rejected = expect(previous).rejects.toMatchObject({ kind: "unknown_outcome" });
+    openSession(instance, "new");
+    await rejected;
+    const pending = instance.send("PLACE_COMPONENT");
+    const responseTo = posted.at(-1)?.message_id;
+    instance.handleIncoming({ response_to: responseTo, status: "OK" });
+    expect(clock.live.size).toBe(1);
+    instance.handleIncoming({ response_to: responseTo, session_id: "new", status: "OK" });
+    await pending;
+    expect(clock.live.size).toBe(0);
+  });
+
+  it("uninstall settles work but reinstall keeps the document session", async () => {
+    const clock = trackingClock();
+    const instance = makeBridge({ clock, transport: { post: () => true } });
+    instance.install();
+    openSession(instance);
+    const rejected = expect(instance.send("PLACE_COMPONENT")).rejects.toMatchObject({ kind: "unknown_outcome" });
+    instance.uninstall();
+    await rejected;
+    expect(clock.live.size).toBe(0);
+    instance.install();
+    expect(instance.getSessionId()).toBe("session-1");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(instance.waitForSession({ signal: controller.signal })).rejects.toMatchObject({ name: "AbortError" });
+  });
 });

--- a/frontend/src/panel/lib/kicad-bridge.test.ts
+++ b/frontend/src/panel/lib/kicad-bridge.test.ts
@@ -164,6 +164,23 @@ describe("KiCadBridge", () => {
     expect(clock.live.size).toBe(0);
   });
 
+  it("honors a longer per-call timeout instead of the 4s default", async () => {
+    vi.useFakeTimers();
+    const clock = trackingClock();
+    const instance = makeBridge({
+      clock,
+      transport: { post: () => true },
+    });
+    openSession(instance);
+    const pending = instance.send("PLACE_COMPONENT", {}, "", 30_000);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(clock.live.size).toBe(1);
+    const timedOut = expect(pending).rejects.toThrow("Response timeout");
+    await vi.advanceTimersByTimeAsync(26_000);
+    await timedOut;
+    expect(clock.live.size).toBe(0);
+  });
+
   it("installs once and drains the backlog without chaining handlers", () => {
     const replies: Posted[] = [];
     const instance = makeBridge({

--- a/frontend/src/panel/lib/kicad-bridge.ts
+++ b/frontend/src/panel/lib/kicad-bridge.ts
@@ -7,8 +7,19 @@
  */
 
 const RPC_VERSION = 1;
-const BACKOFF_MS = [500, 1200, 2500];
 const DEFAULT_RESPONSE_TIMEOUT_MS = 4000;
+
+export type KiCadRpcFailureKind = "pre_dispatch" | "unknown_outcome" | "rpc";
+
+export class KiCadRpcError extends Error {
+  readonly kind: KiCadRpcFailureKind;
+
+  constructor(kind: KiCadRpcFailureKind, message: string) {
+    super(message);
+    this.name = "KiCadRpcError";
+    this.kind = kind;
+  }
+}
 
 type Waiter = {
   resolve: (payload: KiCadResponse) => void;
@@ -182,7 +193,7 @@ export class KiCadBridge {
     timeoutMs = DEFAULT_RESPONSE_TIMEOUT_MS,
   ): Promise<KiCadResponse> {
     if (!this.sessionId) {
-      throw new Error("Session has not been established yet.");
+      throw new KiCadRpcError("pre_dispatch", "Session has not been established yet.");
     }
     const sessionId = this.sessionId;
     const messageId = ++this.messageCounter;
@@ -197,10 +208,16 @@ export class KiCadBridge {
     const pending = this.registerWaiter(sessionId, messageId, timeoutMs);
     try {
       if (!this.transport.post(JSON.stringify(envelope))) {
-        this.rejectWaiter(waiterKey(sessionId, messageId), new Error("KiCad transport is unavailable."));
+        this.rejectWaiter(
+          waiterKey(sessionId, messageId),
+          new KiCadRpcError("pre_dispatch", "KiCad transport is unavailable."),
+        );
       }
     } catch (error) {
-      this.rejectWaiter(waiterKey(sessionId, messageId), error as Error);
+      const wrapped = error instanceof KiCadRpcError
+        ? error
+        : new KiCadRpcError("unknown_outcome", (error as Error).message);
+      this.rejectWaiter(waiterKey(sessionId, messageId), wrapped);
     }
     return pending;
   }
@@ -267,7 +284,7 @@ export class KiCadBridge {
   }
 
   dispose() {
-    this.rejectPending(new Error("Bridge disposed"));
+    this.rejectPending(new KiCadRpcError("unknown_outcome", "Bridge disposed"));
     this.rejectSessionWaiters(new Error("Bridge disposed"));
     this.uninstall();
     this.sessionId = null;
@@ -275,7 +292,7 @@ export class KiCadBridge {
   }
 
   private resetSession(request: KiCadResponse) {
-    this.rejectPending(new Error("Session reset"));
+    this.rejectPending(new KiCadRpcError("unknown_outcome", "Session reset"));
     this.sessionId = request.session_id ?? null;
     this.messageCounter = request.message_id ?? 0;
     if (this.sessionId) {
@@ -309,7 +326,7 @@ export class KiCadBridge {
         resolve,
         reject,
         timer: this.clock.setTimeout(() => {
-          this.rejectWaiter(key, new Error("Response timeout"));
+          this.rejectWaiter(key, new KiCadRpcError("unknown_outcome", "Response timeout"));
         }, timeoutMs),
       };
       this.waiters.set(key, waiter);
@@ -326,7 +343,7 @@ export class KiCadBridge {
     const waiter = this.takeWaiter(key);
     if (!waiter) return;
     if (payload.status === "ERROR") {
-      waiter.reject(new Error(payload.error_message || "KiCad RPC failed"));
+      waiter.reject(new KiCadRpcError("rpc", payload.error_message || "KiCad RPC failed"));
       return;
     }
     waiter.resolve(payload);
@@ -397,22 +414,6 @@ export function sendRpcCommand(
   data = "",
 ): Promise<KiCadResponse> {
   return getDefaultBridge().send(command, parameters, data);
-}
-
-export async function retry<T>(fn: () => Promise<T>): Promise<T> {
-  let lastError: Error | null = null;
-  for (let index = 0; index < BACKOFF_MS.length; index += 1) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error as Error;
-      defaultLog(`Attempt ${index + 1} failed: ${lastError.message}`);
-      if (index < BACKOFF_MS.length - 1) {
-        await new Promise((r) => window.setTimeout(r, BACKOFF_MS[index]));
-      }
-    }
-  }
-  throw lastError;
 }
 
 export function installBridge() {

--- a/frontend/src/panel/lib/kicad-bridge.ts
+++ b/frontend/src/panel/lib/kicad-bridge.ts
@@ -412,8 +412,9 @@ export function sendRpcCommand(
   command: string,
   parameters: Record<string, unknown> = {},
   data = "",
+  timeoutMs?: number,
 ): Promise<KiCadResponse> {
-  return getDefaultBridge().send(command, parameters, data);
+  return getDefaultBridge().send(command, parameters, data, timeoutMs);
 }
 
 export function installBridge() {

--- a/frontend/src/panel/lib/kicad-bridge.ts
+++ b/frontend/src/panel/lib/kicad-bridge.ts
@@ -111,12 +111,8 @@ function postToKiCad(payload: string): boolean {
   if (typeof w.external === "object" && w.external !== null) {
     const ext = w.external as { invoke?: (p: string) => void };
     if (ext.invoke) {
-      try {
-        ext.invoke(payload);
-        return true;
-      } catch {
-        /* ignore */
-      }
+      ext.invoke(payload);
+      return true;
     }
   }
   return false;
@@ -158,6 +154,10 @@ export class KiCadBridge {
     return this.sessionId !== null;
   }
 
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
   handleIncoming(incoming: unknown) {
     let payload: KiCadResponse | null = null;
     if (typeof incoming === "string") {
@@ -197,17 +197,22 @@ export class KiCadBridge {
     }
     const sessionId = this.sessionId;
     const messageId = ++this.messageCounter;
-    const envelope = {
-      version: RPC_VERSION,
-      session_id: sessionId,
-      message_id: messageId,
-      command,
-      parameters: structuredClone(parameters),
-      data,
-    };
+    let payload: string;
+    try {
+      payload = JSON.stringify({
+        version: RPC_VERSION,
+        session_id: sessionId,
+        message_id: messageId,
+        command,
+        parameters: structuredClone(parameters),
+        data,
+      });
+    } catch (error) {
+      throw new KiCadRpcError("pre_dispatch", error instanceof Error ? error.message : String(error));
+    }
     const pending = this.registerWaiter(sessionId, messageId, timeoutMs);
     try {
-      if (!this.transport.post(JSON.stringify(envelope))) {
+      if (!this.transport.post(payload)) {
         this.rejectWaiter(
           waiterKey(sessionId, messageId),
           new KiCadRpcError("pre_dispatch", "KiCad transport is unavailable."),
@@ -216,18 +221,18 @@ export class KiCadBridge {
     } catch (error) {
       const wrapped = error instanceof KiCadRpcError
         ? error
-        : new KiCadRpcError("unknown_outcome", (error as Error).message);
+        : new KiCadRpcError("unknown_outcome", error instanceof Error ? error.message : String(error));
       this.rejectWaiter(waiterKey(sessionId, messageId), wrapped);
     }
     return pending;
   }
 
   waitForSession(options: WaitForSessionOptions = {}): Promise<string> {
-    if (this.sessionId) {
-      return Promise.resolve(this.sessionId);
-    }
     if (options.signal?.aborted) {
       return Promise.reject(abortError());
+    }
+    if (this.sessionId) {
+      return Promise.resolve(this.sessionId);
     }
 
     return new Promise((resolve, reject) => {
@@ -268,6 +273,8 @@ export class KiCadBridge {
   }
 
   uninstall() {
+    this.rejectPending(new KiCadRpcError("unknown_outcome", "Bridge uninstalled"));
+    this.rejectSessionWaiters(new Error("Bridge uninstalled"));
     if (!this.installed) return;
     const w = window as unknown as { kiclient?: KiClient };
     const existing = w.kiclient;
@@ -334,7 +341,7 @@ export class KiCadBridge {
   }
 
   private settleResponse(payload: KiCadResponse) {
-    const responseSession = payload.session_id ?? this.sessionId;
+    const responseSession = payload.session_id;
     if (!this.sessionId || !responseSession || responseSession !== this.sessionId) {
       this.log(`Ignoring stale KiCad response for session ${payload.session_id ?? "?"}`);
       return;
@@ -406,6 +413,10 @@ export function createKiCadBridge(options?: KiCadBridgeOptions): KiCadBridge {
 
 export function hasSession(): boolean {
   return getDefaultBridge().hasSession();
+}
+
+export function getSessionId(): string | null {
+  return getDefaultBridge().getSessionId();
 }
 
 export function sendRpcCommand(

--- a/frontend/src/panel/lib/panel-api.ts
+++ b/frontend/src/panel/lib/panel-api.ts
@@ -222,20 +222,22 @@ export async function getComponent(
 
 export async function getPartManifest(
   partId: string,
-  representationId = ""
+  representationId = "",
+  signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
   const query = representationId ? `?representation=${encodeURIComponent(representationId)}` : "";
   return panelFetch<Record<string, unknown>>(
-    `/api/remote-provider/parts/${partId}${query}`
+    `/api/remote-provider/parts/${partId}${query}`, signal,
   );
 }
 
 export async function getInlineBundle(
   componentId: string,
-  representationId = ""
+  representationId = "",
+  signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
   const query = representationId ? `?representation=${encodeURIComponent(representationId)}` : "";
   return panelFetch<Record<string, unknown>>(
-    `/api/remote-provider/components/${componentId}/inline${query}`
+    `/api/remote-provider/components/${componentId}/inline${query}`, signal,
   );
 }

--- a/frontend/src/panel/lib/panel-api.ts
+++ b/frontend/src/panel/lib/panel-api.ts
@@ -93,7 +93,7 @@ export interface PanelCategory {
   count: number;
 }
 
-class PanelApiError extends Error {
+export class PanelApiError extends Error {
   status: number;
   constructor(status: number, message: string) {
     super(message);

--- a/frontend/src/panel/lib/panel-placement.test.ts
+++ b/frontend/src/panel/lib/panel-placement.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { KiCadRpcError } from "./kicad-bridge";
+import { classifyPlacementError, formatPlacementError } from "./panel-placement";
+
+describe("placement error classification", () => {
+  it("treats missing session and unused transport as pre-dispatch", () => {
+    expect(classifyPlacementError(new KiCadRpcError("pre_dispatch", "KiCad transport is unavailable.")))
+      .toBe("pre_dispatch");
+    expect(formatPlacementError(new Error("Network error: 502"))).toMatch(/^Placement did not start:/);
+  });
+
+  it("does not treat a dropped acknowledgement as a safe retry", () => {
+    const error = new KiCadRpcError("unknown_outcome", "Response timeout");
+    expect(classifyPlacementError(error)).toBe("unknown_outcome");
+    expect(formatPlacementError(error)).toContain("Check the schematic before placing again");
+  });
+
+  it("keeps an explicit KiCad rejection distinct from an unknown outcome", () => {
+    const error = new KiCadRpcError("rpc", "invalid footprint");
+    expect(classifyPlacementError(error)).toBe("rpc");
+    expect(formatPlacementError(error)).toBe("Placement failed: invalid footprint");
+  });
+});

--- a/frontend/src/panel/lib/panel-placement.test.ts
+++ b/frontend/src/panel/lib/panel-placement.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it } from "vitest";
 
 import { KiCadRpcError } from "./kicad-bridge";
+import { PanelApiError } from "./panel-api";
 import { classifyPlacementError, formatPlacementError } from "./panel-placement";
 
 describe("placement error classification", () => {
   it("treats missing session and unused transport as pre-dispatch", () => {
     expect(classifyPlacementError(new KiCadRpcError("pre_dispatch", "KiCad transport is unavailable.")))
       .toBe("pre_dispatch");
-    expect(formatPlacementError(new Error("Network error: 502"))).toMatch(/^Placement did not start:/);
+  });
+
+  it("treats a detail-bodied API failure as pre-dispatch, not a KiCad rejection", () => {
+    const error = new PanelApiError(400, "Selected representation is incomplete");
+    expect(classifyPlacementError(error)).toBe("pre_dispatch");
+    expect(formatPlacementError(error)).toBe(
+      "Placement did not start: Selected representation is incomplete",
+    );
   });
 
   it("does not treat a dropped acknowledgement as a safe retry", () => {

--- a/frontend/src/panel/lib/panel-placement.ts
+++ b/frontend/src/panel/lib/panel-placement.ts
@@ -1,17 +1,16 @@
 import { KiCadRpcError, type KiCadRpcFailureKind } from "@/panel/lib/kicad-bridge";
+import { PanelApiError } from "@/panel/lib/panel-api";
 
 export type PlacementFailureKind = KiCadRpcFailureKind;
+
+/** KiCad may decompress and register an inline bundle before acknowledging. */
+export const PLACEMENT_RESPONSE_TIMEOUT_MS = 30_000;
 
 export function classifyPlacementError(error: unknown): PlacementFailureKind {
   if (error instanceof KiCadRpcError) {
     return error.kind;
   }
-  const message = error instanceof Error ? error.message : String(error);
-  if (
-    message.startsWith("Network error:")
-    || message.startsWith("Request failed")
-    || message === "Cannot place: no session or component."
-  ) {
+  if (error instanceof PanelApiError) {
     return "pre_dispatch";
   }
   return "rpc";

--- a/frontend/src/panel/lib/panel-placement.ts
+++ b/frontend/src/panel/lib/panel-placement.ts
@@ -13,7 +13,7 @@ export function classifyPlacementError(error: unknown): PlacementFailureKind {
   if (error instanceof PanelApiError) {
     return "pre_dispatch";
   }
-  return "rpc";
+  return "unknown_outcome";
 }
 
 export function formatPlacementError(error: unknown): string {

--- a/frontend/src/panel/lib/panel-placement.ts
+++ b/frontend/src/panel/lib/panel-placement.ts
@@ -1,0 +1,30 @@
+import { KiCadRpcError, type KiCadRpcFailureKind } from "@/panel/lib/kicad-bridge";
+
+export type PlacementFailureKind = KiCadRpcFailureKind;
+
+export function classifyPlacementError(error: unknown): PlacementFailureKind {
+  if (error instanceof KiCadRpcError) {
+    return error.kind;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    message.startsWith("Network error:")
+    || message.startsWith("Request failed")
+    || message === "Cannot place: no session or component."
+  ) {
+    return "pre_dispatch";
+  }
+  return "rpc";
+}
+
+export function formatPlacementError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  switch (classifyPlacementError(error)) {
+    case "pre_dispatch":
+      return `Placement did not start: ${message}`;
+    case "unknown_outcome":
+      return `KiCad did not acknowledge placement. Check the schematic before placing again. (${message})`;
+    default:
+      return `Placement failed: ${message}`;
+  }
+}

--- a/frontend/src/panel/screens/PartDetailScreen.tsx
+++ b/frontend/src/panel/screens/PartDetailScreen.tsx
@@ -29,7 +29,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 import type { PanelComponent, PanelSupplySource } from "@/panel/lib/panel-api";
 import { getComponent, getInlineBundle, getPartManifest } from "@/panel/lib/panel-api";
-import { hasSession, sendRpcCommand } from "@/panel/lib/kicad-bridge";
+import { getSessionId, KiCadRpcError, sendRpcCommand } from "@/panel/lib/kicad-bridge";
 import { formatPlacementError, PLACEMENT_RESPONSE_TIMEOUT_MS } from "@/panel/lib/panel-placement";
 import { LibraryPreviewPair } from "@/components/workspace/library-preview-inspector";
 import { cn } from "@/lib/utils";
@@ -95,7 +95,10 @@ export function PartDetailScreen({
   const [placing, setPlacing] = useState(false);
   const [placementError, setPlacementError] = useState<string | null>(null);
   const placingRef = useRef(false);
+  const placementControllerRef = useRef<AbortController | null>(null);
   const [representationId, setRepresentationId] = useState("");
+
+  useEffect(() => () => placementControllerRef.current?.abort(), [componentId]);
 
   // Fetch full component details. List screens pass a slim payload, so detail
   // refreshes the component before previews/assets are shown.
@@ -119,48 +122,51 @@ export function PartDetailScreen({
   }, [componentId, prefetched, appendLog]);
 
   async function runPlacement(path: "manifest" | "inline") {
-    if (!component || !hasSession()) {
+    const sessionId = getSessionId();
+    if (!component || !sessionId) {
       appendLog("Cannot place: no session or component.");
       return;
     }
     if (placingRef.current) return;
     placingRef.current = true;
+    const controller = new AbortController();
+    placementControllerRef.current = controller;
+    let dispatchAttempted = false;
     setPlacing(true);
     setPlacementError(null);
     try {
-      if (path === "manifest") {
-        const manifest = await getPartManifest(component.id, representationId);
-        await sendRpcCommand(
-          "PLACE_COMPONENT",
-          manifest as Record<string, unknown>,
-          "",
-          PLACEMENT_RESPONSE_TIMEOUT_MS,
-        );
-        appendLog(`Placed ${component.name} via manifest.`);
-      } else {
-        const bundle = (await getInlineBundle(component.id, representationId)) as Record<
-          string,
-          unknown
-        >;
-        await sendRpcCommand(
-          "PLACE_COMPONENT",
-          {
-            library: bundle.library,
-            symbol_name: bundle.symbol_name,
-            compression: bundle.compression,
-          },
-          (bundle.data as string) || "",
-          PLACEMENT_RESPONSE_TIMEOUT_MS,
-        );
-        appendLog(`Placed ${component.name} via inline bundle.`);
+      const payload = path === "manifest"
+        ? await getPartManifest(component.id, representationId, controller.signal)
+        : await getInlineBundle(component.id, representationId, controller.signal);
+      if (controller.signal.aborted) return;
+      if (sessionId !== getSessionId()) {
+        throw new KiCadRpcError("pre_dispatch", "KiCad session changed while preparing placement. Try again in the current schematic.");
       }
+      dispatchAttempted = true;
+      await sendRpcCommand(
+        "PLACE_COMPONENT",
+        path === "manifest" ? payload : {
+          library: payload.library,
+          symbol_name: payload.symbol_name,
+          compression: payload.compression,
+        },
+        path === "inline" ? (payload.data as string) || "" : "",
+        PLACEMENT_RESPONSE_TIMEOUT_MS,
+      );
+      if (!controller.signal.aborted) appendLog(`Placed ${component.name} via ${path === "inline" ? "inline bundle" : "manifest"}.`);
     } catch (err) {
-      const message = formatPlacementError(err);
+      if (controller.signal.aborted) return;
+      const failure = dispatchAttempted || err instanceof KiCadRpcError ? err
+        : new KiCadRpcError("pre_dispatch", err instanceof Error ? err.message : String(err));
+      const message = formatPlacementError(failure);
       setPlacementError(message);
       appendLog(message);
     } finally {
-      placingRef.current = false;
-      setPlacing(false);
+      if (placementControllerRef.current === controller) {
+        placingRef.current = false;
+        placementControllerRef.current = null;
+        setPlacing(false);
+      }
     }
   }
 

--- a/frontend/src/panel/screens/PartDetailScreen.tsx
+++ b/frontend/src/panel/screens/PartDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ArrowLeft,
   ChevronDown,
@@ -29,7 +29,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 import type { PanelComponent, PanelSupplySource } from "@/panel/lib/panel-api";
 import { getComponent, getInlineBundle, getPartManifest } from "@/panel/lib/panel-api";
-import { hasSession, retry, sendRpcCommand } from "@/panel/lib/kicad-bridge";
+import { hasSession, sendRpcCommand } from "@/panel/lib/kicad-bridge";
+import { formatPlacementError } from "@/panel/lib/panel-placement";
 import { LibraryPreviewPair } from "@/components/workspace/library-preview-inspector";
 import { cn } from "@/lib/utils";
 import { inventoryWarnings } from "@/lib/inventory-presentation";
@@ -92,7 +93,8 @@ export function PartDetailScreen({
   const [loading, setLoading] = useState(!prefetched);
   const [showAllParams, setShowAllParams] = useState(false);
   const [placing, setPlacing] = useState(false);
-  const [placingInline, setPlacingInline] = useState(false);
+  const [placementError, setPlacementError] = useState<string | null>(null);
+  const placingRef = useRef(false);
   const [representationId, setRepresentationId] = useState("");
 
   // Fetch full component details. List screens pass a slim payload, so detail
@@ -116,44 +118,25 @@ export function PartDetailScreen({
     return () => controller.abort();
   }, [componentId, prefetched, appendLog]);
 
-  // ─── Place via manifest ────────────────────────────────────────
-
-  async function handlePlace() {
+  async function runPlacement(path: "manifest" | "inline") {
     if (!component || !hasSession()) {
       appendLog("Cannot place: no session or component.");
       return;
     }
+    if (placingRef.current) return;
+    placingRef.current = true;
     setPlacing(true);
+    setPlacementError(null);
     try {
-      const manifest = await getPartManifest(component.id, representationId);
-      await retry(async () => {
-        await sendRpcCommand(
-          "PLACE_COMPONENT",
-          manifest as Record<string, unknown>
-        );
-      });
-      appendLog(`Placed ${component.name} via manifest.`);
-    } catch (err) {
-      appendLog(`Placement failed: ${(err as Error).message}`);
-    } finally {
-      setPlacing(false);
-    }
-  }
-
-  // ─── Place via inline ──────────────────────────────────────────
-
-  async function handleInline() {
-    if (!component || !hasSession()) {
-      appendLog("Cannot place: no session or component.");
-      return;
-    }
-    setPlacingInline(true);
-    try {
-      const bundle = (await getInlineBundle(component.id, representationId)) as Record<
-        string,
-        unknown
-      >;
-      await retry(async () => {
+      if (path === "manifest") {
+        const manifest = await getPartManifest(component.id, representationId);
+        await sendRpcCommand("PLACE_COMPONENT", manifest as Record<string, unknown>);
+        appendLog(`Placed ${component.name} via manifest.`);
+      } else {
+        const bundle = (await getInlineBundle(component.id, representationId)) as Record<
+          string,
+          unknown
+        >;
         await sendRpcCommand(
           "PLACE_COMPONENT",
           {
@@ -161,14 +144,17 @@ export function PartDetailScreen({
             symbol_name: bundle.symbol_name,
             compression: bundle.compression,
           },
-          (bundle.data as string) || ""
+          (bundle.data as string) || "",
         );
-      });
-      appendLog(`Placed ${component.name} via inline bundle.`);
+        appendLog(`Placed ${component.name} via inline bundle.`);
+      }
     } catch (err) {
-      appendLog(`Inline placement failed: ${(err as Error).message}`);
+      const message = formatPlacementError(err);
+      setPlacementError(message);
+      appendLog(message);
     } finally {
-      setPlacingInline(false);
+      placingRef.current = false;
+      setPlacing(false);
     }
   }
 
@@ -225,13 +211,13 @@ export function PartDetailScreen({
           {canPlace && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon-xs" aria-label="More actions">
+                <Button variant="ghost" size="icon-xs" aria-label="More actions" disabled={placing}>
                   <MoreHorizontal className="h-3.5 w-3.5" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={handleInline} disabled={placingInline}>
-                  {placingInline ? (
+                <DropdownMenuItem onClick={() => void runPlacement("inline")} disabled={placing}>
+                  {placing ? (
                     <Loader2 className="mr-1 h-3 w-3 animate-spin" />
                   ) : null}
                   Inline Fallback
@@ -402,11 +388,16 @@ export function PartDetailScreen({
               Datasheet
             </Button>
           )}
-          <Button className="min-w-0 flex-1" onClick={handlePlace} disabled={!canPlace || placing}>
+          <Button className="min-w-0 flex-1" onClick={() => void runPlacement("manifest")} disabled={!canPlace || placing}>
             {placing ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
             {canPlace ? "Place" : "Unavailable"}
           </Button>
         </div>
+        {placementError ? (
+          <p className="text-[10px] text-destructive" role="alert">
+            {placementError}
+          </p>
+        ) : null}
       </div>
 
     </div>

--- a/frontend/src/panel/screens/PartDetailScreen.tsx
+++ b/frontend/src/panel/screens/PartDetailScreen.tsx
@@ -30,7 +30,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import type { PanelComponent, PanelSupplySource } from "@/panel/lib/panel-api";
 import { getComponent, getInlineBundle, getPartManifest } from "@/panel/lib/panel-api";
 import { hasSession, sendRpcCommand } from "@/panel/lib/kicad-bridge";
-import { formatPlacementError } from "@/panel/lib/panel-placement";
+import { formatPlacementError, PLACEMENT_RESPONSE_TIMEOUT_MS } from "@/panel/lib/panel-placement";
 import { LibraryPreviewPair } from "@/components/workspace/library-preview-inspector";
 import { cn } from "@/lib/utils";
 import { inventoryWarnings } from "@/lib/inventory-presentation";
@@ -130,7 +130,12 @@ export function PartDetailScreen({
     try {
       if (path === "manifest") {
         const manifest = await getPartManifest(component.id, representationId);
-        await sendRpcCommand("PLACE_COMPONENT", manifest as Record<string, unknown>);
+        await sendRpcCommand(
+          "PLACE_COMPONENT",
+          manifest as Record<string, unknown>,
+          "",
+          PLACEMENT_RESPONSE_TIMEOUT_MS,
+        );
         appendLog(`Placed ${component.name} via manifest.`);
       } else {
         const bundle = (await getInlineBundle(component.id, representationId)) as Record<
@@ -145,6 +150,7 @@ export function PartDetailScreen({
             compression: bundle.compression,
           },
           (bundle.data as string) || "",
+          PLACEMENT_RESPONSE_TIMEOUT_MS,
         );
         appendLog(`Placed ${component.name} via inline bundle.`);
       }

--- a/frontend/src/panel/screens/panel-placement.test.tsx
+++ b/frontend/src/panel/screens/panel-placement.test.tsx
@@ -1,9 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PanelComponent } from "@/panel/lib/panel-api";
 import { getComponent, getInlineBundle, getPartManifest } from "@/panel/lib/panel-api";
-import { KiCadRpcError, hasSession, sendRpcCommand } from "@/panel/lib/kicad-bridge";
+import { createKiCadBridge, KiCadRpcError, getSessionId, sendRpcCommand } from "@/panel/lib/kicad-bridge";
 import { PLACEMENT_RESPONSE_TIMEOUT_MS } from "@/panel/lib/panel-placement";
 
 import { PartDetailScreen } from "./PartDetailScreen";
@@ -16,7 +16,7 @@ vi.mock("@/panel/lib/panel-api", async (importOriginal) => ({
 }));
 vi.mock("@/panel/lib/kicad-bridge", async (importOriginal) => ({
   ...await importOriginal<typeof import("@/panel/lib/kicad-bridge")>(),
-  hasSession: vi.fn(),
+  getSessionId: vi.fn(),
   sendRpcCommand: vi.fn(),
 }));
 vi.mock("@/components/workspace/library-preview-inspector", () => ({
@@ -78,7 +78,7 @@ const placeable: PanelComponent = {
 
 describe("panel placement", () => {
   beforeEach(() => {
-    vi.mocked(hasSession).mockReturnValue(true);
+    vi.mocked(getSessionId).mockReturnValue("session-1");
     vi.mocked(getComponent).mockResolvedValue(placeable);
     vi.mocked(getPartManifest).mockResolvedValue({ library: "Prism" });
     vi.mocked(getInlineBundle).mockResolvedValue({
@@ -127,5 +127,56 @@ describe("panel placement", () => {
     fireEvent.click(screen.getByRole("button", { name: "Place" }));
     await waitFor(() => expect(sendRpcCommand).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  });
+
+  it("does not dispatch a manifest after navigation, even if fetch ignores abort", async () => {
+    let finish!: (manifest: Record<string, unknown>) => void;
+    vi.mocked(getPartManifest).mockImplementation(() => new Promise((resolve) => { finish = resolve; }));
+    const { unmount } = render(<PartDetailScreen componentId="part" onBack={() => {}} appendLog={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Place" }));
+    const signal = vi.mocked(getPartManifest).mock.calls.at(-1)?.[2];
+    unmount();
+    expect(signal?.aborted).toBe(true);
+    await act(async () => finish({ library: "Prism" }));
+    expect(sendRpcCommand).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch into a different session after preparing a manifest", async () => {
+    vi.mocked(getPartManifest).mockImplementation(async () => {
+      vi.mocked(getSessionId).mockReturnValue("session-2");
+      return { library: "Prism" };
+    });
+    render(<PartDetailScreen componentId="part" onBack={() => {}} appendLog={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Place" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Placement did not start: KiCad session changed");
+    expect(sendRpcCommand).not.toHaveBeenCalled();
+  });
+
+  it("classifies a malformed manifest response as pre-dispatch", async () => {
+    vi.mocked(getPartManifest).mockRejectedValue(new SyntaxError("Invalid JSON"));
+    render(<PartDetailScreen componentId="part" onBack={() => {}} appendLog={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Place" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Placement did not start: Invalid JSON");
+    expect(sendRpcCommand).not.toHaveBeenCalled();
+  });
+
+  it("does not replay after the real bridge timeout and old retry window expire", async () => {
+    const posted: Array<{ command: string }> = [];
+    const bridge = createKiCadBridge({ transport: { post: (payload) => { posted.push(JSON.parse(payload)); return true; } } });
+    bridge.handleIncoming({ command: "NEW_SESSION", session_id: "session-1", message_id: 1 });
+    vi.mocked(sendRpcCommand).mockImplementation((...args) => bridge.send(...args));
+    const { unmount } = render(<PartDetailScreen componentId="part" onBack={() => {}} appendLog={() => {}} />);
+    const button = await screen.findByRole("button", { name: "Place" });
+    vi.useFakeTimers();
+    try {
+      await act(async () => { fireEvent.click(button); fireEvent.click(button); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(90_000); });
+      expect(screen.getByRole("alert")).toHaveTextContent("Check the schematic before placing again");
+      expect(posted.filter((message) => message.command === "PLACE_COMPONENT")).toHaveLength(1);
+      expect(button).toBeEnabled();
+    } finally {
+      unmount();
+      bridge.dispose();
+    }
   });
 });

--- a/frontend/src/panel/screens/panel-placement.test.tsx
+++ b/frontend/src/panel/screens/panel-placement.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PanelComponent } from "@/panel/lib/panel-api";
 import { getComponent, getInlineBundle, getPartManifest } from "@/panel/lib/panel-api";
 import { KiCadRpcError, hasSession, sendRpcCommand } from "@/panel/lib/kicad-bridge";
+import { PLACEMENT_RESPONSE_TIMEOUT_MS } from "@/panel/lib/panel-placement";
 
 import { PartDetailScreen } from "./PartDetailScreen";
 
@@ -99,7 +100,12 @@ describe("panel placement", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Place" }));
     await waitFor(() => expect(sendRpcCommand).toHaveBeenCalledTimes(1));
-    expect(sendRpcCommand).toHaveBeenCalledWith("PLACE_COMPONENT", { library: "Prism" });
+    expect(sendRpcCommand).toHaveBeenCalledWith(
+      "PLACE_COMPONENT",
+      { library: "Prism" },
+      "",
+      PLACEMENT_RESPONSE_TIMEOUT_MS,
+    );
     expect(screen.getByRole("button", { name: "Place" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "More actions" })).toBeDisabled();
 

--- a/frontend/src/panel/screens/panel-placement.test.tsx
+++ b/frontend/src/panel/screens/panel-placement.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PanelComponent } from "@/panel/lib/panel-api";
+import { getComponent, getInlineBundle, getPartManifest } from "@/panel/lib/panel-api";
+import { KiCadRpcError, hasSession, sendRpcCommand } from "@/panel/lib/kicad-bridge";
+
+import { PartDetailScreen } from "./PartDetailScreen";
+
+vi.mock("@/panel/lib/panel-api", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/panel/lib/panel-api")>(),
+  getComponent: vi.fn(),
+  getPartManifest: vi.fn(),
+  getInlineBundle: vi.fn(),
+}));
+vi.mock("@/panel/lib/kicad-bridge", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/panel/lib/kicad-bridge")>(),
+  hasSession: vi.fn(),
+  sendRpcCommand: vi.fn(),
+}));
+vi.mock("@/components/workspace/library-preview-inspector", () => ({
+  LibraryPreviewPair: () => null,
+}));
+
+const placeable: PanelComponent = {
+  id: "part",
+  slug: "part",
+  name: "LM358",
+  identity_kind: "mpn",
+  manufacturer: "TI",
+  mpn: "LM358",
+  description: "Op-amp",
+  package_name: "SOIC-8",
+  category: "ICs",
+  datasheet_url: "",
+  summary: "",
+  version: "1",
+  library_name: "Prism",
+  symbol_name: "LM358",
+  representations: [{
+    id: "rep-1",
+    label: "Default",
+    is_default: true,
+    display_order: 0,
+    source_internal_part_number: "",
+    symbol: {
+      id: "sym",
+      asset_type: "symbol",
+      name: "LM358",
+      target_library: "Prism",
+      target_name: "LM358",
+      content_type: "application/x-kicad-symbol",
+      required: true,
+    },
+    footprint: {
+      id: "fp",
+      asset_type: "footprint",
+      name: "SOIC-8",
+      target_library: "Prism",
+      target_name: "SOIC-8",
+      content_type: "application/x-kicad-footprint",
+      required: true,
+    },
+  }],
+  assets: [],
+  missing_assets: [],
+  availability_state: "place_ready",
+  place_enabled: true,
+  default_representation_id: "rep-1",
+  effective_representation_id: "rep-1",
+  preview_status: {},
+  symbol_preview_url: "",
+  footprint_preview_url: "",
+  manifest_url: "",
+  inline_url: "",
+};
+
+describe("panel placement", () => {
+  beforeEach(() => {
+    vi.mocked(hasSession).mockReturnValue(true);
+    vi.mocked(getComponent).mockResolvedValue(placeable);
+    vi.mocked(getPartManifest).mockResolvedValue({ library: "Prism" });
+    vi.mocked(getInlineBundle).mockResolvedValue({
+      library: "Prism",
+      symbol_name: "LM358",
+      compression: "",
+      data: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("dispatches PLACE_COMPONENT once when KiCad accepts and drops the reply", async () => {
+    vi.mocked(sendRpcCommand).mockImplementation(() => new Promise(() => {}));
+    render(<PartDetailScreen componentId="part" onBack={() => {}} appendLog={() => {}} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Place" }));
+    await waitFor(() => expect(sendRpcCommand).toHaveBeenCalledTimes(1));
+    expect(sendRpcCommand).toHaveBeenCalledWith("PLACE_COMPONENT", { library: "Prism" });
+    expect(screen.getByRole("button", { name: "Place" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "More actions" })).toBeDisabled();
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(sendRpcCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an actionable error after a dropped acknowledgement and allows a deliberate retry", async () => {
+    vi.mocked(sendRpcCommand)
+      .mockRejectedValueOnce(new KiCadRpcError("unknown_outcome", "Response timeout"))
+      .mockResolvedValueOnce({ status: "OK", command: "PLACE_COMPONENT" });
+
+    render(<PartDetailScreen componentId="part" onBack={() => {}} appendLog={() => {}} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Place" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Check the schematic before placing again");
+    expect(sendRpcCommand).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Place" }));
+    await waitFor(() => expect(sendRpcCommand).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
RP-03: dispatch each placement once and report ambiguous outcomes without replaying the command.

Manifest and inline placement share a synchronous busy guard. A lost acknowledgement leaves the outcome unknown and asks the designer to inspect the schematic before deliberately placing again. Fetch and serialization failures are classified as pre-dispatch; transport exceptions and timeouts remain unknown outcomes.

Review corrections also repair RP-02 lifecycle handling: Strict Mode can uninstall and reinstall the bridge, uninstall settles pending work, and replies require the matching session. Placement preparation is aborted on navigation and cannot dispatch into a different KiCad session.

Validation at 5a0454e:
- Frontend: 640 tests across 84 files; lint; application build; panel build; React Doctor gate (zero warnings/errors).
- Backend review: 1,227 tests, 42 skipped, using a disposable PostgreSQL database.
- Regression coverage includes a real bridge timeout advanced to 90 seconds, rapid repeated clicks, navigation during manifest fetch, session changes, malformed payloads, thrown Linux sends, and Strict Mode setup/cleanup.

Reviewed the preceding DB-07/08, CW-01–06, and RP-01/02 implementations. Designer-defined metadata field behaviour is preserved. Further component-navigation lifecycle edge cases in workspace validation/downloads are recorded as follow-ups, outside this panel change.

KiCad issue [25530](https://gitlab.com/kicad/code/kicad/-/work_items/25530) is independently reproducible in the latest published macOS nightly checked on 2026-09-13: `kicad-unified-universal-20260910-0504-d7e34de179.dmg`, KiCad 10.99.0. A loopback provider sent exactly one PLACE_COMPONENT per action: first part into new library A failed with “Unable to save the downloaded symbol.”; second part into A succeeded; first part into new library B failed. This upstream bug is not solved by retrying placement and remains separate from this PR.

Required CI must pass on the updated head before merging.
